### PR TITLE
Multiprocessing not supported for win32 - yet

### DIFF
--- a/scalene/replacement_get_context.py
+++ b/scalene/replacement_get_context.py
@@ -1,4 +1,6 @@
 import multiprocessing
+import sys
+
 from typing import Any
 
 from scalene.scalene_profiler import Scalene
@@ -9,6 +11,11 @@ def replacement_mp_get_context(scalene: Scalene) -> None:
     old_get_context = multiprocessing.get_context
 
     def replacement_get_context(method: Any = None) -> Any:
+        if sys.platform == "win32":
+            print(
+            "Scalene currently only supports the `multiprocessing` library on Mac and Unix platforms."
+            )
+            sys.exit(1)
         return old_get_context("fork")
 
     multiprocessing.get_context = replacement_get_context

--- a/scalene/replacement_lock.py
+++ b/scalene/replacement_lock.py
@@ -8,7 +8,7 @@ from scalene.scalene_profiler import Scalene
 
 @Scalene.shim
 def replacement_lock(scalene: Scalene) -> None:
-    class ReplacementLock(object):
+    class ReplacementLock:
         """Replace lock with a version that periodically yields and updates sleeping status."""
 
         def __init__(self) -> None:


### PR DESCRIPTION
In light of https://github.com/plasma-umass/scalene/issues/416, warn users of Scalene on Windows that it does not currently support use of `multiprocessing` on that platform.
