### PR TITLE
Fixed file handling

### DIFF
--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -77,8 +77,8 @@ class ScaleneJSON:
     ) -> Dict[str, Any]:
         """Print at most one line of the profile (true == printed one)."""
 
-        full_fname = fname
-        fname = os.path.basename(full_fname)
+        full_fname = os.path.abspath(fname)
+        
         if not force_print and not profile_this_code(fname, line_no):
             return {}
         # Prepare output values.
@@ -267,6 +267,7 @@ class ScaleneJSON:
                 and percent_cpu_time < self.cpu_percent_threshold
             ):
                 continue
+
             report_files.append(fname)
 
         # Don't actually output the profile if we are a child process.
@@ -344,7 +345,7 @@ class ScaleneJSON:
             }
             for lineno, line in enumerate(code_lines, start=1):
                 profile_line = self.output_profile_line(
-                    fname=full_fname,
+                    fname=fname,
                     fname_print=fname_print,
                     line_no=LineNumber(lineno),
                     stats=stats,
@@ -361,6 +362,8 @@ class ScaleneJSON:
                         output["files"][fname_print]["lines"].append(
                             profile_line
                         )
+
+
             fn_stats = stats.build_function_stats(fname)
             # Check CPU samples and memory samples.
             print_fn_summary = False

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -76,6 +76,7 @@ class ScaleneJSON:
         force_print: bool = False,
     ) -> Dict[str, Any]:
         """Print at most one line of the profile (true == printed one)."""
+
         full_fname = fname
         fname = os.path.basename(full_fname)
         if not force_print and not profile_this_code(fname, line_no):
@@ -330,33 +331,36 @@ class ScaleneJSON:
 
             # Print out the the profile for the source, line by line.
             full_fname = os.path.normpath(os.path.join(program_path, fname))
-            with open(full_fname, "r", encoding="utf-8") as source_file:
-                code_lines = source_file.readlines()
+            try:
+                with open(full_fname, "r", encoding="utf-8") as source_file:
+                    code_lines = source_file.readlines()
+            except FileNotFoundError:
+                continue
 
-                output["files"][fname_print] = {
-                    "percent_cpu_time": percent_cpu_time,
-                    "lines": [],
-                    "leaks": reported_leaks,
-                }
-                for lineno, line in enumerate(code_lines, start=1):
-                    profile_line = self.output_profile_line(
-                        fname=full_fname,
-                        fname_print=fname_print,
-                        line_no=LineNumber(lineno),
-                        stats=stats,
-                        profile_this_code=profile_this_code,
-                        profile_memory=profile_memory,
-                        force_print=False,
-                    )
-                    # Only output if the payload for the line is non-zero.
-                    if profile_line:
-                        profile_line_copy = copy.copy(profile_line)
-                        del profile_line_copy["line"]
-                        del profile_line_copy["lineno"]
-                        if any(profile_line_copy.values()):
-                            output["files"][fname_print]["lines"].append(
-                                profile_line
-                            )
+            output["files"][fname_print] = {
+                "percent_cpu_time": percent_cpu_time,
+                "lines": [],
+                "leaks": reported_leaks,
+            }
+            for lineno, line in enumerate(code_lines, start=1):
+                profile_line = self.output_profile_line(
+                    fname=full_fname,
+                    fname_print=fname_print,
+                    line_no=LineNumber(lineno),
+                    stats=stats,
+                    profile_this_code=profile_this_code,
+                    profile_memory=profile_memory,
+                    force_print=False,
+                )
+                # Only output if the payload for the line is non-zero.
+                if profile_line:
+                    profile_line_copy = copy.copy(profile_line)
+                    del profile_line_copy["line"]
+                    del profile_line_copy["lineno"]
+                    if any(profile_line_copy.values()):
+                        output["files"][fname_print]["lines"].append(
+                            profile_line
+                        )
             fn_stats = stats.build_function_stats(fname)
             # Check CPU samples and memory samples.
             print_fn_summary = False

--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -530,52 +530,56 @@ class ScaleneOutput:
                 continue
             # Print out the profile for the source, line by line.
             full_fname = os.path.normpath(os.path.join(program_path, fname))
-            with open(full_fname, "r", encoding="utf-8") as source_file:
-                # We track whether we should put in ellipsis (for reduced profiles)
-                # or not.
-                did_print = True  # did we print a profile line last time?
-                code_lines = source_file.read()
-                # Generate syntax highlighted version for the whole file,
-                # which we will consume a line at a time.
-                # See https://github.com/willmcgugan/rich/discussions/965#discussioncomment-314233
-                syntax_highlighted = Syntax(
-                    code_lines,
-                    "python",
-                    theme="default" if self.html else "vim",
-                    line_numbers=False,
-                    code_width=None,
+            try:
+                with open(full_fname, "r", encoding="utf-8") as source_file:
+                    code_lines = source_file.read()
+            except FileNotFoundError:
+                continue
+
+            # We track whether we should put in ellipsis (for reduced profiles)
+            # or not.
+            did_print = True  # did we print a profile line last time?
+            # Generate syntax highlighted version for the whole file,
+            # which we will consume a line at a time.
+            # See https://github.com/willmcgugan/rich/discussions/965#discussioncomment-314233
+            syntax_highlighted = Syntax(
+                code_lines,
+                "python",
+                theme="default" if self.html else "vim",
+                line_numbers=False,
+                code_width=None,
+            )
+            capture_console = Console(
+                width=column_width - other_columns_width,
+                force_terminal=True,
+            )
+            formatted_lines = [
+                SyntaxLine(segments)
+                for segments in capture_console.render_lines(
+                    syntax_highlighted
                 )
-                capture_console = Console(
-                    width=column_width - other_columns_width,
-                    force_terminal=True,
+            ]
+            for line_no, line in enumerate(formatted_lines, start=1):
+                old_did_print = did_print
+                did_print = self.output_profile_line(
+                    json=json,
+                    fname=fname,
+                    line_no=LineNumber(line_no),
+                    line=line,
+                    console=console,
+                    tbl=tbl,
+                    stats=stats,
+                    profile_this_code=profile_this_code,
+                    profile_memory=profile_memory,
+                    force_print=False,
+                    suppress_lineno_print=False,
+                    is_function_summary=False,
+                    reduced_profile=reduced_profile,
                 )
-                formatted_lines = [
-                    SyntaxLine(segments)
-                    for segments in capture_console.render_lines(
-                        syntax_highlighted
-                    )
-                ]
-                for line_no, line in enumerate(formatted_lines, start=1):
-                    old_did_print = did_print
-                    did_print = self.output_profile_line(
-                        json=json,
-                        fname=fname,
-                        line_no=LineNumber(line_no),
-                        line=line,
-                        console=console,
-                        tbl=tbl,
-                        stats=stats,
-                        profile_this_code=profile_this_code,
-                        profile_memory=profile_memory,
-                        force_print=False,
-                        suppress_lineno_print=False,
-                        is_function_summary=False,
-                        reduced_profile=reduced_profile,
-                    )
-                    if old_did_print and not did_print:
-                        # We are skipping lines, so add an ellipsis.
-                        tbl.add_row("...")
-                    old_did_print = did_print
+                if old_did_print and not did_print:
+                    # We are skipping lines, so add an ellipsis.
+                    tbl.add_row("...")
+                old_did_print = did_print
 
             # Potentially print a function summary.
             fn_stats = stats.build_function_stats(fname)

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -754,7 +754,6 @@ class Scalene:
         # Restart the timer while handling any timers set by the client.
         if sys.platform != "win32":
             if Scalene.client_timer.is_set:
-
                 (
                     should_raise,
                     remaining_time,
@@ -1249,7 +1248,12 @@ class Scalene:
         allocs = 0.0
         last_malloc = (Filename(""), LineNumber(0), Address("0x0"))
         malloc_pointer = "0x0"
-        curr = before
+        # was: curr = before
+        curr = 0
+        try:
+            curr = stats.per_line_footprint_samples[fname][lineno][-1][1]
+        except BaseException:
+            pass
 
         # Go through the array again and add each updated current footprint.
         for item in arr:
@@ -1841,7 +1845,7 @@ class Scalene:
                     try:
                         code = compile(
                             prog_being_profiled.read(),
-                            progs[0],
+                            os.path.basename(progs[0]),
                             "exec",
                         )
                     except SyntaxError:

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1248,12 +1248,13 @@ class Scalene:
         allocs = 0.0
         last_malloc = (Filename(""), LineNumber(0), Address("0x0"))
         malloc_pointer = "0x0"
-        # was: curr = before
-        curr = 0
-        try:
-            curr = stats.per_line_footprint_samples[fname][lineno][-1][1]
-        except BaseException:
-            pass
+        curr = before
+        if False:
+            curr = 0
+            try:
+                curr = stats.per_line_footprint_samples[fname][lineno][-1][1]
+            except BaseException:
+                pass
 
         # Go through the array again and add each updated current footprint.
         for item in arr:
@@ -1276,7 +1277,6 @@ class Scalene:
                 stats.memory_aggregate_footprint[last_file][
                     last_line
                 ] += stats.memory_current_highwater_mark[last_file][last_line]
-
                 stats.memory_current_footprint[last_file][last_line] = 0
                 stats.memory_current_highwater_mark[last_file][last_line] = 0
                 continue

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1249,12 +1249,6 @@ class Scalene:
         last_malloc = (Filename(""), LineNumber(0), Address("0x0"))
         malloc_pointer = "0x0"
         curr = before
-        if False:
-            curr = 0
-            try:
-                curr = stats.per_line_footprint_samples[fname][lineno][-1][1]
-            except BaseException:
-                pass
 
         # Go through the array again and add each updated current footprint.
         for item in arr:

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1845,7 +1845,7 @@ class Scalene:
                     try:
                         code = compile(
                             prog_being_profiled.read(),
-                            os.path.basename(progs[0]),
+                            progs[0],
                             "exec",
                         )
                     except SyntaxError:


### PR DESCRIPTION
Scalene now fails gracefully when it encounters a file name that does not correspond to a real file, like `<bootstrap something>`. Working on improving the handling the name of the input file to cope with invocations of files from a different directory than the current, or names containing `./` (for example).
