### PR TITLE
Changes to get fewer errors from `mypy`

### DIFF
--- a/scalene/scalene_magics.py
+++ b/scalene/scalene_magics.py
@@ -15,6 +15,7 @@ try:
     class ScaleneMagics(Magics):  # type: ignore
         def run_code(self, args: ScaleneArguments, code: str) -> None:
             import IPython
+
             # Create a file to hold the supplied code.
             # We encode the cell number in the string for later recovery.
             # The length of the history buffer lets us find the most recent string (this one).

--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -1,3 +1,4 @@
+import pathlib
 import shutil
 import sys
 import tempfile
@@ -308,7 +309,7 @@ class ScaleneOutput:
         stats: ScaleneStatistics,
         pid: int,
         profile_this_code: Callable[[Filename, LineNumber], bool],
-        python_alias_dir: Filename,
+        python_alias_dir: pathlib.Path,
         profile_memory: bool = True,
         reduced_profile: bool = False,
     ) -> bool:

--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -460,39 +460,66 @@ class ScaleneOutput:
             )
 
             tbl.add_column(
-                Markdown("Line", style="dim"), style="dim", justify="right", no_wrap=True, width=4
+                Markdown("Line", style="dim"),
+                style="dim",
+                justify="right",
+                no_wrap=True,
+                width=4,
             )
             tbl.add_column(
-                Markdown("Time  " + "\n" + "_Python_", style="blue"), style="blue", no_wrap=True, width=6
+                Markdown("Time  " + "\n" + "_Python_", style="blue"),
+                style="blue",
+                no_wrap=True,
+                width=6,
             )
             tbl.add_column(
-                Markdown("––––––  \n_native_", style="blue"), style="blue", no_wrap=True, width=6
+                Markdown("––––––  \n_native_", style="blue"),
+                style="blue",
+                no_wrap=True,
+                width=6,
             )
             tbl.add_column(
-                Markdown("––––––  \n_system_", style="blue"), style="blue", no_wrap=True, width=6
+                Markdown("––––––  \n_system_", style="blue"),
+                style="blue",
+                no_wrap=True,
+                width=6,
             )
             if self.gpu:
                 tbl.add_column(
-                    Markdown("––––––  \n_GPU_", style="yellow4"), style="yellow4", no_wrap=True, width=6
+                    Markdown("––––––  \n_GPU_", style="yellow4"),
+                    style="yellow4",
+                    no_wrap=True,
+                    width=6,
                 )
 
             other_columns_width = 0  # Size taken up by all columns BUT code
 
             if profile_memory:
                 tbl.add_column(
-                    Markdown("Memory  \n_Python_", style="dark_green"), style="dark_green", no_wrap=True, width=7
+                    Markdown("Memory  \n_Python_", style="dark_green"),
+                    style="dark_green",
+                    no_wrap=True,
+                    width=7,
                 )
                 tbl.add_column(
-                    Markdown("––––––  \n_net_", style="dark_green"), style="dark_green", no_wrap=True, width=6
+                    Markdown("––––––  \n_net_", style="dark_green"),
+                    style="dark_green",
+                    no_wrap=True,
+                    width=6,
                 )
                 tbl.add_column(
-                    Markdown("–––––––––––  \n_timeline_/%", style="dark_green"),
+                    Markdown(
+                        "–––––––––––  \n_timeline_/%", style="dark_green"
+                    ),
                     style="dark_green",
                     no_wrap=True,
                     width=14,
                 )
                 tbl.add_column(
-                    Markdown("Copy  \n_(MB/s)_", style="yellow4"), style="yellow4", no_wrap=True, width=6
+                    Markdown("Copy  \n_(MB/s)_", style="yellow4"),
+                    style="yellow4",
+                    no_wrap=True,
+                    width=6,
                 )
                 other_columns_width = 75 + (6 if self.gpu else 0)
                 tbl.add_column(

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -13,16 +13,17 @@ import sys
 
 
 class RichArgParser(argparse.ArgumentParser):
-
     def __init__(self, *args: Any, **kwargs: Any):
         from rich.console import Console
+
         self.console = Console()
         super().__init__(*args, **kwargs)
-        
-    def _print_message(self, message : Optional[str], file: Any = None) -> None:
+
+    def _print_message(self, message: Optional[str], file: Any = None) -> None:
         if message:
             self.console.print(message)
-                
+
+
 class StopJupyterExecution(Exception):
     """NOP exception to enable clean exits from within Jupyter notebooks."""
 
@@ -78,7 +79,7 @@ for the process ID that Scalene reports. For example:
 """
         )
 
-        parser = RichArgParser( # argparse.ArgumentParser(
+        parser = RichArgParser(  # argparse.ArgumentParser(
             prog="scalene",
             description=usage,
             epilog=epilog,
@@ -131,7 +132,11 @@ for the process ID that Scalene reports. For example:
             const=True,
             default=defaults.cpu_only,
             help="only profile CPU+GPU time (default: [blue]profile "
-            + ("CPU only" if defaults.cpu_only else "CPU+GPU, memory, and copying")
+            + (
+                "CPU only"
+                if defaults.cpu_only
+                else "CPU+GPU, memory, and copying"
+            )
             + "[/blue])",
         )
         parser.add_argument(
@@ -224,7 +229,10 @@ for the process ID that Scalene reports. For example:
         args, left = parser.parse_known_args()
         left += args.unused_args
         import re
-        in_jupyter_notebook = len(sys.argv) >= 1 and re.match("<ipython-input-([0-9]+)-.*>", sys.argv[0])
+
+        in_jupyter_notebook = len(sys.argv) >= 1 and re.match(
+            "<ipython-input-([0-9]+)-.*>", sys.argv[0]
+        )
         # If the user did not enter any commands (just `scalene` or `python3 -m scalene`),
         # print the usage information and bail.
         if not in_jupyter_notebook and (len(sys.argv) + len(left) == 1):

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -2,7 +2,9 @@ from scalene.scalene_arguments import ScaleneArguments
 from scalene.scalene_version import scalene_version
 
 from typing import (
+    Any,
     List,
+    Optional,
     Tuple,
 )
 from textwrap import dedent
@@ -12,12 +14,12 @@ import sys
 
 class RichArgParser(argparse.ArgumentParser):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         from rich.console import Console
         self.console = Console()
         super().__init__(*args, **kwargs)
         
-    def _print_message(self, message, file=None):
+    def _print_message(self, message : Optional[str], file: Any = None) -> None:
         if message:
             self.console.print(message)
                 
@@ -41,8 +43,8 @@ class ScaleneParseArgs:
             from IPython import get_ipython
 
             if get_ipython():
-                sys.exit = clean_exit  # type: ignore
-                sys._exit = clean_exit
+                sys.exit = ScaleneParseArgs.clean_exit  # type: ignore
+                sys._exit = ScaleneParseArgs.clean_exit
         except:
             pass
         defaults = ScaleneArguments()

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -61,7 +61,7 @@ class ScalenePreload:
 
             if get_ipython():
                 sys.exit = Scalene.clean_exit  # type: ignore
-                sys._exit = Scalene.clean_exit
+                sys._exit = Scalene.clean_exit  # type: ignore
         except:
             pass
 

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -9,6 +9,7 @@ import sys
 
 from typing import Dict
 
+
 class ScalenePreload:
     @staticmethod
     def get_preload_environ(args: argparse.Namespace) -> Dict[str, str]:
@@ -16,12 +17,16 @@ class ScalenePreload:
 
         if sys.platform == "linux":
             if not args.cpu_only:
-                env["LD_PRELOAD"] = os.path.join(scalene.__path__[0], "libscalene.so")
+                env["LD_PRELOAD"] = os.path.join(
+                    scalene.__path__[0], "libscalene.so"
+                )
                 env["PYTHONMALLOC"] = "malloc"
 
         elif sys.platform == "darwin":
             if not args.cpu_only:
-                env["DYLD_INSERT_LIBRARIES"] = os.path.join(scalene.__path__[0], "libscalene.dylib")
+                env["DYLD_INSERT_LIBRARIES"] = os.path.join(
+                    scalene.__path__[0], "libscalene.dylib"
+                )
                 env["PYTHONMALLOC"] = "malloc"
             # required for multiprocessing support, even without libscalene
             env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
@@ -76,9 +81,7 @@ class ScalenePreload:
                 "-m",
                 "scalene",
             ] + sys.argv[1:]
-            result = subprocess.Popen(
-                new_args, close_fds=True, shell=False
-            )
+            result = subprocess.Popen(new_args, close_fds=True, shell=False)
             try:
                 # If running in the background, print the PID.
                 if os.getpgrp() != os.tcgetpgrp(sys.stdout.fileno()):

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -45,7 +45,6 @@ from signal import Handlers, Signals
 from types import CodeType, FrameType
 from typing import (
     Any,
-    AnyStr,
     Callable,
     Dict,
     Set,

--- a/scalene/scalene_sigqueue.py
+++ b/scalene/scalene_sigqueue.py
@@ -2,14 +2,15 @@ import queue
 import threading
 from typing import Any, Callable, Generic, Optional, TypeVar
 
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 class ScaleneSigQueue(Generic[T]):
-    def __init__(self, process : Any) -> None:
-        self.queue : queue.SimpleQueue[Optional[T]] = queue.SimpleQueue()
+    def __init__(self, process: Any) -> None:
+        self.queue: queue.SimpleQueue[Optional[T]] = queue.SimpleQueue()
         self.process = process
-        self.thread : Optional[threading.Thread] = None
-        self.lock = threading.RLock() # held while processing an item
+        self.thread: Optional[threading.Thread] = None
+        self.lock = threading.RLock()  # held while processing an item
 
     def put(self, item: Optional[T]) -> None:
         self.queue.put(item)

--- a/scalene/scalene_sigqueue.py
+++ b/scalene/scalene_sigqueue.py
@@ -1,27 +1,29 @@
 import queue
 import threading
+from typing import Any, Callable, Generic, Optional, TypeVar
 
+T = TypeVar('T')
 
-class ScaleneSigQueue:
-    def __init__(self, process):
-        self.queue = queue.SimpleQueue()
+class ScaleneSigQueue(Generic[T]):
+    def __init__(self, process : Any) -> None:
+        self.queue : queue.SimpleQueue[Optional[T]] = queue.SimpleQueue()
         self.process = process
-        self.thread = None
+        self.thread : Optional[threading.Thread] = None
         self.lock = threading.RLock() # held while processing an item
 
-    def put(self, item):
+    def put(self, item: Optional[T]) -> None:
         self.queue.put(item)
 
-    def get(self):
+    def get(self) -> Optional[T]:
         return self.queue.get()
 
-    def start(self):
+    def start(self) -> None:
         # We use a daemon thread to defensively avoid hanging if we never join with it
         if not self.thread:
             self.thread = threading.Thread(target=self.run, daemon=True)
             self.thread.start()
 
-    def stop(self):
+    def stop(self) -> None:
         if self.thread:
             self.queue.put(None)
             # We need to join all threads before a fork() to avoid an inconsistent
@@ -29,7 +31,7 @@ class ScaleneSigQueue:
             self.thread.join()
             self.thread = None
 
-    def run(self):
+    def run(self) -> None:
         while True:
             item = self.queue.get()
             if item == None:  # None == stop request

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -32,7 +32,7 @@ class ScaleneStatistics:
     #
     def __init__(self) -> None:
         # time the profiling started
-        self.start_time: float = None
+        self.start_time: float = 0
 
         # total time spent in program being profiled
         self.elapsed_time: float = 0
@@ -194,7 +194,7 @@ class ScaleneStatistics:
 
     def stop_clock(self) -> None:
         self.elapsed_time += time.perf_counter() - self.start_time
-        self.start_time = None
+        self.start_time = 0
 
     def build_function_stats(self, filename: Filename):  # type: ignore
         fn_stats = ScaleneStatistics()
@@ -280,7 +280,7 @@ class ScaleneStatistics:
     ]
     # To be added: __malloc_samples
 
-    def output_stats(self, pid: int, dir_name: Filename) -> None:
+    def output_stats(self, pid: int, dir_name: pathlib.Path) -> None:
         payload: List[Any] = []
         for n in ScaleneStatistics.payload_contents:
             payload.append(getattr(self, n))
@@ -324,7 +324,7 @@ class ScaleneStatistics:
                         filename
                     ][lineno][ind]
 
-    def merge_stats(self, the_dir_name: Filename) -> None:
+    def merge_stats(self, the_dir_name: pathlib.Path) -> None:
         the_dir = pathlib.Path(the_dir_name)
         for f in list(the_dir.glob("**/scalene*")):
             # Skip empty files.

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -193,6 +193,7 @@ class ScaleneStatistics:
         self.start_time = time.perf_counter()
 
     def stop_clock(self) -> None:
+        assert self.start_time > 0
         self.elapsed_time += time.perf_counter() - self.start_time
         self.start_time = 0
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,3 +1,0 @@
-# vendor
-
-This directory holds repos that are checked out during build.


### PR DESCRIPTION
Still not mypy-clean, but it turned up the mismatch that gets reported by https://github.com/plasma-umass/scalene/issues/250, where for some reason it doesn't look like `ScaleneStatistics.start_clock` is ever invoked. Moved some stuff to use `pathlib` which is cleaner than using strings and avoids the need to cast the alias directory to `Filename` (which was never quite right anyway). 