### PR TITLE
Fixed scalene looping infinitely in some functions

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -937,8 +937,10 @@ class Scalene:
         f = frame
         try:
             while "<" in Filename(f.f_code.co_name):
-                f = cast(FrameType, f.f_back)
-                
+                f = cast(FrameType, frame.f_back)
+                # Handle case where the <\w+> is at the bottom of the stack
+                if f is None:
+                    return
         except:
             return
         if not Scalene.should_trace(f.f_code.co_filename):

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -938,7 +938,7 @@ class Scalene:
         try:
             while "<" in Filename(f.f_code.co_name):
                 f = cast(FrameType, f.f_back)
-                # Handle case where the <\w+> is at the bottom of the stack
+                # Handle case where the function with the name wrapped in triangle brackets is at the bottom of the stack
                 if f is None:
                     return
         except:

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -937,7 +937,7 @@ class Scalene:
         f = frame
         try:
             while "<" in Filename(f.f_code.co_name):
-                f = cast(FrameType, frame.f_back)
+                f = cast(FrameType, f.f_back)
                 # Handle case where the <\w+> is at the bottom of the stack
                 if f is None:
                     return

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -937,13 +937,8 @@ class Scalene:
         f = frame
         try:
             while "<" in Filename(f.f_code.co_name):
-                f = cast(FrameType, frame.f_back)
-                if (
-                    "<genexpr>" in f.f_code.co_name
-                    or "<module>" in f.f_code.co_name
-                    or "<listcomp>" in f.f_code.co_name
-                ):
-                    return
+                f = cast(FrameType, f.f_back)
+                
         except:
             return
         if not Scalene.should_trace(f.f_code.co_filename):


### PR DESCRIPTION
Fixed an anomalous loop condition that I suspect caused #201 as well as several other bits of weirdness. Logic was supposed to be "If code in a special block such as `<module>` or `<listcomp>`, keep going back in the stack until you find real code", but this logic has been around for a long time.