### PR TITLE
Update stats handling to track average peak per line.

### DIFF
--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -64,14 +64,20 @@ class ScaleneJSON:
         n_malloc_mb = 0.0
         n_mallocs = 0
         n_python_malloc_mb = 0.0
+
         for index in stats.bytei_map[fname][line_no]:
             mallocs = stats.memory_malloc_samples[fname][line_no][index]
             n_mallocs += stats.memory_malloc_count[fname][line_no][index]
-            n_malloc_mb += mallocs
             n_python_malloc_mb += stats.memory_python_samples[fname][line_no][
                 index
             ]
 
+        # Use the average **peak** memory allocated by this line.
+        # This approach correctly accounts for varying footprints
+        # (mallocs+frees) that happened during execution of a single
+        # line.
+        n_malloc_mb = stats.memory_max_footprint[fname][line_no]
+        
         n_usage_fraction = (
             0
             if not stats.total_memory_malloc_samples

--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -585,19 +585,11 @@ class ScaleneOutput:
             avg_mallocs: Dict[LineNumber, float] = defaultdict(float)
             for line_no in stats.bytei_map[fname]:
                 count = 0
-                n_malloc_mb = 0
+                n_malloc_mb = stats.memory_max_footprint[fname][line_no]
                 for bytecode_index in stats.bytei_map[fname][line_no]:
                     count += stats.memory_malloc_count[fname][line_no][
                         bytecode_index
                     ]
-                    n_malloc_mb += (
-                        stats.memory_malloc_samples[fname][line_no][
-                            bytecode_index
-                        ]
-                        # - stats.memory_free_samples[fname][line_no][
-                        #    bytecode_index
-                        # ]
-                    )
                 if count:
                     avg_mallocs[line_no] += n_malloc_mb / count
                 else:

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1070,6 +1070,18 @@ class Scalene:
                     # Check if pointer actually matches
                     if stats.last_malloc_triggered[2] == pointer:
                         freed_last_trigger += 1
+            # Precisely attribute frees when we are still executing a single line.
+            # Check to see whether we are currently tracing execution of a line.
+            (f, l, b) = Scalene.__last_profiled
+            if not is_malloc and f != Filename("NADA"):
+                # We just executed a free while we are tracing a line.
+                # We should update the current and peak amount of memory
+                # associated with that line.
+                stats.memory_current_footprint[f][l] -= count
+            if is_malloc:
+                stats.memory_current_footprint[fname][lineno] += count
+                stats.memory_max_footprint[fname][lineno] = max(stats.memory_current_footprint[fname][lineno],
+                                                                stats.memory_max_footprint[fname][lineno])
             stats.memory_footprint_samples.add(stats.current_footprint)
         after = stats.current_footprint
 

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -64,6 +64,16 @@ class ScaleneStatistics:
             Filename, Dict[LineNumber, Dict[ByteCodeIndex, int]]
         ] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
 
+        # the current footprint for this line
+        self.memory_current_footprint: Dict[
+            Filename, Dict[LineNumber, int]
+        ] = defaultdict(lambda: defaultdict(int))
+
+        # the max footprint for this line
+        self.memory_max_footprint: Dict[
+            Filename, Dict[LineNumber, int]
+        ] = defaultdict(lambda: defaultdict(int))
+
         # the last malloc to trigger a sample (used for leak detection)
         self.last_malloc_triggered: Tuple[Filename, LineNumber, Address] = (
             Filename(""),
@@ -150,6 +160,8 @@ class ScaleneStatistics:
         self.malloc_samples.clear()
         self.memory_malloc_samples.clear()
         self.memory_malloc_count.clear()
+        self.memory_current_footprint.clear()
+        self.memory_max_footprint.clear()
         self.memory_python_samples.clear()
         self.memory_free_samples.clear()
         self.memory_free_count.clear()


### PR DESCRIPTION
This PR corrects a problem with Scalene's memory attribution, where it could potentially dramatically over-report the amount of memory allocated by a line of code.

Prior to this PR, Scalene only tracked _total_ memory allocations per line. This approach doesn't work well when executing native code that itself is allocating and freeing a lot of memory, since it potentially exaggerates the amount of memory consumed by that line. In the worst case, a line of code could have a max footprint of 1 object (malloc-free-malloc-free...), but Scalene would report _N_ objects as the footprint.

This PR fixes this situation by tracking (sampled) frees whenever we are tracing a line of code (which we already do to count the number of distinct executions of a sampled line of code).

Normally, Scalene has no way to attribute frees to lines of code, since they are triggered by Python's GC, and thus not directly associated with the line that allocated them.

However, when a free comes in and Scalene is in the midst of tracing — meaning it is still tracking the execution of a single line of code that triggered a memory sample — it must be associated with that line.

Leveraging this fact, Scalene now correctly attributes those frees to the line of code. It then updates the running current memory footprint for that line (and the peak memory footprint, if necessary).
