### PR TITLE
F202109 wheels using memory apis

### DIFF
--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -48,10 +48,6 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
 
-    - name: Come up with test version for testpipy
-      run: |
-        git log -1 --format=%ct scalene/scalene_version.py
-
     - name: Build source dist
       if: matrix.os == 'ubuntu-latest' # we only need sdist once
       env:

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -27,6 +27,13 @@ jobs:
       GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 
     steps:
+    - name: Pick .devN name if a test build
+      env:
+        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
+      run: |
+        # setup.py checks for DEV_BUILD
+        [ "$TWINE_REPOSITORY" == "testpypi" ] && echo "DEV_BUILD=$(date '+%Y%m%d%H%M')" >> $GITHUB_ENV
+
     - uses: actions/checkout@v2
 
     - name: Set up python (script version)
@@ -52,13 +59,9 @@ jobs:
 
     - name: Build source dist
       if: matrix.os == 'ubuntu-latest' # we only need sdist once
-      env:
-        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }} # used by setup.py
       run: make sdist
 
     - name: Build binary dist
-      env:
-        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }} # used by setup.py
       run: |
         make bdist
         echo "UPLOAD_TARGET=$(ls dist/scalene*.whl)" >> $GITHUB_ENV

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -39,7 +39,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-#        python3 -m pip install --upgrade pip
         pip3 install setuptools wheel twine
 
     - name: Work around arm64 support on MacOS

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -43,7 +43,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
-        which git
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
+        apt update
         apt install git
 
     - name: Work around arm64 support on MacOS

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -36,26 +36,10 @@ jobs:
       run: |
         PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -d -1 /opt/python/cp$PYV*/bin | head -n 1 >> $GITHUB_PATH
         cat $GITHUB_PATH
-#        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-#
-#    - name: Set up python (3.8+container)
-#      if: matrix.container != '' && matrix.python_version == '3.8'
-#      run: |
-#        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
-#
-#    - name: Set up python (3.9+container)
-#      if: matrix.container != '' && matrix.python_version == '3.9'
-#      run: |
-#        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
-#
-#    - name: Set up python (3.10+container)
-#      if: matrix.container != '' && matrix.python_version == '3.10'
-#      run: |
-#        echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+#        python3 -m pip install --upgrade pip
         pip3 install setuptools wheel twine
 
     - name: Work around arm64 support on MacOS

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -60,7 +60,7 @@ jobs:
         TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }} # used by setup.py
       run: |
         make bdist
-        echo "UPLOAD_TARGET=$(ls dist/scalene*.whl)" >> GITHUB_ENV
+        echo "UPLOAD_TARGET=$(ls dist/scalene*.whl)" >> $GITHUB_ENV
 
     - name: Upload to google drive, for testing
       if: env.GOOGLE_DRIVE_FOLDER != ''
@@ -68,7 +68,7 @@ jobs:
       with:
         target: ${{ env.UPLOAD_TARGET }}
         credentials: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }}
-        folder: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
+        folder: ${{ env.GOOGLE_DRIVE_FOLDER }}
 
     - name: Upload
       if: env.GOOGLE_DRIVE_FOLDER == ''

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -23,14 +23,14 @@ jobs:
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
-#          - os: macos-latest
+          - os: macos-latest
 #          - os: windows-latest
 #            python_version: 3.8
 
     container: ${{ matrix.container }}
     env:
       # secrets can't be accessed directly in "if:"
-      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
+#      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
       TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
 
     steps:

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -63,7 +63,7 @@ jobs:
       if: env.GOOGLE_DRIVE_FOLDER != ''
       uses: Jodebu/upload-to-drive@master
       with:
-        target: dist/scalene*.whl
+        target: $(ls dist/scalene*.whl)
         credentials: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }}
         folder: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         python_version: ['3.7', '3.8', '3.9']
         include:
-#          - os: ubuntu-latest
-#            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
-          - os: macos-latest
+          - os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+#          - os: macos-latest
 #          - os: windows-latest
 #            python_version: 3.8
 

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -70,8 +70,7 @@ jobs:
       run: make sdist
 
     - name: Build binary dist
-      run: |
-        make bdist
+      run: make bdist
 
     - name: Figure out google drive upload target
       if: env.GOOGLE_DRIVE_FOLDER != ''

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -1,6 +1,13 @@
 # https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries
 
-name: build & pypi upload
+# To upload to [test]pypi, define the project secrets PYPI_REPOSITORY (set to "pypi" or
+# "testpypi"), PYPI_USERNAME and PYPI_PASSWORD.
+
+# To have files upload to Google Drive rather than [test]pypi, follow the setup
+# instructions at https://github.com/Jodebu/upload-to-drive and define the
+# GOOGLE_DRIVE_FOLDER and GOOGLE_DRIVE_CREDENTIALS secrets in the project.
+
+name: build & upload
 
 on:
   release:
@@ -50,6 +57,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
+        pip3 install find_libpython
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.7']
+        python_version: ['3.7', '3.8', '3.9']
 #        python_version: ['3.7', '3.8', '3.9']
         include:
-          - os: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
-#          - os: macos-latest
+#          - os: ubuntu-latest
+#            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+          - os: macos-latest
 #          - os: windows-latest
 #            python_version: 3.8
 

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,14 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        python_version: [3.7 3.8 3.9]
         include:
-          - os: macos-latest
-            python_version: 3.7
           - os: ubuntu-latest
-            python_version: 3.7
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
-          - os: windows-latest
-            python_version: 3.8
+#          - os: macos-latest
+#          - os: windows-latest
+#            python_version: 3.8
 
     container: ${{ matrix.container }}
 
@@ -32,10 +31,20 @@ jobs:
       with:
         python-version: ${{ matrix.python_version }}
 
-    - name: Set up python (container version)
-      if: matrix.container != ''
+    - name: Set up python (3.7 container)
+      if: matrix.container != '' && matrix.python_version == '3.7'
       run: |
         echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+
+    - name: Set up python (3.8 container)
+      if: matrix.container != '' && matrix.python_version == '3.8'
+      run: |
+        echo "/opt/python/cp38-cp38m/bin" >> $GITHUB_PATH
+
+    - name: Set up python (3.9 container)
+      if: matrix.container != '' && matrix.python_version == '3.9'
+      run: |
+        echo "/opt/python/cp39-cp39m/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.7', '3.8', '3.9']
+        python_version: ['3.7']
+#        python_version: ['3.7', '3.8', '3.9']
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
@@ -57,13 +58,15 @@ jobs:
     - name: Build binary dist
       env:
         TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }} # used by setup.py
-      run: make bdist
+      run: |
+        make bdist
+        echo "UPLOAD_TARGET=$(ls dist/scalene*.whl)" >> GITHUB_ENV
 
     - name: Upload to google drive, for testing
       if: env.GOOGLE_DRIVE_FOLDER != ''
       uses: Jodebu/upload-to-drive@master
       with:
-        target: $(ls dist/scalene*.whl)
+        target: ${{ env.UPLOAD_TARGET }}
         credentials: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }}
         folder: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -22,10 +22,12 @@ jobs:
 
     container: ${{ matrix.container }}
     env:
-      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
+      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }} # secrets can't be accessed directly in "if:"
 
     steps:
     - uses: actions/checkout@v2
+      run: |
+        git log -1 --format=%ct scalene/scalene_version.py
 
     - name: Set up python (script version)
       if: matrix.container == ''

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.7', '3.8', '3.9']
-#        python_version: ['3.7', '3.8', '3.9']
         include:
 #          - os: ubuntu-latest
 #            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
@@ -56,8 +55,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip3 install setuptools wheel twine
-        pip3 install find_libpython
+        pip3 install setuptools wheel twine find_libpython
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557
@@ -71,9 +69,13 @@ jobs:
     - name: Build binary dist
       run: |
         make bdist
+
+    - name: Figure out google drive upload target
+      if: env.GOOGLE_DRIVE_FOLDER != ''
+      run: |
         echo "UPLOAD_TARGET=$(ls dist/scalene*.whl)" >> $GITHUB_ENV
 
-    - name: Upload to google drive, for testing
+    - name: Upload to google drive
       if: env.GOOGLE_DRIVE_FOLDER != ''
       uses: Jodebu/upload-to-drive@master
       with:

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -58,7 +58,7 @@ jobs:
       run: make bdist
 
     - name: Upload to google drive, for testing
-      if: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }} != ''
+      if: secrets.GOOGLE_DRIVE_CREDENTIALS != ''
       uses: Jodebu/upload-to-drive@master
       with:
         target: dist/scalene*.whl
@@ -66,7 +66,7 @@ jobs:
         folder: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 
     - name: Upload
-      if: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }} == ''
+      if: secrets.GOOGLE_DRIVE_CREDENTIALS == ''
       env:
         TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.7', '3.8', '3.9', '3.10']
+        python_version: ['3.7', '3.8', '3.9']
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         python-version: ${{ matrix.python_version }}
 
-    - name: Set up python (container)
+    - name: Set up python (container version)
       if: matrix.container != ''
       run: |
         PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -d -1 /opt/python/cp$PYV*/bin | head -n 1 >> $GITHUB_PATH

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -57,7 +57,16 @@ jobs:
         TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }} # used by setup.py
       run: make bdist
 
+    - name: Upload to google drive, for testing
+      if: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }} != ''
+      uses: Jodebu/upload-to-drive@master
+      with:
+        target: dist/scalene*.whl
+        credentials: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }}
+        folder: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
+
     - name: Upload
+      if: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }} == ''
       env:
         TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.7', '3.8', '3.9']
+        python_version: ['3.7']
+#        python_version: ['3.7', '3.8', '3.9']
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -23,7 +23,8 @@ jobs:
 
     container: ${{ matrix.container }}
     env:
-      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }} # secrets can't be accessed directly in "if:"
+      # secrets can't be accessed directly in "if:"
+      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 
     steps:
     - uses: actions/checkout@v2
@@ -43,6 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
+        apt install git
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.7']
-#        python_version: ['3.7', '3.8', '3.9']
+        python_version: ['3.7', '3.8', '3.9']
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up python (container)
       if: matrix.container != ''
       run: |
-        PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -d -1 "/opt/python/cp$PYV*/bin" | head -n 1 >> $GITHUB_PATH
+        PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -d -1 /opt/python/cp$PYV*/bin | head -n 1 >> $GITHUB_PATH
         cat $GITHUB_PATH
 #        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 #

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
+        which git
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: [3.7 3.8 3.9]
+        python_version: [3.7, 3.8, 3.9]
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -24,6 +24,9 @@ jobs:
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
+          - os: macos-latest
+            python_version: 3.7
+            upload_source: true   # just need ONE of them to do it
 #          - os: windows-latest
 #            python_version: 3.8
 
@@ -63,7 +66,7 @@ jobs:
       run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
 
     - name: Build source dist
-      if: matrix.os == 'ubuntu-latest' # we only need sdist once
+      if: matrix.upload_source
       run: make sdist
 
     - name: Build binary dist

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -44,8 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
-        apt update
-        apt install git
+        git --version
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9, 3.10]
+        python_version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
@@ -34,7 +34,7 @@ jobs:
     - name: Set up python (container)
       if: matrix.container != ''
       run: |
-        PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -1 "/opt/python/cp$PYV*/bin" | head -n 1 >> $GITHUB_PATH
+        PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -d -1 "/opt/python/cp$PYV*/bin" | head -n 1 >> $GITHUB_PATH
         cat $GITHUB_PATH
 #        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 #

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -21,6 +21,8 @@ jobs:
 #            python_version: 3.8
 
     container: ${{ matrix.container }}
+    env:
+      GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 
     steps:
     - uses: actions/checkout@v2
@@ -58,7 +60,7 @@ jobs:
       run: make bdist
 
     - name: Upload to google drive, for testing
-      if: secrets.GOOGLE_DRIVE_CREDENTIALS != ''
+      if: env.GOOGLE_DRIVE_FOLDER != ''
       uses: Jodebu/upload-to-drive@master
       with:
         target: dist/scalene*.whl
@@ -66,7 +68,7 @@ jobs:
         folder: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
 
     - name: Upload
-      if: secrets.GOOGLE_DRIVE_CREDENTIALS == ''
+      if: env.GOOGLE_DRIVE_FOLDER == ''
       env:
         TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Set up python (3.7 container)
       if: matrix.container != '' && matrix.python_version == '3.7'
       run: |
+        ls -alF /opt/python
         echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 
     - name: Set up python (3.8 container)

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -44,7 +44,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install setuptools wheel twine
-        git --version
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -26,8 +26,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      run: |
-        git log -1 --format=%ct scalene/scalene_version.py
 
     - name: Set up python (script version)
       if: matrix.container == ''
@@ -49,6 +47,10 @@ jobs:
       # https://github.com/actions/virtual-environments/issues/2557
       if: matrix.os == 'macos-latest'
       run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+
+    - name: Come up with test version for testpipy
+      run: |
+        git log -1 --format=%ct scalene/scalene_version.py
 
     - name: Build source dist
       if: matrix.os == 'ubuntu-latest' # we only need sdist once

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9]
+        python_version: [3.7, 3.8, 3.9, 3.10]
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
@@ -31,26 +31,32 @@ jobs:
       with:
         python-version: ${{ matrix.python_version }}
 
-    - name: Set up python (3.7 container)
-      if: matrix.container != '' && matrix.python_version == '3.7'
+    - name: Set up python (container)
+      if: matrix.container != ''
       run: |
-        ls -alF /opt/python
-        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-
-    - name: Set up python (3.8 container)
-      if: matrix.container != '' && matrix.python_version == '3.8'
-      run: |
-        echo "/opt/python/cp38-cp38m/bin" >> $GITHUB_PATH
-
-    - name: Set up python (3.9 container)
-      if: matrix.container != '' && matrix.python_version == '3.9'
-      run: |
-        echo "/opt/python/cp39-cp39m/bin" >> $GITHUB_PATH
+        PYV=`echo "${{ matrix.python_version }}" | tr -d "."`; ls -1 "/opt/python/cp$PYV*/bin" | head -n 1 >> $GITHUB_PATH
+        cat $GITHUB_PATH
+#        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+#
+#    - name: Set up python (3.8+container)
+#      if: matrix.container != '' && matrix.python_version == '3.8'
+#      run: |
+#        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+#
+#    - name: Set up python (3.9+container)
+#      if: matrix.container != '' && matrix.python_version == '3.9'
+#      run: |
+#        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+#
+#    - name: Set up python (3.10+container)
+#      if: matrix.container != '' && matrix.python_version == '3.10'
+#      run: |
+#        echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        python3 -m pip install --upgrade pip
+        pip3 install setuptools wheel twine
 
     - name: Work around arm64 support on MacOS
       # https://github.com/actions/virtual-environments/issues/2557

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.7', '3.8', '3.9']
+        os: ['ubuntu-latest', 'macos-latest']
         include:
           - os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
-          - os: macos-latest
 #          - os: windows-latest
 #            python_version: 3.8
 

--- a/.github/workflows/release-pypi-upload.yml
+++ b/.github/workflows/release-pypi-upload.yml
@@ -25,14 +25,13 @@ jobs:
     env:
       # secrets can't be accessed directly in "if:"
       GOOGLE_DRIVE_FOLDER: ${{ secrets.GOOGLE_DRIVE_FOLDER }}
+      TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
 
     steps:
     - name: Pick .devN name if a test build
-      env:
-        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
+      if: env.TWINE_REPOSITORY == 'testpypi'
       run: |
-        # setup.py checks for DEV_BUILD
-        [ "$TWINE_REPOSITORY" == "testpypi" ] && echo "DEV_BUILD=$(date '+%Y%m%d%H%M')" >> $GITHUB_ENV
+        echo "DEV_BUILD=$(date '+%Y%m%d%H%M')" >> $GITHUB_ENV  # for setup.py
 
     - uses: actions/checkout@v2
 
@@ -77,7 +76,6 @@ jobs:
     - name: Upload
       if: env.GOOGLE_DRIVE_FOLDER == ''
       env:
-        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: twine upload dist/*

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -77,9 +77,9 @@ clang-format:
 black:
 	-black -l 79 $(PYTHON_SOURCES)
 
-ifeq ($(shell uname -s),Darwin)
-  PYTHON_PLAT:=-p $(shell $(PYTHON) -c 'from pkg_resources import get_build_platform; p=get_build_platform(); print(p[:p.rindex("-")])')-universal2
-endif
+#ifeq ($(shell uname -s),Darwin)
+#  PYTHON_PLAT:=-p $(shell $(PYTHON) -c 'from pkg_resources import get_build_platform; p=get_build_platform(); print(p[:p.rindex("-")])')-universal2
+#endif
 
 PYTHON_API_VER:=$(shell $(PYTHON) -c 'from pip._vendor.packaging.tags import interpreter_name, interpreter_version; print(interpreter_name()+interpreter_version())')
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -84,7 +84,7 @@ endif
 PYTHON_API_VER:=$(shell $(PYTHON) -c 'from pip._vendor.packaging.tags import interpreter_name, interpreter_version; print(interpreter_name()+interpreter_version())')
 
 bdist: vendor-deps
-	$(PYTHON) setup.py bdist_wheel --py-limited-api=$(PYTHON_API_VER) $(PYTHON_PLAT)
+	$(PYTHON) setup.py bdist_wheel $(PYTHON_PLAT)
 ifeq ($(shell uname -s),Linux)
 	auditwheel repair dist/*.whl
 	rm -f dist/*.whl

--- a/setup.py
+++ b/setup.py
@@ -93,10 +93,7 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if True: #testing:
     import subprocess
     import time
-    print(subprocess.check_output(["pwd"]))
-    print(subprocess.check_output(["ls"]))
-    print(subprocess.check_output(["echo", "git log -1 --decorate=no -- scalene_version.py"]))
-    print(subprocess.check_output(["echo", "git log -1 --decorate=no -- scalene/scalene_version.py"]))
+    print(subprocess.check_output(["echo", "git log -1 --decorate=no HEAD -- scalene/scalene_version.py"]))
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def multiarch_args():
     if sys.platform == 'darwin':
         return []
         # multiple architectures disabled for now, because of issues linking with the Python library.
-#         return ['-arch', 'x86_64', '-arch', 'arm64']
+        # return ['-arch', 'x86_64', '-arch', 'arm64']
     return []
 
 def extra_compile_args():

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if testing:
     import subprocess
     import time
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
-                                                 "--", "scalene/scalene_version.py"])
+                                                 "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)
     #mins_since_version = (time.time() - int(version_timestamp))/60
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if True: #testing:
     import subprocess
     import time
-    print(subprocess.check_output(["bash", "-c", "git log -- scalene/scalene_version.py"]))
+    print(subprocess.check_output(["bash", "-c", "git log -1 --decorate=no -- scalene/scalene_version.py"]))
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/setup.py
+++ b/setup.py
@@ -93,9 +93,10 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if testing:
     import subprocess
     import time
-    version_timestamp = int(subprocess.check_output(["git", "log", "-1", "--format=%ct",
-                                                     "scalene/scalene_version.py"]))
-    mins_since_version = (time.time() - version_timestamp)/60
+    version_timestamp = subprocess.check_output(["git", "log", "-1", "--format=%ct",
+                                                 "scalene/scalene_version.py"])
+    print(version_timestamp)
+    mins_since_version = (time.time() - int(version_timestamp))/60
 
 setup(
     name="scalene",

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ def multiarch_args():
     """Returns args requesting multi-architecture support, if applicable."""
     # On MacOS we build "universal2" packages, for both x86_64 and arm64/M1
     if sys.platform == 'darwin':
-        return []
-        # multiple architectures disabled for now, because of issues linking with the Python library.
-        # return ['-arch', 'x86_64', '-arch', 'arm64']
+#        return []
+#        # multiple architectures disabled for now, because of issues linking with the Python library.
+         return ['-arch', 'x86_64', '-arch', 'arm64']
     return []
 
 def extra_compile_args():

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if testing:
     import subprocess
     import time
-    version_timestamp = subprocess.check_output(["git", "log", "--", "scalene/scalene_version.py"], text=True)
+    version_timestamp = subprocess.check_output(["git", "log", "--", "scalene/scalene_profiler.py"], text=True)
 #    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
 #                                                 "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ def multiarch_args():
     """Returns args requesting multi-architecture support, if applicable."""
     # On MacOS we build "universal2" packages, for both x86_64 and arm64/M1
     if sys.platform == 'darwin':
-#        return []
-#        # multiple architectures disabled for now, because of issues linking with the Python library.
-         return ['-arch', 'x86_64', '-arch', 'arm64']
+        return []
+        # multiple architectures disabled for now, because of issues linking with the Python library.
+#         return ['-arch', 'x86_64', '-arch', 'arm64']
     return []
 
 def extra_compile_args():

--- a/setup.py
+++ b/setup.py
@@ -93,10 +93,10 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if testing:
     import subprocess
     import time
-    version_timestamp = subprocess.check_output(["git", "log", "-1", "--format=%ct",
+    version_timestamp = subprocess.check_output(["git", "log", "-1", #"--format=%ct",
                                                  "scalene/scalene_version.py"])
     print(version_timestamp)
-    mins_since_version = (time.time() - int(version_timestamp))/60
+    #mins_since_version = (time.time() - int(version_timestamp))/60
 
 setup(
     name="scalene",

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if testing:
     import subprocess
     import time
-    version_timestamp = subprocess.check_output(["git", "log", "-1", #"--format=%ct",
+    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"])
     print(version_timestamp)
     #mins_since_version = (time.time() - int(version_timestamp))/60

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,9 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if testing:
     import subprocess
     import time
-    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
-                                                 "--", "scalene/scalene_version.py"], text=True)
+    version_timestamp = subprocess.check_output(["git", "log", "--", "scalene/scalene_version.py"], text=True)
+#    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
+#                                                 "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)
     #mins_since_version = (time.time() - int(version_timestamp))/60
 

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,10 @@ get_line_atomic = Extension('scalene.get_line_atomic',
 # we can upload new files (as testpypi/pypi don't allow re-uploading files with
 # the same name as previously uploaded).
 testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'testpypi'
-if testing:
+if True: #testing:
     import subprocess
     import time
+    print(subprocess.check_output(["bash", "-c", "which git"]))
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if True: #testing:
     import subprocess
     import time
-    print(subprocess.check_output(["bash", "-c", "which git"]))
+    print(subprocess.check_output(["bash", "-c", "git log -- scalene/scalene_version.py"]))
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if testing:
     import subprocess
     import time
     version_timestamp = subprocess.check_output(["git", "log", "-1", #"--format=%ct",
-                                                 "scalene/scalene_version.py"])
+                                                 "--", "scalene/scalene_version.py"])
     print(version_timestamp)
     #mins_since_version = (time.time() - int(version_timestamp))/60
 

--- a/setup.py
+++ b/setup.py
@@ -93,9 +93,8 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if testing:
     import subprocess
     import time
-    version_timestamp = subprocess.check_output(["git", "log", "--", "scalene/scalene_profiler.py"], text=True)
-#    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
-#                                                 "--", "scalene/scalene_version.py"], text=True)
+    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
+                                                 "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)
     #mins_since_version = (time.time() - int(version_timestamp))/60
 

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,9 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if True: #testing:
     import subprocess
     import time
-    print(subprocess.check_output(["bash", "git log -1 --decorate=no HEAD -- scalene/scalene_version.py"]))
-    print(subprocess.check_output(["bash", "git log -1 --decorate=no HEAD -- scalene/scalene_profiler.py"]))
+    print(subprocess.check_output(["ls", "-alF", "scalene/scalene_version.py"]))
+    print(subprocess.check_output(["bash", "-c", "git log -1 --decorate=no HEAD -- scalene/scalene_version.py"]))
+    print(subprocess.check_output(["bash", "-c", "git log -1 --decorate=no HEAD -- scalene/scalene_profiler.py"]))
     version_timestamp = subprocess.check_output(["git", "log", "-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/setup.py
+++ b/setup.py
@@ -93,8 +93,9 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if True: #testing:
     import subprocess
     import time
-    print(subprocess.check_output(["echo", "git log -1 --decorate=no HEAD -- scalene/scalene_version.py"]))
-    version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
+    print(subprocess.check_output(["bash", "git log -1 --decorate=no HEAD -- scalene/scalene_version.py"]))
+    print(subprocess.check_output(["bash", "git log -1 --decorate=no HEAD -- scalene/scalene_profiler.py"]))
+    version_timestamp = subprocess.check_output(["git", "log", "-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)
     #mins_since_version = (time.time() - int(version_timestamp))/60

--- a/setup.py
+++ b/setup.py
@@ -85,25 +85,15 @@ get_line_atomic = Extension('scalene.get_line_atomic',
     language="c++"
 )
 
-# if TWINE_REPOSITORY=testpypi, we're testing packaging. Build using a ".devN"
-# (monotonically increasing, not too big) suffix in the version number, so that
-# we can upload new files (as testpypi/pypi don't allow re-uploading files with
+# If we're testing packaging, build using a ".devN" suffix in the version number,
+# so that we can upload new files (as testpypi/pypi don't allow re-uploading files with
 # the same name as previously uploaded).
-testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'testpypi'
-if True: #testing:
-    import subprocess
-    import time
-    print(subprocess.check_output(["ls", "-alF", "scalene/scalene_version.py"]))
-    print(subprocess.check_output(["bash", "-c", "git log -1 --decorate=no HEAD -- scalene/scalene_version.py"]))
-    print(subprocess.check_output(["bash", "-c", "git log -1 --decorate=no HEAD -- scalene/scalene_profiler.py"]))
-    version_timestamp = subprocess.check_output(["git", "log", "-1", #"--format=%ct",
-                                                 "--", "scalene/scalene_version.py"], text=True)
-    print(version_timestamp)
-    #mins_since_version = (time.time() - int(version_timestamp))/60
+# Numbering scheme: https://www.python.org/dev/peps/pep-0440
+dev_build = ('.dev' + environ['DEV_BUILD']) if 'DEV_BUILD' in environ else ''
 
 setup(
     name="scalene",
-    version=scalene_version + (f'.dev{int(mins_since_version/5)}' if testing else ''),
+    version=scalene_version + dev_build,
     description="Scalene: A high-resolution, low-overhead CPU, GPU, and memory profiler for Python",
     keywords="performance memory profiler",
     long_description=read_file("README.md"),

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,8 @@ if True: #testing:
     import subprocess
     import time
     print(subprocess.check_output(["pwd"]))
+    print(subprocess.check_output(["ls"]))
+    print(subprocess.check_output(["echo", "git log -1 --decorate=no -- scalene_version.py"]))
     print(subprocess.check_output(["echo", "git log -1 --decorate=no -- scalene/scalene_version.py"]))
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ testing = 'TWINE_REPOSITORY' in environ and environ['TWINE_REPOSITORY'] == 'test
 if True: #testing:
     import subprocess
     import time
-    print(subprocess.check_output(["bash", "-c", "git log -1 --decorate=no -- scalene/scalene_version.py"]))
+    print(subprocess.check_output(["pwd"]))
+    print(subprocess.check_output(["echo", "git log -1 --decorate=no -- scalene/scalene_version.py"]))
     version_timestamp = subprocess.check_output(["git", "log", #"-1", #"--format=%ct",
                                                  "--", "scalene/scalene_version.py"], text=True)
     print(version_timestamp)

--- a/src/include/py_env.hpp
+++ b/src/include/py_env.hpp
@@ -27,9 +27,11 @@ class PyStringPtrList {
     scalene_base_path = PyBytes_AsString(PyUnicode_AsASCIIString(base_path));
     is_initialized = true;
   }
+
   PyStringPtrList() { is_initialized = false; }
 
   bool initialized() { return is_initialized; }
+
   bool should_trace(char* filename) {
     if (strstr(filename, "site-packages") || strstr(filename, "/lib/python")) {
       return false;
@@ -55,6 +57,7 @@ class PyStringPtrList {
 
     return strstr(resolved_path, scalene_base_path) != nullptr;
   }
+
   void print() {
     printf("Profile all? %d\nitems {", profile_all);
     for (auto c : items) {

--- a/src/include/py_env.hpp
+++ b/src/include/py_env.hpp
@@ -79,6 +79,6 @@ static PyStringPtrList py_string_ptr_list;
 
 static void set_py_string_ptr_list(PyObject* p, PyObject* base_path,
                                    bool trace_all) {
-  std::lock_guard g(_mx);
+  std::lock_guard<decltype(_mx)> g(_mx);
   py_string_ptr_list = PyStringPtrList{p, base_path, trace_all};
 }

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -177,7 +177,7 @@ class MakeLocalAllocator {
 #endif
 #if USE_HEADERS
     auto *header =
-        new (get_original_allocator().malloc(ctx, len + SLACK + sizeof(Header)))
+        new (get_original_allocator()->malloc(ctx, len + SLACK + sizeof(Header)))
             Header(len);
 #else
     auto *header = (Header *)get_original_allocator().malloc(ctx, len + SLACK);


### PR DESCRIPTION
Updated build & upload workflow as well as other files as needed to build with the new code using the Python allocator API:
- builds can't use the restricted API anymore because there is no API call to get the executing file name; with that, they need to be built for each Python version;
- builds on MacOS aren't currently universal because we're linking directly with `libpython`, and that isn't universal;

This also fixes the `.devN` file naming for testing to `testpypi`. The MacOS wheels aren't currently working because `libpython` usually isn't found. Building for Windows is future work.