### PR TITLE
Resolve AttributeErrors in scalene.profile

### DIFF
--- a/scalene/profile.py
+++ b/scalene/profile.py
@@ -26,10 +26,10 @@ if len(sys.argv) == 1 or args.pid == 0:
 
 try:
     if args.on:
-        os.kill(args.pid, ScaleneSignals.start_profiling_signal)
+        os.kill(args.pid, ScaleneSignals().start_profiling_signal)
         print("Scalene: profiling turned on.")
     else:
-        os.kill(args.pid, ScaleneSignals.stop_profiling_signal)
+        os.kill(args.pid, ScaleneSignals().stop_profiling_signal)
         print("Scalene: profiling turned off.")
 
 except ProcessLookupError:


### PR DESCRIPTION
Initializes `ScaleneSignals` in `scalene.profile` before accessing attributes `stop_profiling_signal` and `start_profiling_signal` to avoid `AttributeError`s.

This resolves two `AttributeError`s  which could be caused like:

```
$ python3 -m scalene.profile --on --pid 10
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/jim/.local/lib/python3.8/site-packages/scalene/profile.py", line 29, in <module>
    os.kill(args.pid, ScaleneSignals.start_profiling_signal)
AttributeError: type object 'ScaleneSignals' has no attribute 'start_profiling_signal'
```

and

```
$ python3 -m scalene.profile --off --pid 10
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/jim/.local/lib/python3.8/site-packages/scalene/profile.py", line 32, in <module>
    os.kill(args.pid, ScaleneSignals.stop_profiling_signal)
AttributeError: type object 'ScaleneSignals' has no attribute 'stop_profiling_signal'
```