### PR TITLE
Moves allocation and memcpy signal handling from starting threads to producer-consumer queue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -66,5 +65,5 @@ setup(
     setup_requires=['setuptools_scm'],
     include_package_data=True,
     entry_points={"console_scripts": ["scalene = scalene.__main__:main"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Note that this changes the minimum Python requirement to 3.7, as SimpleQueue is only available from that version onwards.
Alternatively, this could be modified to use my [signal_queue](https://github.com/jaltmayerpizzorno/signal_queue) implementation.

This also speeds up scalene a bit.