### PR TITLE
Resolve paths according to original working directory.

### DIFF
--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -1,5 +1,6 @@
 import copy
 import linecache
+import os
 import random
 import re
 from collections import OrderedDict, defaultdict
@@ -182,6 +183,7 @@ class ScaleneJSON:
         pid: int,
         profile_this_code: Callable[[Filename, LineNumber], bool],
         python_alias_dir: Path,
+        program_path: Path,
         profile_memory: bool = True,
     ) -> Dict[str, Any]:
         """Write the profile out."""
@@ -325,7 +327,8 @@ class ScaleneJSON:
                 )
 
             # Print out the the profile for the source, line by line.
-            with open(fname, "r", encoding="utf-8") as source_file:
+            full_fname = os.path.normpath(os.path.join(program_path, fname))
+            with open(full_fname, "r", encoding="utf-8") as source_file:
                 code_lines = source_file.readlines()
 
                 output["files"][fname_print] = {

--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -1,3 +1,4 @@
+import os
 import random
 import sys
 import tempfile
@@ -304,6 +305,7 @@ class ScaleneOutput:
         pid: int,
         profile_this_code: Callable[[Filename, LineNumber], bool],
         python_alias_dir: Path,
+        program_path: Path,
         profile_memory: bool = True,
         reduced_profile: bool = False,
     ) -> bool:
@@ -527,7 +529,8 @@ class ScaleneOutput:
             if not fname:
                 continue
             # Print out the profile for the source, line by line.
-            with open(fname, "r", encoding="utf-8") as source_file:
+            full_fname = os.path.normpath(os.path.join(program_path, fname))
+            with open(full_fname, "r", encoding="utf-8") as source_file:
                 # We track whether we should put in ellipsis (for reduced profiles)
                 # or not.
                 did_print = True  # did we print a profile line last time?

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1830,8 +1830,14 @@ class Scalene:
                     # Push the program's path.
                     program_path = os.path.dirname(os.path.abspath(progs[0]))
                     sys.path.insert(0, program_path)
-                    # Save the directory from which Scalene was invoked.
-                    Scalene.__program_path = os.getcwd()
+                    # If a program path was specified at the command-line, use it.
+                    if len(args.program_path) > 0:
+                        Scalene.__program_path = os.path.abspath(
+                            args.program_path
+                        )
+                    else:
+                        # Otherwise, use the invoked directory.
+                        Scalene.__program_path = os.getcwd()
                     # Grab local and global variables.
                     if not Scalene.__args.cpu_only:
                         from scalene import pywhere  # type: ignore

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -781,6 +781,7 @@ class Scalene:
                 Scalene.__pid,
                 Scalene.profile_this_code,
                 Scalene.__python_alias_dir,
+                Scalene.__program_path,
                 profile_memory=not Scalene.__args.cpu_only,
             )
             if not Scalene.__output.output_file:
@@ -810,6 +811,7 @@ class Scalene:
                 Scalene.__pid,
                 Scalene.profile_this_code,
                 Scalene.__python_alias_dir,
+                Scalene.__program_path,
                 profile_memory=not Scalene.__args.cpu_only,
                 reduced_profile=Scalene.__args.reduced_profile,
             )
@@ -1466,7 +1468,9 @@ class Scalene:
             return True
         # Profile anything in the program's directory or a child directory,
         # but nothing else, unless otherwise specified.
-        filename = os.path.abspath(filename)
+        filename = os.path.normpath(
+            os.path.join(Scalene.__program_path, filename)
+        )
         return Scalene.__program_path in filename
 
     __done = False

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1830,12 +1830,8 @@ class Scalene:
                     # Push the program's path.
                     program_path = os.path.dirname(os.path.abspath(progs[0]))
                     sys.path.insert(0, program_path)
-                    if len(args.program_path) > 0:
-                        Scalene.__program_path = os.path.abspath(
-                            args.program_path
-                        )
-                    else:
-                        Scalene.__program_path = program_path
+                    # Save the directory from which Scalene was invoked.
+                    Scalene.__program_path = os.getcwd()
                     # Grab local and global variables.
                     if not Scalene.__args.cpu_only:
                         from scalene import pywhere  # type: ignore


### PR DESCRIPTION
Right now, changing the current working directory in the middle of profiling disrupts name resolution (and even triggers an `abort`). This PR resolves all file names using the original invocation path.