### PR TITLE
Fixed double-counting newlines

### DIFF
--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -165,6 +165,7 @@ class MakeLocalAllocator {
       TheHeapWrapper::register_malloc(len, ScaleneHeader::getObject(header));
     }
     class Nada {};
+    static_assert(SampleHeap<1, HL::NullHeap<Nada>>::NEWLINE > PYMALLOC_MAX_SIZE, "NEWLINE must be greater than PYMALLOC_MAX_SIZE.");
     if (len == SampleHeap<1, HL::NullHeap<Nada>>::NEWLINE) {
       // Special case: register the new line execution.
       TheHeapWrapper::register_malloc(len, ScaleneHeader::getObject(header));


### PR DESCRIPTION
The Scalene allocator was calling `register_malloc` twice, once in `MakeLocalAllocator` and once in `SampleHeap`. However, it only registered a single `free`. This fix suppresses the write inside of `SampleHeap` so that the only one is in `MakeLocalAllocator`