### PR TITLE
Add override of realloc to prevent reentrancy 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ C_SOURCES = src/source/*.cpp src/include/*.h*
 .PHONY: black clang-format format upload vendor-deps
 
 # CXXFLAGS = -std=c++17 -g -O0 # FIXME
-CXXFLAGS = -std=c++17 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -pipe -fno-builtin-malloc -fvisibility=hidden
+CXXFLAGS = -std=c++17 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden
 CXX = g++
 
 INCLUDES  = -Isrc -Isrc/include

--- a/src/include/sampleheap.hpp
+++ b/src/include/sampleheap.hpp
@@ -217,7 +217,6 @@ class SampleHeap : public SuperHeap {
   }
 
   inline void register_free(size_t realSize, void* ptr) {
-    // printf_("In realloc %p\n", &in_realloc);
     auto sampleFree = _allocationSampler.decrement(realSize);
     
     if (unlikely(ptr && (ptr == _lastMallocTrigger))) {

--- a/src/include/sampleheap.hpp
+++ b/src/include/sampleheap.hpp
@@ -108,7 +108,7 @@ class SampleHeap : public SuperHeap {
 #if defined(__APPLE__)
     // 0 size = free. We return a small object.  This behavior is
     // apparently required under Mac OS X and optional under POSIX.
-    return xxmalloc(1);
+    return SuperHeap::malloc(1);
 #else
     // For POSIX, don't return anything.
     return nullptr;

--- a/src/include/scaleneheader.hpp
+++ b/src/include/scaleneheader.hpp
@@ -14,7 +14,7 @@ extern "C" size_t malloc_usable_size(void *) throw();
 #include <assert.h>
 
 #define USE_HEADERS 1
-#define DEBUG_HEADER 0
+#define DEBUG_HEADER 1
 
 // Maximum size allocated internally by pymalloc;
 // aka "SMALL_REQUEST_THRESHOLD" in cpython/Objects/obmalloc.c
@@ -28,12 +28,13 @@ class ScaleneHeader {
 #if USE_HEADERS
 #if DEBUG_HEADER
   ScaleneHeader(size_t sz) : size(sz), magic(MAGIC_NUMBER) {}
-  alignas(std::max_align_t) size_t size;
+  size_t size;
+  size_t padding;
   size_t magic;
 #else
   ScaleneHeader(size_t sz) : size(sz) {}
   // size_t size;
-  alignas(std::max_align_t) size_t size;
+  size_t size;
 
 #endif
 #else
@@ -52,6 +53,9 @@ class ScaleneHeader {
   static inline size_t getSize(void *ptr) {
 #if USE_HEADERS
 #if DEBUG_HEADER
+    if(getHeader(ptr)->magic != MAGIC_NUMBER) {
+      printf_("AAAAA\n");
+    }
     assert(getHeader(ptr)->magic == MAGIC_NUMBER);
 #endif
     auto sz = getHeader(ptr)->size;

--- a/src/include/scaleneheader.hpp
+++ b/src/include/scaleneheader.hpp
@@ -33,7 +33,6 @@ class ScaleneHeader {
   size_t magic;
 #else
   ScaleneHeader(size_t sz) : size(sz) {}
-  // size_t size;
   size_t size;
 
 #endif
@@ -53,9 +52,6 @@ class ScaleneHeader {
   static inline size_t getSize(void *ptr) {
 #if USE_HEADERS
 #if DEBUG_HEADER
-    if(getHeader(ptr)->magic != MAGIC_NUMBER) {
-      printf_("AAAAA\n");
-    }
     assert(getHeader(ptr)->magic == MAGIC_NUMBER);
 #endif
     auto sz = getHeader(ptr)->size;

--- a/src/include/scaleneheader.hpp
+++ b/src/include/scaleneheader.hpp
@@ -14,7 +14,7 @@ extern "C" size_t malloc_usable_size(void *) throw();
 #include <assert.h>
 
 #define USE_HEADERS 1
-#define DEBUG_HEADER 1
+#define DEBUG_HEADER 0
 
 // Maximum size allocated internally by pymalloc;
 // aka "SMALL_REQUEST_THRESHOLD" in cpython/Objects/obmalloc.c

--- a/src/include/scaleneheader.hpp
+++ b/src/include/scaleneheader.hpp
@@ -32,8 +32,8 @@ class ScaleneHeader {
   size_t magic;
 #else
   ScaleneHeader(size_t sz) : size(sz) {}
-  size_t size;
-  //    alignas(std::max_align_t) size_t size;
+  // size_t size;
+  alignas(std::max_align_t) size_t size;
 
 #endif
 #else


### PR DESCRIPTION
Fixes #360 -- A highly network-bound program was running into `SIGSEGV`s. Inspection in `gdb` revealed that this was a double free happening in the arena allocator. In the process of adding a new arena, the array of arenas was being reallocated with `PyMem_RawRealloc`, and because `realloc` was previously overloaded as a composition of `malloc` and `free`. At some point in the middle of this, `SampleHeap::process_malloc` was being called, which called `whereInPython`, which queries the Python interpreter, which in turn allocates memory and creates a new arena, which requires expanding the list of arenas. This means that the list being `realloc`ed is freed in the middle of the call to `realloc`, leading to a double free. The solution to this was to [add the ability to redefine `realloc` in Heap-Layers](https://github.com/emeryberger/Heap-Layers/pull/45) and then redefine `realloc` in `SampleHeap`. We verified that this resolves the issue by running the test program in a Vagrant instance running Ubuntu 21.10. 