### PR TITLE
Fixes incompatibility with rich < 9.4.0

### DIFF
--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -530,7 +530,10 @@ class ScaleneOutput:
                 break
 
             if print_fn_summary:
-                tbl.add_row(None, end_section=True)
+                try:
+                    tbl.add_row(None, end_section=True)
+                except TypeError:  # rich < 9.4.0 compatibility
+                    tbl.add_row(None)
                 txt = Text.assemble(
                     f"function summary for {fname}", style="bold italic"
                 )


### PR DESCRIPTION
Without this you'd get a

```
TypeError: add_row() got an unexpected keyword argument 'end_section'
```
The output with this diff on rich 9.2.0 still looks fine to me.

[Airflow 2.0.0 for instance still requires rich 9.2.0](https://github.com/apache/airflow/blob/2.0.0/setup.cfg#L129), for instance, so I'd say there's still reason to support rich down to that version.