### PR TITLE
Reverted to using signal.raise_signal on Windows

### DIFF
--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python_version: [ 3.7 ]
         include:
+          - os: macos-latest
+            python_version: 3.7
           - os: ubuntu-latest
+            python_version: 3.7
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
           - os: windows-latest
             python_version: 3.8

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -13,9 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python_version: [ 3.7 ]
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+          - os: windows-latest
+            python_version: 3.8
 
     container: ${{ matrix.container }}
 
@@ -26,7 +29,7 @@ jobs:
       if: matrix.container == ''
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python_version }}
 
     - name: Set up python (container version)
       if: matrix.container != ''

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ code...
 <details open>
 <summary>Using <code>pip</code> (Mac OS X, Linux, Windows, and WSL2)</summary>
 
-Scalene is distributed as a `pip` package and works on Mac OS X, Linux (including Ubuntu in [Windows WSL2](docs.microsoft.com/en-us/windows/wsl/wsl2-index)) and (with limitations) Windows platforms. (**Note**: the Windows port isn't complete yet and should be considered early alpha.)
+Scalene is distributed as a `pip` package and works on Mac OS X, Linux (including Ubuntu in [Windows WSL2](docs.microsoft.com/en-us/windows/wsl/wsl2-index)) and (with limitations) Windows platforms. (**Note**: the Windows port isn't complete yet and should be considered early alpha; it requires Python 3.8 or later)
 
 You can install it as follows:
 ```console

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ code...
 <details open>
 <summary>Using <code>pip</code> (Mac OS X, Linux, Windows, and WSL2)</summary>
 
-Scalene is distributed as a `pip` package and works on Mac OS X, Linux (including Ubuntu in [Windows WSL2](docs.microsoft.com/en-us/windows/wsl/wsl2-index)) and (with limitations) Windows platforms. (**Note**: the Windows port isn't complete yet and should be considered early alpha; it requires Python 3.8 or later)
+Scalene is distributed as a `pip` package and works on Mac OS X, Linux (including Ubuntu in [Windows WSL2](docs.microsoft.com/en-us/windows/wsl/wsl2-index)) and (with limitations) Windows platforms. (**Note**: the Windows port isn't complete yet and should be considered early alpha; it requires Python 3.8 or later.)
 
 You can install it as follows:
 ```console

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -65,7 +65,11 @@ from scalene.scalene_gpu import ScaleneGPU
 from scalene.scalene_parseargs import ScaleneParseArgs, StopJupyterExecution
 from scalene.scalene_sigqueue import ScaleneSigQueue
 
-assert (sys.version_info >= (3,7)), "Scalene requires Python version 3.7 or above."
+def require_python(version: Tuple[int, int]):
+    assert (sys.version_info >= version), \
+           f"Scalene requires Python version {version[0]}.{version[1]} or above."
+
+require_python((3,7) if sys.platform != "win32" else (3,8))
 
 
 # Scalene fully supports Unix-like operating systems; in
@@ -300,10 +304,9 @@ class Scalene:
     def windows_timer_loop() -> None:
         """For Windows, send periodic timer signals; launch as a background thread."""
         Scalene.timer_signals = True
-        pid = os.getpid()
         while Scalene.timer_signals:
             time.sleep(Scalene.__args.cpu_sampling_rate)
-            os.kill(pid, ScaleneSignals.cpu_signal)
+            signal.raise_signal(ScaleneSignals.cpu_signal)
 
     @staticmethod
     def set_timer_signals() -> None:

--- a/scalene/scalene_version.py
+++ b/scalene/scalene_version.py
@@ -1,1 +1,1 @@
-scalene_version = "1.3.11"
+scalene_version = "1.3.12"

--- a/setup.py
+++ b/setup.py
@@ -105,8 +105,9 @@ setup(
         "Topic :: Software Development :: Debuggers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3"
+    ] + (["Programming Language :: Python :: 3.7"] if sys.platform != 'win32' else []) + 
+    [
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: Apache Software License",
@@ -129,5 +130,5 @@ setup(
     setup_requires=['setuptools_scm'],
     include_package_data=True,
     entry_points={"console_scripts": ["scalene = scalene.__main__:main"]},
-    python_requires=">=3.7",
+    python_requires=">=3.7" if sys.platform != 'win32' else ">=3.8",
 )


### PR DESCRIPTION
Also raises the Python version requirement to 3.8 on Windows.