### PR TITLE
Changes NextHeap initialization to compensate for "early" malloc invocation

### DIFF
--- a/heaplayers-make.mk
+++ b/heaplayers-make.mk
@@ -1,5 +1,5 @@
 # CPPFLAGS = -std=c++14 -g -O0
-CPPFLAGS = -std=c++14 -g -O3 -DNDEBUG -fno-builtin-malloc -fvisibility=hidden
+CPPFLAGS = -std=c++17 -g -O3 -DNDEBUG -fno-builtin-malloc -fvisibility=hidden
 CXX = clang++
 
 INCLUDES = -I. -I./include -IHeap-Layers -IHeap-Layers/wrappers -IHeap-Layers/utility

--- a/include/nextheap.hpp
+++ b/include/nextheap.hpp
@@ -49,7 +49,7 @@ class NextHeap {
       if (_inInit) {
         return _initHeap->malloc(sz);
       }
-      init();
+      init(); // FIXME call through std::call_once (here and elsewhere)?
     }
     return (*_malloc)(sz);
   }
@@ -91,7 +91,6 @@ class NextHeap {
   }
 
  private:
-  // FIXME this should be run from std::call_once
   void init() {
     // malloc et al can be called during initialization even before C++ constructors run,
     // so we rely on compile-time static data member initialization and on an in place new

--- a/include/nextheap.hpp
+++ b/include/nextheap.hpp
@@ -7,6 +7,7 @@
 
 #if defined(__APPLE__)
 
+// XXX use the same code on __APPLE__?
 class NextHeap {
  public:
   enum { Alignment = alignof(max_align_t) };
@@ -29,52 +30,48 @@ class NextHeap {
 #include "staticbufferheap.hpp"
 
 extern "C" {
-typedef void *mallocFn(size_t);
-typedef void freeFn(void *);
-typedef size_t mallocusablesizeFn(void *);
-typedef void *memalignFn(size_t, size_t);
+  typedef void *mallocFn(size_t);
+  typedef void freeFn(void *);
+  typedef size_t mallocusablesizeFn(void *);
+  typedef void *memalignFn(size_t, size_t);
 }
 
+/**
+ * Provides access to the original system heap, even if the standard malloc/free/etc.
+ * have been redirected by way of LD_PRELOAD, MacOS interpose, etc.
+ */
 class NextHeap {
- private:
-  StaticBufferHeap<640 * 1024> buffer;  // should be enough for anyone :)
-
  public:
   enum { Alignment = alignof(max_align_t) };
-  NextHeap()
-      : _inMalloc(false),
-        _inMemalign(false),
-        _inFree(false),
-        _malloc(nullptr),
-        _free(nullptr),
-        _memalign(nullptr),
-        _malloc_usable_size(nullptr) {}
+
   inline void *malloc(size_t sz) {
     if (unlikely(_malloc == nullptr)) {
-      if (_inMalloc) {
-        return buffer.malloc(sz);
+      if (_inInit) {
+        return _initHeap->malloc(sz);
       }
       init();
     }
     return (*_malloc)(sz);
   }
+
   inline void *memalign(size_t alignment, size_t sz) {
     if (unlikely(_memalign == nullptr)) {
-      if (_inMalloc) {
-        return buffer.malloc(sz);  // FIXME
+      if (_inInit) {
+        return _initHeap->malloc(sz);  // FIXME 'alignment' ignored
       }
       init();
     }
     return (*_memalign)(alignment, sz);
   }
+
   inline bool free(void *ptr) {
     if (unlikely(_free == nullptr)) {
-      if (_inMalloc) {
+      if (_inInit) {
         return false;
       }
       init();
     }
-    if (!buffer.isValid(ptr)) {
+    if (!_initHeap->isValid(ptr)) {
       (*_free)(ptr);
     }
     return true;
@@ -82,46 +79,45 @@ class NextHeap {
 
   inline size_t getSize(void *ptr) {
     if (unlikely(_malloc_usable_size == nullptr)) {
-      if (_inMalloc) {
-        return buffer.getSize(ptr);
+      if (_inInit) {
+        return _initHeap->getSize(ptr);
       }
       init();
     }
-    if (buffer.isValid(ptr)) {
-      return buffer.getSize(ptr);
+    if (_initHeap->isValid(ptr)) {
+      return _initHeap->getSize(ptr);
     }
     return (*_malloc_usable_size)(ptr);
   }
 
  private:
+  // FIXME this should be run from std::call_once
   void init() {
-    _inMalloc = true;
-    // Welcome to the hideous incantation required to use dlsym with C++...
-    *(void **)(&_malloc_usable_size) = dlsym(RTLD_NEXT, "malloc_usable_size");
-    *(void **)(&_free) = dlsym(RTLD_NEXT, "free");
-    *(void **)(&_malloc) = dlsym(RTLD_NEXT, "malloc");
-    *(void **)(&_memalign) = dlsym(RTLD_NEXT, "memalign");
-    _inMalloc = false;
+    // malloc et al can be called during initialization even before C++ constructors run,
+    // so we rely on compile-time static data member initialization and on an in place new
+    // to provide an interim heap in case what we call here needs it.
+    if (_initHeap == 0) {
+      _initHeap = new (_initHeapMem) StaticBufferHeap<INIT_HEAP_SIZE>;
+      _inInit = true;
+
+      _malloc_usable_size = (mallocusablesizeFn*) dlsym(RTLD_NEXT, "malloc_usable_size");
+      _free = (freeFn*) dlsym(RTLD_NEXT, "free");
+      _malloc = (mallocFn*) dlsym(RTLD_NEXT, "malloc");
+      _memalign = (memalignFn*) dlsym(RTLD_NEXT, "memalign");
+
+      _inInit = false;
+    }
   }
 
-  bool slowPathFree(void *ptr) {
-    (*_free)(ptr);
-    return true;
-  }
+  static const int INIT_HEAP_SIZE = 640 * 1024; // should be enough for anyone :)
 
-  void *slowPathMalloc(size_t sz) { return (*_malloc)(sz); }
-
-  void *slowPathMemalign(size_t alignment, size_t sz) {
-    return (*_memalign)(alignment, sz);
-  }
-
-  bool _inMalloc;
-  bool _inMemalign;
-  bool _inFree;
-  mallocFn *_malloc;
-  freeFn *_free;
-  memalignFn *_memalign;
-  mallocusablesizeFn *_malloc_usable_size;
+  inline static char _initHeapMem[sizeof(StaticBufferHeap<INIT_HEAP_SIZE>)];
+  inline static StaticBufferHeap<INIT_HEAP_SIZE>* _initHeap{0};
+  inline static bool _inInit{false};
+  inline static mallocFn *_malloc{0};
+  inline static freeFn *_free{0};
+  inline static memalignFn *_memalign{0};
+  inline static mallocusablesizeFn *_malloc_usable_size{0};
 };
 #endif
 

--- a/include/nextheap.hpp
+++ b/include/nextheap.hpp
@@ -7,7 +7,7 @@
 
 #if defined(__APPLE__)
 
-// XXX use the same code on __APPLE__?
+// FIXME use the non-__APPLE__ code on __APPLE__ as well to reduce unnecessary variants?
 class NextHeap {
  public:
   enum { Alignment = alignof(max_align_t) };
@@ -49,7 +49,7 @@ class NextHeap {
       if (_inInit) {
         return _initHeap->malloc(sz);
       }
-      init(); // FIXME call through std::call_once (here and elsewhere)?
+      init(); // FIXME call through std::call_once (here and elsewhere)? Is it recursion safe?
     }
     return (*_malloc)(sz);
   }

--- a/include/sysmallocheap.hpp
+++ b/include/sysmallocheap.hpp
@@ -8,7 +8,7 @@
 #if defined(__APPLE__)
 
 // FIXME use the non-__APPLE__ code on __APPLE__ as well to reduce unnecessary variants?
-class NextHeap {
+class SysMallocHeap {
  public:
   enum { Alignment = alignof(max_align_t) };
 
@@ -37,10 +37,10 @@ extern "C" {
 }
 
 /**
- * Provides access to the original system heap, even if the standard malloc/free/etc.
+ * Provides access to the original system heap, even if the standard malloc/free/...
  * have been redirected by way of LD_PRELOAD, MacOS interpose, etc.
  */
-class NextHeap {
+class SysMallocHeap {
  public:
   enum { Alignment = alignof(max_align_t) };
 

--- a/libscalene.cpp
+++ b/libscalene.cpp
@@ -22,10 +22,10 @@
 const uint64_t MallocSamplingRate = 1048576ULL;
 const uint64_t MemcpySamplingRate = MallocSamplingRate * 2ULL;
 
-#include "nextheap.hpp"
+#include "sysmallocheap.hpp"
 
 class ParentHeap
-    : public HL::ThreadSpecificHeap<SampleHeap<MallocSamplingRate, NextHeap>> {
+    : public HL::ThreadSpecificHeap<SampleHeap<MallocSamplingRate, SysMallocHeap>> {
 };
 
 static bool _initialized{false};


### PR DESCRIPTION
Malloc can be used very early during process startup, even before the C++ constructors run.
This was causing NextHeap to initialize twice, and StaticBufferHeap to fail if actually needed.
This code adjusts for that, mostly by relying on static data members.

As discussed, this PR also renames NextHeap to SysMallocHeap, which prevents the diff from working.
The following link shows most of the actual changes: https://github.com/plasma-umass/scalene/commit/2f351dd9f4bba75720da96227b295baf229ffce2

I think we should remove the __APPLE__ variant, but I would like to improve my testing before opening a PR.