### PR TITLE
Added `--allocation-sampling-window`; fixed reporting of peak function summary

### DIFF
--- a/scalene/scalene_arguments.py
+++ b/scalene/scalene_arguments.py
@@ -8,6 +8,8 @@ class ScaleneArguments(argparse.Namespace):
         self.cpu_percent_threshold = 1
         # mean seconds between interrupts for CPU sampling.
         self.cpu_sampling_rate = 0.01
+        # Size of allocation window (sample when footprint increases or decreases by this amount)
+        self.allocation_sampling_window = 1549351 # sync with src/source/libscalene.cpp
         self.html = False
         self.json = False
         self.column_width = (

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -213,6 +213,13 @@ for the process ID that Scalene reports. For example:
             help=f"CPU sampling rate (default: every [blue]{defaults.cpu_sampling_rate}s[/blue])",
         )
         parser.add_argument(
+            "--allocation-sampling-window",
+            dest="allocation_sampling_window",
+            type=int,
+            default=defaults.allocation_sampling_window,
+            help=f"Allocation sampling window size, in bytes (default: [blue]{defaults.allocation_sampling_window} bytes[/blue])",
+        )
+        parser.add_argument(
             "--malloc-threshold",
             dest="malloc_threshold",
             type=int,

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -16,6 +16,12 @@ class ScalenePreload:
     def get_preload_environ(args: argparse.Namespace) -> Dict[str, str]:
         env = dict()
 
+        # Set allocation sampling window (sync environment variable
+        # name with src/include/sampleheap.hpp).
+        env["SCALENE_ALLOCATION_SAMPLING_WINDOW"] = str(args.allocation_sampling_window)
+
+        # Set environment variables for loading the Scalene dynamic library,
+        # which interposes on allocation and copying functions.
         if sys.platform == "linux":
             if not args.cpu_only:
                 env["LD_PRELOAD"] = os.path.join(

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1516,7 +1516,7 @@ class Scalene:
                     # Grab local and global variables.
                     if not Scalene.__args.cpu_only:
                         from scalene import pywhere
-
+                        
                         pywhere.register_files_to_profile(
                             list(Scalene.__files_to_profile.keys()),
                             Scalene.__program_path,

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -267,6 +267,9 @@ class ScaleneStatistics:
                 fn_stats.leak_score[fn_name][first_line_no][1]
                 + self.leak_score[filename][line_no][1],
             )
+            fn_stats.memory_max_footprint[fn_name][first_line_no] = max(
+                fn_stats.memory_max_footprint[fn_name][first_line_no],
+                self.memory_max_footprint[filename][line_no])
         return fn_stats
 
     payload_contents = [

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -29,17 +29,17 @@ using BaseHeap = HL::OneHeap<HL::SysMallocHeap>;
 // https://github.com/mpaland/printf)
 extern "C" void _putchar(char ch) { ::write(1, (void *)&ch, 1); }
 
-constexpr uint64_t AllocationSamplingRate = 1 * 1549351ULL;  // 1 * 1048576ULL;
-constexpr uint64_t MemcpySamplingRate = AllocationSamplingRate * 7;
+constexpr uint64_t DefaultAllocationSamplingRate = 1 * 1549351ULL;  // 1 * 1048576ULL;
+constexpr uint64_t MemcpySamplingRate = DefaultAllocationSamplingRate * 7;
 
 /**
  * @brief the replacement heap for sampling purposes
  *
  */
 class CustomHeapType : public HL::ThreadSpecificHeap<
-                           SampleHeap<AllocationSamplingRate, BaseHeap>> {
+  SampleHeap<DefaultAllocationSamplingRate, BaseHeap>> {
   using super =
-      HL::ThreadSpecificHeap<SampleHeap<AllocationSamplingRate, BaseHeap>>;
+    HL::ThreadSpecificHeap<SampleHeap<DefaultAllocationSamplingRate, BaseHeap>>;
 
  public:
   void lock() {}


### PR DESCRIPTION
The allocation sampling window can now be changed at invocation time via the `--allocation-sampling-window` flag. Larger windows improve performance, at the cost of lower granularity peak reporting.