### PR TITLE
Bugfix/cautious attribute retrieval (closes #193)

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -771,14 +771,11 @@ class Scalene:
                     fn_name = prepend_name + "." + fn_name
                 break
             if "cls" in f.f_locals:
-                try:
-                    prepend_name = f.f_locals["cls"].__name__
-                    if "Scalene" in prepend_name:
-                        break
-                    fn_name = prepend_name + "." + fn_name
+                prepend_name = getattr(f.f_locals["cls"], "__name__", None)
+                if not prepend_name or "Scalene" in prepend_name:
                     break
-                except KeyError:
-                    pass
+                fn_name = prepend_name + "." + fn_name
+                break
             f = f.f_back
 
         stats.function_map[fname][lineno] = fn_name

--- a/test/issues/test-issue193.py
+++ b/test/issues/test-issue193.py
@@ -1,0 +1,9 @@
+import time
+
+def test_cls_in_locals():
+    cls = "This value is not a class"
+    time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    test_cls_in_locals()


### PR DESCRIPTION
In addition to using `getattr()` instead of dot notation, this PR also removes the exception handler introduced by cd5b7e7, because it seems like a `KeyError` could only originate here if the `f_locals` dict changes between the membership test and the indexing operation. That _might_ be possible, but would be better addressed by accessing `f_locals` only once and caching the result.