### PR TITLE
Fix `rich` version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         'build_ext': BuildExtCommand,
     },
     install_requires=[
-        "rich>=9.2.10",
+        "rich>=9.2.0",
         "cloudpickle>=1.5.0",
         "nvidia-ml-py==11.450.51",
         "wheel==0.36.2",


### PR DESCRIPTION
The version constraint is currently tied to a version of `rich` [that doesn't exist](https://pypi.org/project/rich/#history). I'm guessing this is a typo. The version that makes sense to me that might've been intended is `9.2.0`.

Coincidentally, 9.2.0 is also required by another library I want to use. Currently I can't use pip's new resolver to install that library and scalene because of the current version constraint on `rich` here. So this little change has a real effect for me.

In trying to find which version should be appropriate here, I found the commit where this was changed https://github.com/plasma-umass/scalene/commit/e5a1a5bb0d237b8bc3c9618f019239c5231dc86e, but it didn't tell me why the change was made. Could this commit even be reverted? If `2.0.0` actually works, then reverting that might mean greater dependency compatibility with other libraries. If `9.2.0` is really required, that's fine, but I'd recommend loosening the constraint if it isn't necessary, for others in a similar situation with other libraries.

If this is merged (or that commit reverted), I would appreciate a release with a patch version update even if just for this. Thanks!