### PR TITLE
Fixes libscalene preloading, DRYes some code duplications

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -35,9 +35,12 @@ endif
 SRC := src/source/lib$(LIBNAME).cpp $(WRAPPER) vendor/printf/printf.cpp
 
 all: vendor/Heap-Layers $(SRC) $(OTHER_DEPS)
-	rm -f $(LIBFILE) scalene/$(LIBFILE)
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SRC) -o $(LIBFILE) -ldl -lpthread
-	cp $(LIBFILE) scalene
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SRC) -o scalene/$(LIBFILE) -ldl -lpthread
+
+clean:
+	git restore scalene/$(LIBFILE)
+	rm -rf scalene/$(LIBFILE).dSYM
+	rm -rf scalene.egg-info get_line_atomic*.so
 
 $(WRAPPER) : vendor/Heap-Layers
 

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -16,16 +16,12 @@ class ScalenePreload:
 
         if sys.platform == "linux":
             if not args.cpu_only:
-                env["LD_PRELOAD"] = os.path.join(
-                    os.path.dirname(scalene.__path__[0]), "libscalene.so"
-                )
+                env["LD_PRELOAD"] = os.path.join(scalene.__path__[0], "libscalene.so")
                 env["PYTHONMALLOC"] = "malloc"
 
         elif sys.platform == "darwin":
             if not args.cpu_only:
-                env["DYLD_INSERT_LIBRARIES"] = os.path.join(
-                    os.path.dirname(scalene.__path__[0]), "libscalene.dylib"
-                )
+                env["DYLD_INSERT_LIBRARIES"] = os.path.join(scalene.__path__[0], "libscalene.dylib")
                 env["PYTHONMALLOC"] = "malloc"
             # required for multiprocessing support, even without libscalene
             env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
@@ -70,7 +66,7 @@ class ScalenePreload:
         # Start a subprocess with the required environment variables.
         if sys.platform == "linux" or sys.platform == "darwin":
             req_env = ScalenePreload.get_preload_environ(args)
-            if not all(k in os.environ for k in req_env):
+            if not all(k_v in os.environ.items() for k_v in req_env.items()):
                 os.environ.update(req_env)
 
                 new_args = [

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -15,17 +15,20 @@ class ScalenePreload:
         env = dict()
 
         if sys.platform == "linux":
-            env["LD_PRELOAD"] = os.path.join(
-                os.path.dirname(scalene.__path__[0]), "libscalene.so"
-            )
-            env["PYTHONMALLOC"] = "malloc"
+            if not args.cpu_only:
+                env["LD_PRELOAD"] = os.path.join(
+                    os.path.dirname(scalene.__path__[0]), "libscalene.so"
+                )
+                env["PYTHONMALLOC"] = "malloc"
 
         elif sys.platform == "darwin":
-            env["DYLD_INSERT_LIBRARIES"] = os.path.join(
-                os.path.dirname(scalene.__path__[0]), "libscalene.dylib"
-            )
+            if not args.cpu_only:
+                env["DYLD_INSERT_LIBRARIES"] = os.path.join(
+                    os.path.dirname(scalene.__path__[0]), "libscalene.dylib"
+                )
+                env["PYTHONMALLOC"] = "malloc"
+            # required for multiprocessing support, even without libscalene
             env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
-            env["PYTHONMALLOC"] = "malloc"
 
         return env
 
@@ -54,9 +57,6 @@ class ScalenePreload:
 
         # Load shared objects (that is, interpose on malloc, memcpy and friends)
         # unless the user specifies "--cpu-only" at the command-line.
-
-        if args.cpu_only:
-            return False
 
         try:
             from IPython import get_ipython

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -97,5 +97,6 @@ class ScalenePreload:
                         signal.Signals(-result.returncode).name,
                     )
                 sys.exit(result.returncode)
+                return True
 
-        return True
+        return False

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -455,7 +455,6 @@ class Scalene:
             # one is a shell script that redirects to Scalene.
             Scalene.__pid = 0
             cmdline = ""
-            preface = ""
             # Pass along commands from the invoking command line.
             cmdline += f" --cpu-sampling-rate={arguments.cpu_sampling_rate}"
             if arguments.use_virtual_time:
@@ -464,18 +463,10 @@ class Scalene:
                 cmdline += " --off"
             if arguments.cpu_only:
                 cmdline += " --cpu-only"
-            else:
-                preface = "PYTHONMALLOC=malloc "
-                if sys.platform == "linux":
-                    shared_lib = os.path.join(
-                        os.path.dirname(__file__), "libscalene.so"
-                    )
-                    preface += "LD_PRELOAD=" + shared_lib
-                else:
-                    shared_lib = os.path.join(
-                        os.path.dirname(__file__), "libscalene.dylib"
-                    )
-                    preface += "DYLD_INSERT_LIBRARIES=" + shared_lib
+
+            environ = ScalenePreload.get_preload_environ(arguments)
+            preface = ' '.join('='.join((k,str(v))) for (k,v) in environ.items())
+
             # Add the --pid field so we can propagate it to the child.
             cmdline += f" --pid={os.getpid()} ---"
             payload = """#!/bin/bash


### PR DESCRIPTION
Note that `libscalene.dylib` and `libscalene.so` are no longer generated at the top level directory, but directly into `scalene`. The homebrew formula may need to be adjusted.