### PR TITLE
Pymalloc mmap sampling

### DIFF
--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -27,7 +27,8 @@ class ScalenePreload:
                 env["DYLD_INSERT_LIBRARIES"] = os.path.join(
                     scalene.__path__[0], "libscalene.dylib"
                 )
-                env["PYTHONMALLOC"] = "malloc"
+                # env["PYTHONMALLOC"] = "malloc"
+                env["PYTHONMALLOC"] = "pymalloc"
             # required for multiprocessing support, even without libscalene
             env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
 

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -20,7 +20,8 @@ class ScalenePreload:
                 env["LD_PRELOAD"] = os.path.join(
                     scalene.__path__[0], "libscalene.so"
                 )
-                env["PYTHONMALLOC"] = "malloc"
+                # env["PYTHONMALLOC"] = "malloc"
+                env["PYTHONMALLOC"] = "pymalloc"
 
         elif sys.platform == "darwin":
             if not args.cpu_only:

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -193,8 +193,8 @@ class ScaleneStatistics:
         self.start_time = time.perf_counter()
 
     def stop_clock(self) -> None:
-        assert self.start_time > 0
-        self.elapsed_time += time.perf_counter() - self.start_time
+        if self.start_time > 0:
+            self.elapsed_time += time.perf_counter() - self.start_time
         self.start_time = 0
 
     def build_function_stats(self, filename: Filename):  # type: ignore

--- a/scalene/scalene_version.py
+++ b/scalene/scalene_version.py
@@ -1,1 +1,1 @@
-scalene_version = "1.3.12"
+scalene_version = "1.3.14"

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -27,65 +27,20 @@
 #include "macinterpose.h"
 #endif
 
-#if defined(__APPLE__)
-// Using the system allocator rather than Python's would add too much overhead;
-// we use Hoard instead to avoid that.
-
-class ScaleneBaseHeap : public HL::ANSIWrapper<Hoard::TLABBase> {
-  using super = HL::ANSIWrapper<Hoard::TLABBase>;
-
-  static Hoard::HoardHeapType *getMainHoardHeap() {
-    alignas(std::max_align_t) static char thBuf[sizeof(Hoard::HoardHeapType)];
-    static auto *th = new (thBuf) Hoard::HoardHeapType;
-    return th;
-  }
-
- public:
-  static constexpr size_t Alignment = alignof(std::max_align_t);
-
-  ScaleneBaseHeap() : super(getMainHoardHeap()) {}
-};
-
-class BaseHeap : public HL::OneHeap<ScaleneBaseHeap> {
- public:
-  void *memalign(size_t alignment, size_t size) {
-    // XXX Copied from Heap-Layers/wrappers/generic-memalign.cpp ; we can't use
-    // it directly because it invokes xxmalloc, which would be detected as a
-    // recursive malloc call, causing all memalign to be serviced by
-    // heapredirect's static buffer.  We use this->malloc() and this->free() to
-    // ensure these are bound to this heap's functions.
-
-    // Check for non power-of-two alignment.
-    if ((alignment == 0) || (alignment & (alignment - 1))) {
-      return nullptr;
-    }
-
-    if (alignment <= alignof(max_align_t)) {
-      // Already aligned by default.
-      return this->malloc(size);
-    }
-
-    // Try to just allocate an object of the requested size.
-    // If it happens to be aligned properly, just return it.
-    void *ptr = this->malloc(size);
-    if (((size_t)ptr & ~(alignment - 1)) == (size_t)ptr) {
-      // It is already aligned just fine; return it.
-      return ptr;
-    }
-    // It was not aligned as requested: free the object and allocate a big one,
-    // and align within.
-    this->free(ptr);
-    ptr = this->malloc(size + 2 * alignment);
-    void *alignedPtr =
-        (void *)(((size_t)ptr + alignment - 1) & ~(alignment - 1));
-    return alignedPtr;
-  }
-};
-
-#else  // not __APPLE__
-
 using BaseHeap = HL::SysMallocHeap;
 
+#if 0 // for debugging
+class BaseHeap : public HL::SysMallocHeap {
+public:
+  using HL::SysMallocHeap::SysMallocHeap;
+
+  void * malloc(size_t sz) {
+    if (sz >= 256 * 1024) {
+      printf("malloc %lu\n", sz);
+    }
+    return HL::SysMallocHeap::malloc(sz);
+  }
+};
 #endif
 
 // For use by the replacement printf routines (see
@@ -137,8 +92,36 @@ extern "C" ATTRIBUTE_EXPORT char *LOCAL_PREFIX(strcpy)(char *dst,
   return result;
 }
 
+// Initial support for tracking mmap and munmap of arenas to enable correct use of pymalloc.
+//
+// TODO: walk the stack to verify that this is a Python-allocated
+// arena -- a call to alloc(ctx, size) should be sufficiently
+// disambiguating. See
+// https://docs.python.org/3/c-api/memory.html#customize-pymalloc-arena-allocator
+// For now, assume that all exactly 256MB requests are in fact Python
+// arenas. See
+// https://docs.python.org/3/c-api/memory.html#the-pymalloc-allocator).
+
+extern "C" ATTRIBUTE_EXPORT void * LOCAL_PREFIX(mmap)(void *addr, size_t len, int prot, int flags, int fd, off_t offset) {
+  auto ptr = ::mmap(addr, len, prot, flags, fd, offset);
+  if (len == 256 * 1024) {
+    TheHeapWrapper::register_malloc(len, 0);
+  }
+  return ptr;
+}
+
+extern "C" ATTRIBUTE_EXPORT int LOCAL_PREFIX(munmap)(void * addr, size_t len) {
+  auto result = ::munmap(addr, len);
+  if (len == 256 * 1024) {
+    TheHeapWrapper::register_free(len, 0);
+  }
+  return result;
+}
+
 #if defined(__APPLE__)
 MAC_INTERPOSE(xxmemcpy, memcpy);
 MAC_INTERPOSE(xxmemmove, memmove);
 MAC_INTERPOSE(xxstrcpy, strcpy);
+MAC_INTERPOSE(xxmmap, mmap);
+MAC_INTERPOSE(xxmunmap, munmap);
 #endif

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -27,9 +27,12 @@
 #include "macinterpose.h"
 #endif
 
+#if 1
+
 using BaseHeap = HL::SysMallocHeap;
 
-#if 0 // for debugging
+#else // for debugging
+
 class BaseHeap : public HL::SysMallocHeap {
 public:
   using HL::SysMallocHeap::SysMallocHeap;
@@ -47,10 +50,10 @@ public:
 // https://github.com/mpaland/printf)
 extern "C" void _putchar(char ch) { int ignored = ::write(1, (void *)&ch, 1); }
 
-constexpr uint64_t MallocSamplingRate = 870173ULL;
-//  1048571ULL * 4;  // a prime number near a megabyte
-constexpr uint64_t FreeSamplingRate = 758201ULL;
-//  1048571ULL * 4;  // a prime number near a megabyte
+constexpr uint64_t MallocSamplingRate = 262147ULL; // 870173ULL;
+//  1048571ULL * 4;  // a prime number near 256K
+constexpr uint64_t FreeSamplingRate = 262261ULL; // 758201ULL;
+//  1048571ULL * 4;  // a prime number near 256K
 constexpr uint64_t MemcpySamplingRate = 2097169ULL;  // another prime, near 2MB
 
 class CustomHeapType : public HL::ThreadSpecificHeap<SampleHeap<MallocSamplingRate, FreeSamplingRate, BaseHeap>> {
@@ -98,7 +101,8 @@ extern "C" ATTRIBUTE_EXPORT char *LOCAL_PREFIX(strcpy)(char *dst,
 // arena -- a call to alloc(ctx, size) should be sufficiently
 // disambiguating. See
 // https://docs.python.org/3/c-api/memory.html#customize-pymalloc-arena-allocator
-// For now, assume that all exactly 256MB requests are in fact Python
+// For now, assume that all exactly 256MB or 1GB requests for the
+// right kind of memory (private, anonymous, etc.) are in fact Python
 // arenas. See
 // https://docs.python.org/3/c-api/memory.html#the-pymalloc-allocator).
 
@@ -113,12 +117,24 @@ extern "C" {
     static auto * _mmap = reinterpret_cast<decltype(::mmap) *>(reinterpret_cast<size_t>(dlsym(RTLD_NEXT, "mmap")));
     auto ptr = _mmap(addr, len, prot, flags, fd, offset);
 #endif
-    if (len == 256 * 1024) {
-      TheHeapWrapper::register_malloc(len, 0);
+    if ((addr == NULL) &&
+	(prot == PROT_READ | PROT_WRITE) &&
+	(flags == MAP_PRIVATE | MAP_ANONYMOUS) &&
+	(fd == -1) &&
+	(offset == 0) &&
+	((len == 256 * 1024) || (len == 1024 * 1024)))
+      {
+	TheHeapWrapper::register_malloc(len, 0);
+      } else {
     }
     return ptr;
   }
 
+  ATTRIBUTE_EXPORT void * LOCAL_PREFIX(mmap64)(void *addr, size_t len, int prot, int flags, int fd, off_t offset) {
+    auto ptr = LOCAL_PREFIX(mmap)(addr, len, prot, flags, fd, offset);
+    return ptr;
+  }
+  
   ATTRIBUTE_EXPORT int LOCAL_PREFIX(munmap)(void * addr, size_t len) {
 #if defined(__APPLE__)
     auto result = ::munmap(addr, len);
@@ -126,9 +142,12 @@ extern "C" {
     static auto * _munmap = reinterpret_cast<decltype(::munmap) *>(reinterpret_cast<size_t>(dlsym(RTLD_NEXT, "munmap")));
     auto result = _munmap(addr, len);
 #endif
-    if (len == 256 * 1024) {
-      TheHeapWrapper::register_free(len, 0);
-    }
+     if ((len == (256 * 1024)) ||
+	(len == (1024 * 1024))) {
+       TheHeapWrapper::register_free(len, 0);
+     } else {
+       //       printf("munmap %llu, %p\n", len, addr);
+     }       
     return result;
   }
 

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -50,9 +50,11 @@ public:
 // https://github.com/mpaland/printf)
 extern "C" void _putchar(char ch) { int ignored = ::write(1, (void *)&ch, 1); }
 
-constexpr uint64_t MallocSamplingRate = 262147ULL; // 870173ULL;
+//constexpr uint64_t MallocSamplingRate = 262147ULL; // 870173ULL;
+constexpr uint64_t MallocSamplingRate = 870173ULL;
 //  1048571ULL * 4;  // a prime number near 256K
-constexpr uint64_t FreeSamplingRate = 262261ULL; // 758201ULL;
+//constexpr uint64_t FreeSamplingRate = 262261ULL; // 758201ULL;
+constexpr uint64_t FreeSamplingRate = 758201ULL;
 //  1048571ULL * 4;  // a prime number near 256K
 constexpr uint64_t MemcpySamplingRate = 2097169ULL;  // another prime, near 2MB
 

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -101,7 +101,7 @@ extern "C" ATTRIBUTE_EXPORT char *LOCAL_PREFIX(strcpy)(char *dst,
 // arena -- a call to alloc(ctx, size) should be sufficiently
 // disambiguating. See
 // https://docs.python.org/3/c-api/memory.html#customize-pymalloc-arena-allocator
-// For now, assume that all exactly 256MB or 1GB requests for the
+// For now, assume that all exactly 256MB requests for the
 // right kind of memory (private, anonymous, etc.) are in fact Python
 // arenas. See
 // https://docs.python.org/3/c-api/memory.html#the-pymalloc-allocator).
@@ -118,11 +118,11 @@ extern "C" {
     auto ptr = _mmap(addr, len, prot, flags, fd, offset);
 #endif
     if ((addr == NULL) &&
-	(prot == PROT_READ | PROT_WRITE) &&
-	(flags == MAP_PRIVATE | MAP_ANONYMOUS) &&
+	(prot == (PROT_READ | PROT_WRITE)) &&
+	(flags == (MAP_PRIVATE | MAP_ANONYMOUS)) &&
 	(fd == -1) &&
 	(offset == 0) &&
-	((len == 256 * 1024) || (len == 1024 * 1024)))
+	(len == 256 * 1024))
       {
 	TheHeapWrapper::register_malloc(len, 0);
       } else {
@@ -142,8 +142,7 @@ extern "C" {
     static auto * _munmap = reinterpret_cast<decltype(::munmap) *>(reinterpret_cast<size_t>(dlsym(RTLD_NEXT, "munmap")));
     auto result = _munmap(addr, len);
 #endif
-     if ((len == (256 * 1024)) ||
-	(len == (1024 * 1024))) {
+     if (len == (256 * 1024)) {
        TheHeapWrapper::register_free(len, 0);
      } else {
        //       printf("munmap %llu, %p\n", len, addr);


### PR DESCRIPTION
Dramatically reduces overhead by using `pymalloc` (Python's built-in small object allocator) for most requests and instead tracking `mmap` requests for arena refills. Maintains previous accuracy for large object requests (> 512 bytes); seems to work surprisingly well even for large numbers of small object requests.