### PR TITLE
Generate HTML instead of using a webserver; rationalizes metrics (--cpu, --gpu, and --memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ Commonly used options:
 ```console
 scalene your_prog.py                             # full profile (outputs to web interface)
 python3 -m scalene your_prog.py                  # equivalent alternative
+
 scalene --cli your_prog.py                       # use the command-line only (no web interface)
-scalene --cpu-only your_prog.py                  # only CPU/GPU
+
+scalene --cpu your_prog.py                       # only profile CPU
+scalene --cpu --gpu your_prog.py                 # only profile CPU and GPU
+scalene --cpu --gpu --memory your_prog.py        # profile everything (same as no options)
+
 scalene --reduced-profile your_prog.py           # only profile lines with significant usage
 scalene --profile-interval 5.0 your_prog.py      # output a new profile every five seconds
+
 scalene (Scalene options) --- your_prog.py (...) # use --- to tell Scalene to ignore options after that point
 scalene --help                                   # lists all options
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cloudpickle==1.6.0
 ipython==7.31.1
+Jinja2==3.0.3
 lxml==4.9.1
 packaging==20.9
 pyperf==2.0.0

--- a/scalene/scalene-gui/index.html.template
+++ b/scalene/scalene-gui/index.html.template
@@ -1,0 +1,2617 @@
+{# index.html.template #}
+<html>
+  <head>
+    <title>Scalene</title>
+    <link rel="icon" href="https://raw.githubusercontent.com/plasma-umass/scalene/master/scalene/scalene-gui/favicon.ico" type="image/x-icon">
+    <!-- Latest compiled and minified CSS -->
+    <script src="https://code.jquery.com/jquery-3.6.0.slim.min.js"></script>
+    
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+    <style>
+/* PrismJS 1.26.0
+https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+python&plugins=normalize-whitespace */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: black;
+	background: none;
+	text-shadow: 0 1px white;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+@media print {
+	code[class*="language-"],
+	pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #f5f2f0;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: slategray;
+}
+
+.token.punctuation {
+	color: #999;
+}
+
+.token.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+	color: #9a6e3a;
+	/* This background color was intended by the author of this theme. */
+	background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+	color: #07a;
+}
+
+.token.function,
+.token.class-name {
+	color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+	color: #e90;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+
+      
+    </style>
+    <style>
+      .table-condensed>thead>tr>th, .table-condensed>tbody>tr>th, .table-condensed>tfoot>tr>th, .table-condensed>thead>tr>td, .table-condensed>tbody>tr>td, .table-condensed>tfoot>tr>td{
+	  padding: 1px; border-spacing: 0px; border:none;
+      }
+    form label:hover, form button:hover {
+      background-color: black;
+      color: white;
+    }
+
+    form label:active, form button:active {
+      background-color: blue;
+      color: white;
+    }      
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4JXPHEBMTY"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      
+      gtag('config', 'G-4JXPHEBMTY');
+    </script>
+
+    <script>
+/* PrismJS 1.26.0
+https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+python&plugins=normalize-whitespace */
+/// <reference lib="WebWorker"/>
+
+var _self =
+  typeof window !== "undefined"
+    ? window // if in browser
+    : typeof WorkerGlobalScope !== "undefined" &&
+      self instanceof WorkerGlobalScope
+    ? self // if in worker
+    : {}; // if in node js
+
+/**
+ * Prism: Lightweight, robust, elegant syntax highlighting
+ *
+ * @license MIT <https://opensource.org/licenses/MIT>
+ * @author Lea Verou <https://lea.verou.me>
+ * @namespace
+ * @public
+ */
+var Prism = (function (_self) {
+  // Private helper vars
+  var lang = /(?:^|\s)lang(?:uage)?-([\w-]+)(?=\s|$)/i;
+  var uniqueId = 0;
+
+  // The grammar object for plaintext
+  var plainTextGrammar = {};
+
+  var _ = {
+    /**
+     * By default, Prism will attempt to highlight all code elements (by calling {@link Prism.highlightAll}) on the
+     * current page after the page finished loading. This might be a problem if e.g. you wanted to asynchronously load
+     * additional languages or plugins yourself.
+     *
+     * By setting this value to `true`, Prism will not automatically highlight all code elements on the page.
+     *
+     * You obviously have to change this value before the automatic highlighting started. To do this, you can add an
+     * empty Prism object into the global scope before loading the Prism script like this:
+     *
+     * ```js
+     * window.Prism = window.Prism || {};
+     * Prism.manual = true;
+     * // add a new <script> to load Prism's script
+     * ```
+     *
+     * @default false
+     * @type {boolean}
+     * @memberof Prism
+     * @public
+     */
+    manual: _self.Prism && _self.Prism.manual,
+    /**
+     * By default, if Prism is in a web worker, it assumes that it is in a worker it created itself, so it uses
+     * `addEventListener` to communicate with its parent instance. However, if you're using Prism manually in your
+     * own worker, you don't want it to do this.
+     *
+     * By setting this value to `true`, Prism will not add its own listeners to the worker.
+     *
+     * You obviously have to change this value before Prism executes. To do this, you can add an
+     * empty Prism object into the global scope before loading the Prism script like this:
+     *
+     * ```js
+     * window.Prism = window.Prism || {};
+     * Prism.disableWorkerMessageHandler = true;
+     * // Load Prism's script
+     * ```
+     *
+     * @default false
+     * @type {boolean}
+     * @memberof Prism
+     * @public
+     */
+    disableWorkerMessageHandler:
+      _self.Prism && _self.Prism.disableWorkerMessageHandler,
+
+    /**
+     * A namespace for utility methods.
+     *
+     * All function in this namespace that are not explicitly marked as _public_ are for __internal use only__ and may
+     * change or disappear at any time.
+     *
+     * @namespace
+     * @memberof Prism
+     */
+    util: {
+      encode: function encode(tokens) {
+        if (tokens instanceof Token) {
+          return new Token(tokens.type, encode(tokens.content), tokens.alias);
+        } else if (Array.isArray(tokens)) {
+          return tokens.map(encode);
+        } else {
+          return tokens
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/\u00a0/g, " ");
+        }
+      },
+
+      /**
+       * Returns the name of the type of the given value.
+       *
+       * @param {any} o
+       * @returns {string}
+       * @example
+       * type(null)      === 'Null'
+       * type(undefined) === 'Undefined'
+       * type(123)       === 'Number'
+       * type('foo')     === 'String'
+       * type(true)      === 'Boolean'
+       * type([1, 2])    === 'Array'
+       * type({})        === 'Object'
+       * type(String)    === 'Function'
+       * type(/abc+/)    === 'RegExp'
+       */
+      type: function (o) {
+        return Object.prototype.toString.call(o).slice(8, -1);
+      },
+
+      /**
+       * Returns a unique number for the given object. Later calls will still return the same number.
+       *
+       * @param {Object} obj
+       * @returns {number}
+       */
+      objId: function (obj) {
+        if (!obj["__id"]) {
+          Object.defineProperty(obj, "__id", { value: ++uniqueId });
+        }
+        return obj["__id"];
+      },
+
+      /**
+       * Creates a deep clone of the given object.
+       *
+       * The main intended use of this function is to clone language definitions.
+       *
+       * @param {T} o
+       * @param {Record<number, any>} [visited]
+       * @returns {T}
+       * @template T
+       */
+      clone: function deepClone(o, visited) {
+        visited = visited || {};
+
+        var clone;
+        var id;
+        switch (_.util.type(o)) {
+          case "Object":
+            id = _.util.objId(o);
+            if (visited[id]) {
+              return visited[id];
+            }
+            clone = /** @type {Record<string, any>} */ ({});
+            visited[id] = clone;
+
+            for (var key in o) {
+              if (o.hasOwnProperty(key)) {
+                clone[key] = deepClone(o[key], visited);
+              }
+            }
+
+            return /** @type {any} */ (clone);
+
+          case "Array":
+            id = _.util.objId(o);
+            if (visited[id]) {
+              return visited[id];
+            }
+            clone = [];
+            visited[id] = clone;
+
+            /** @type {Array} */ (/** @type {any} */ (o)).forEach(function (
+              v,
+              i
+            ) {
+              clone[i] = deepClone(v, visited);
+            });
+
+            return /** @type {any} */ (clone);
+
+          default:
+            return o;
+        }
+      },
+
+      /**
+       * Returns the Prism language of the given element set by a `language-xxxx` or `lang-xxxx` class.
+       *
+       * If no language is set for the element or the element is `null` or `undefined`, `none` will be returned.
+       *
+       * @param {Element} element
+       * @returns {string}
+       */
+      getLanguage: function (element) {
+        while (element) {
+          var m = lang.exec(element.className);
+          if (m) {
+            return m[1].toLowerCase();
+          }
+          element = element.parentElement;
+        }
+        return "none";
+      },
+
+      /**
+       * Sets the Prism `language-xxxx` class of the given element.
+       *
+       * @param {Element} element
+       * @param {string} language
+       * @returns {void}
+       */
+      setLanguage: function (element, language) {
+        // remove all `language-xxxx` classes
+        // (this might leave behind a leading space)
+        element.className = element.className.replace(RegExp(lang, "gi"), "");
+
+        // add the new `language-xxxx` class
+        // (using `classList` will automatically clean up spaces for us)
+        element.classList.add("language-" + language);
+      },
+
+      /**
+       * Returns the script element that is currently executing.
+       *
+       * This does __not__ work for line script element.
+       *
+       * @returns {HTMLScriptElement | null}
+       */
+      currentScript: function () {
+        if (typeof document === "undefined") {
+          return null;
+        }
+        if (
+          "currentScript" in document &&
+          1 < 2 /* hack to trip TS' flow analysis */
+        ) {
+          return /** @type {any} */ (document.currentScript);
+        }
+
+        // IE11 workaround
+        // we'll get the src of the current script by parsing IE11's error stack trace
+        // this will not work for inline scripts
+
+        try {
+          throw new Error();
+        } catch (err) {
+          // Get file src url from stack. Specifically works with the format of stack traces in IE.
+          // A stack will look like this:
+          //
+          // Error
+          //    at _.util.currentScript (http://localhost/components/prism-core.js:119:5)
+          //    at Global code (http://localhost/components/prism-core.js:606:1)
+
+          var src = (/at [^(\r\n]*\((.*):[^:]+:[^:]+\)$/i.exec(err.stack) ||
+            [])[1];
+          if (src) {
+            var scripts = document.getElementsByTagName("script");
+            for (var i in scripts) {
+              if (scripts[i].src == src) {
+                return scripts[i];
+              }
+            }
+          }
+          return null;
+        }
+      },
+
+      /**
+       * Returns whether a given class is active for `element`.
+       *
+       * The class can be activated if `element` or one of its ancestors has the given class and it can be deactivated
+       * if `element` or one of its ancestors has the negated version of the given class. The _negated version_ of the
+       * given class is just the given class with a `no-` prefix.
+       *
+       * Whether the class is active is determined by the closest ancestor of `element` (where `element` itself is
+       * closest ancestor) that has the given class or the negated version of it. If neither `element` nor any of its
+       * ancestors have the given class or the negated version of it, then the default activation will be returned.
+       *
+       * In the paradoxical situation where the closest ancestor contains __both__ the given class and the negated
+       * version of it, the class is considered active.
+       *
+       * @param {Element} element
+       * @param {string} className
+       * @param {boolean} [defaultActivation=false]
+       * @returns {boolean}
+       */
+      isActive: function (element, className, defaultActivation) {
+        var no = "no-" + className;
+
+        while (element) {
+          var classList = element.classList;
+          if (classList.contains(className)) {
+            return true;
+          }
+          if (classList.contains(no)) {
+            return false;
+          }
+          element = element.parentElement;
+        }
+        return !!defaultActivation;
+      },
+    },
+
+    /**
+     * This namespace contains all currently loaded languages and the some helper functions to create and modify languages.
+     *
+     * @namespace
+     * @memberof Prism
+     * @public
+     */
+    languages: {
+      /**
+       * The grammar for plain, unformatted text.
+       */
+      plain: plainTextGrammar,
+      plaintext: plainTextGrammar,
+      text: plainTextGrammar,
+      txt: plainTextGrammar,
+
+      /**
+       * Creates a deep copy of the language with the given id and appends the given tokens.
+       *
+       * If a token in `redef` also appears in the copied language, then the existing token in the copied language
+       * will be overwritten at its original position.
+       *
+       * ## Best practices
+       *
+       * Since the position of overwriting tokens (token in `redef` that overwrite tokens in the copied language)
+       * doesn't matter, they can technically be in any order. However, this can be confusing to others that trying to
+       * understand the language definition because, normally, the order of tokens matters in Prism grammars.
+       *
+       * Therefore, it is encouraged to order overwriting tokens according to the positions of the overwritten tokens.
+       * Furthermore, all non-overwriting tokens should be placed after the overwriting ones.
+       *
+       * @param {string} id The id of the language to extend. This has to be a key in `Prism.languages`.
+       * @param {Grammar} redef The new tokens to append.
+       * @returns {Grammar} The new language created.
+       * @public
+       * @example
+       * Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
+       *     // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
+       *     // at its original position
+       *     'comment': { ... },
+       *     // CSS doesn't have a 'color' token, so this token will be appended
+       *     'color': /\b(?:red|green|blue)\b/
+       * });
+       */
+      extend: function (id, redef) {
+        var lang = _.util.clone(_.languages[id]);
+
+        for (var key in redef) {
+          lang[key] = redef[key];
+        }
+
+        return lang;
+      },
+
+      /**
+       * Inserts tokens _before_ another token in a language definition or any other grammar.
+       *
+       * ## Usage
+       *
+       * This helper method makes it easy to modify existing languages. For example, the CSS language definition
+       * not only defines CSS highlighting for CSS documents, but also needs to define highlighting for CSS embedded
+       * in HTML through `<style>` elements. To do this, it needs to modify `Prism.languages.markup` and add the
+       * appropriate tokens. However, `Prism.languages.markup` is a regular JavaScript object literal, so if you do
+       * this:
+       *
+       * ```js
+       * Prism.languages.markup.style = {
+       *     // token
+       * };
+       * ```
+       *
+       * then the `style` token will be added (and processed) at the end. `insertBefore` allows you to insert tokens
+       * before existing tokens. For the CSS example above, you would use it like this:
+       *
+       * ```js
+       * Prism.languages.insertBefore('markup', 'cdata', {
+       *     'style': {
+       *         // token
+       *     }
+       * });
+       * ```
+       *
+       * ## Special cases
+       *
+       * If the grammars of `inside` and `insert` have tokens with the same name, the tokens in `inside`'s grammar
+       * will be ignored.
+       *
+       * This behavior can be used to insert tokens after `before`:
+       *
+       * ```js
+       * Prism.languages.insertBefore('markup', 'comment', {
+       *     'comment': Prism.languages.markup.comment,
+       *     // tokens after 'comment'
+       * });
+       * ```
+       *
+       * ## Limitations
+       *
+       * The main problem `insertBefore` has to solve is iteration order. Since ES2015, the iteration order for object
+       * properties is guaranteed to be the insertion order (except for integer keys) but some browsers behave
+       * differently when keys are deleted and re-inserted. So `insertBefore` can't be implemented by temporarily
+       * deleting properties which is necessary to insert at arbitrary positions.
+       *
+       * To solve this problem, `insertBefore` doesn't actually insert the given tokens into the target object.
+       * Instead, it will create a new object and replace all references to the target object with the new one. This
+       * can be done without temporarily deleting properties, so the iteration order is well-defined.
+       *
+       * However, only references that can be reached from `Prism.languages` or `insert` will be replaced. I.e. if
+       * you hold the target object in a variable, then the value of the variable will not change.
+       *
+       * ```js
+       * var oldMarkup = Prism.languages.markup;
+       * var newMarkup = Prism.languages.insertBefore('markup', 'comment', { ... });
+       *
+       * assert(oldMarkup !== Prism.languages.markup);
+       * assert(newMarkup === Prism.languages.markup);
+       * ```
+       *
+       * @param {string} inside The property of `root` (e.g. a language id in `Prism.languages`) that contains the
+       * object to be modified.
+       * @param {string} before The key to insert before.
+       * @param {Grammar} insert An object containing the key-value pairs to be inserted.
+       * @param {Object<string, any>} [root] The object containing `inside`, i.e. the object that contains the
+       * object to be modified.
+       *
+       * Defaults to `Prism.languages`.
+       * @returns {Grammar} The new grammar object.
+       * @public
+       */
+      insertBefore: function (inside, before, insert, root) {
+        root = root || /** @type {any} */ (_.languages);
+        var grammar = root[inside];
+        /** @type {Grammar} */
+        var ret = {};
+
+        for (var token in grammar) {
+          if (grammar.hasOwnProperty(token)) {
+            if (token == before) {
+              for (var newToken in insert) {
+                if (insert.hasOwnProperty(newToken)) {
+                  ret[newToken] = insert[newToken];
+                }
+              }
+            }
+
+            // Do not insert token which also occur in insert. See #1525
+            if (!insert.hasOwnProperty(token)) {
+              ret[token] = grammar[token];
+            }
+          }
+        }
+
+        var old = root[inside];
+        root[inside] = ret;
+
+        // Update references in other language definitions
+        _.languages.DFS(_.languages, function (key, value) {
+          if (value === old && key != inside) {
+            this[key] = ret;
+          }
+        });
+
+        return ret;
+      },
+
+      // Traverse a language definition with Depth First Search
+      DFS: function DFS(o, callback, type, visited) {
+        visited = visited || {};
+
+        var objId = _.util.objId;
+
+        for (var i in o) {
+          if (o.hasOwnProperty(i)) {
+            callback.call(o, i, o[i], type || i);
+
+            var property = o[i];
+            var propertyType = _.util.type(property);
+
+            if (propertyType === "Object" && !visited[objId(property)]) {
+              visited[objId(property)] = true;
+              DFS(property, callback, null, visited);
+            } else if (propertyType === "Array" && !visited[objId(property)]) {
+              visited[objId(property)] = true;
+              DFS(property, callback, i, visited);
+            }
+          }
+        }
+      },
+    },
+
+    plugins: {},
+
+    /**
+     * This is the most high-level function in Prism’s API.
+     * It fetches all the elements that have a `.language-xxxx` class and then calls {@link Prism.highlightElement} on
+     * each one of them.
+     *
+     * This is equivalent to `Prism.highlightAllUnder(document, async, callback)`.
+     *
+     * @param {boolean} [async=false] Same as in {@link Prism.highlightAllUnder}.
+     * @param {HighlightCallback} [callback] Same as in {@link Prism.highlightAllUnder}.
+     * @memberof Prism
+     * @public
+     */
+    highlightAll: function (async, callback) {
+      _.highlightAllUnder(document, async, callback);
+    },
+
+    /**
+     * Fetches all the descendants of `container` that have a `.language-xxxx` class and then calls
+     * {@link Prism.highlightElement} on each one of them.
+     *
+     * The following hooks will be run:
+     * 1. `before-highlightall`
+     * 2. `before-all-elements-highlight`
+     * 3. All hooks of {@link Prism.highlightElement} for each element.
+     *
+     * @param {ParentNode} container The root element, whose descendants that have a `.language-xxxx` class will be highlighted.
+     * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers.
+     * @param {HighlightCallback} [callback] An optional callback to be invoked on each element after its highlighting is done.
+     * @memberof Prism
+     * @public
+     */
+    highlightAllUnder: function (container, async, callback) {
+      var env = {
+        callback: callback,
+        container: container,
+        selector:
+          'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code',
+      };
+
+      _.hooks.run("before-highlightall", env);
+
+      env.elements = Array.prototype.slice.apply(
+        env.container.querySelectorAll(env.selector)
+      );
+
+      _.hooks.run("before-all-elements-highlight", env);
+
+      for (var i = 0, element; (element = env.elements[i++]); ) {
+        _.highlightElement(element, async === true, env.callback);
+      }
+    },
+
+    /**
+     * Highlights the code inside a single element.
+     *
+     * The following hooks will be run:
+     * 1. `before-sanity-check`
+     * 2. `before-highlight`
+     * 3. All hooks of {@link Prism.highlight}. These hooks will be run by an asynchronous worker if `async` is `true`.
+     * 4. `before-insert`
+     * 5. `after-highlight`
+     * 6. `complete`
+     *
+     * Some the above hooks will be skipped if the element doesn't contain any text or there is no grammar loaded for
+     * the element's language.
+     *
+     * @param {Element} element The element containing the code.
+     * It must have a class of `language-xxxx` to be processed, where `xxxx` is a valid language identifier.
+     * @param {boolean} [async=false] Whether the element is to be highlighted asynchronously using Web Workers
+     * to improve performance and avoid blocking the UI when highlighting very large chunks of code. This option is
+     * [disabled by default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
+     *
+     * Note: All language definitions required to highlight the code must be included in the main `prism.js` file for
+     * asynchronous highlighting to work. You can build your own bundle on the
+     * [Download page](https://prismjs.com/download.html).
+     * @param {HighlightCallback} [callback] An optional callback to be invoked after the highlighting is done.
+     * Mostly useful when `async` is `true`, since in that case, the highlighting is done asynchronously.
+     * @memberof Prism
+     * @public
+     */
+    highlightElement: function (element, async, callback) {
+      // Find language
+      var language = _.util.getLanguage(element);
+      var grammar = _.languages[language];
+
+      // Set language on the element, if not present
+      _.util.setLanguage(element, language);
+
+      // Set language on the parent, for styling
+      var parent = element.parentElement;
+      if (parent && parent.nodeName.toLowerCase() === "pre") {
+        _.util.setLanguage(parent, language);
+      }
+
+      var code = element.textContent;
+
+      var env = {
+        element: element,
+        language: language,
+        grammar: grammar,
+        code: code,
+      };
+
+      function insertHighlightedCode(highlightedCode) {
+        env.highlightedCode = highlightedCode;
+
+        _.hooks.run("before-insert", env);
+
+        env.element.innerHTML = env.highlightedCode;
+
+        _.hooks.run("after-highlight", env);
+        _.hooks.run("complete", env);
+        callback && callback.call(env.element);
+      }
+
+      _.hooks.run("before-sanity-check", env);
+
+      // plugins may change/add the parent/element
+      parent = env.element.parentElement;
+      if (
+        parent &&
+        parent.nodeName.toLowerCase() === "pre" &&
+        !parent.hasAttribute("tabindex")
+      ) {
+        parent.setAttribute("tabindex", "0");
+      }
+
+      if (!env.code) {
+        _.hooks.run("complete", env);
+        callback && callback.call(env.element);
+        return;
+      }
+
+      _.hooks.run("before-highlight", env);
+
+      if (!env.grammar) {
+        insertHighlightedCode(_.util.encode(env.code));
+        return;
+      }
+
+      if (async && _self.Worker) {
+        var worker = new Worker(_.filename);
+
+        worker.onmessage = function (evt) {
+          insertHighlightedCode(evt.data);
+        };
+
+        worker.postMessage(
+          JSON.stringify({
+            language: env.language,
+            code: env.code,
+            immediateClose: true,
+          })
+        );
+      } else {
+        insertHighlightedCode(_.highlight(env.code, env.grammar, env.language));
+      }
+    },
+
+    /**
+     * Low-level function, only use if you know what you’re doing. It accepts a string of text as input
+     * and the language definitions to use, and returns a string with the HTML produced.
+     *
+     * The following hooks will be run:
+     * 1. `before-tokenize`
+     * 2. `after-tokenize`
+     * 3. `wrap`: On each {@link Token}.
+     *
+     * @param {string} text A string with the code to be highlighted.
+     * @param {Grammar} grammar An object containing the tokens to use.
+     *
+     * Usually a language definition like `Prism.languages.markup`.
+     * @param {string} language The name of the language definition passed to `grammar`.
+     * @returns {string} The highlighted HTML.
+     * @memberof Prism
+     * @public
+     * @example
+     * Prism.highlight('var foo = true;', Prism.languages.javascript, 'javascript');
+     */
+    highlight: function (text, grammar, language) {
+      var env = {
+        code: text,
+        grammar: grammar,
+        language: language,
+      };
+      _.hooks.run("before-tokenize", env);
+      env.tokens = _.tokenize(env.code, env.grammar);
+      _.hooks.run("after-tokenize", env);
+      return Token.stringify(_.util.encode(env.tokens), env.language);
+    },
+
+    /**
+     * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
+     * and the language definitions to use, and returns an array with the tokenized code.
+     *
+     * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
+     *
+     * This method could be useful in other contexts as well, as a very crude parser.
+     *
+     * @param {string} text A string with the code to be highlighted.
+     * @param {Grammar} grammar An object containing the tokens to use.
+     *
+     * Usually a language definition like `Prism.languages.markup`.
+     * @returns {TokenStream} An array of strings and tokens, a token stream.
+     * @memberof Prism
+     * @public
+     * @example
+     * let code = `var foo = 0;`;
+     * let tokens = Prism.tokenize(code, Prism.languages.javascript);
+     * tokens.forEach(token => {
+     *     if (token instanceof Prism.Token && token.type === 'number') {
+     *         console.log(`Found numeric literal: ${token.content}`);
+     *     }
+     * });
+     */
+    tokenize: function (text, grammar) {
+      var rest = grammar.rest;
+      if (rest) {
+        for (var token in rest) {
+          grammar[token] = rest[token];
+        }
+
+        delete grammar.rest;
+      }
+
+      var tokenList = new LinkedList();
+      addAfter(tokenList, tokenList.head, text);
+
+      matchGrammar(text, tokenList, grammar, tokenList.head, 0);
+
+      return toArray(tokenList);
+    },
+
+    /**
+     * @namespace
+     * @memberof Prism
+     * @public
+     */
+    hooks: {
+      all: {},
+
+      /**
+       * Adds the given callback to the list of callbacks for the given hook.
+       *
+       * The callback will be invoked when the hook it is registered for is run.
+       * Hooks are usually directly run by a highlight function but you can also run hooks yourself.
+       *
+       * One callback function can be registered to multiple hooks and the same hook multiple times.
+       *
+       * @param {string} name The name of the hook.
+       * @param {HookCallback} callback The callback function which is given environment variables.
+       * @public
+       */
+      add: function (name, callback) {
+        var hooks = _.hooks.all;
+
+        hooks[name] = hooks[name] || [];
+
+        hooks[name].push(callback);
+      },
+
+      /**
+       * Runs a hook invoking all registered callbacks with the given environment variables.
+       *
+       * Callbacks will be invoked synchronously and in the order in which they were registered.
+       *
+       * @param {string} name The name of the hook.
+       * @param {Object<string, any>} env The environment variables of the hook passed to all callbacks registered.
+       * @public
+       */
+      run: function (name, env) {
+        var callbacks = _.hooks.all[name];
+
+        if (!callbacks || !callbacks.length) {
+          return;
+        }
+
+        for (var i = 0, callback; (callback = callbacks[i++]); ) {
+          callback(env);
+        }
+      },
+    },
+
+    Token: Token,
+  };
+  _self.Prism = _;
+
+  // Typescript note:
+  // The following can be used to import the Token type in JSDoc:
+  //
+  //   @typedef {InstanceType<import("./prism-core")["Token"]>} Token
+
+  /**
+   * Creates a new token.
+   *
+   * @param {string} type See {@link Token#type type}
+   * @param {string | TokenStream} content See {@link Token#content content}
+   * @param {string|string[]} [alias] The alias(es) of the token.
+   * @param {string} [matchedStr=""] A copy of the full string this token was created from.
+   * @class
+   * @global
+   * @public
+   */
+  function Token(type, content, alias, matchedStr) {
+    /**
+     * The type of the token.
+     *
+     * This is usually the key of a pattern in a {@link Grammar}.
+     *
+     * @type {string}
+     * @see GrammarToken
+     * @public
+     */
+    this.type = type;
+    /**
+     * The strings or tokens contained by this token.
+     *
+     * This will be a token stream if the pattern matched also defined an `inside` grammar.
+     *
+     * @type {string | TokenStream}
+     * @public
+     */
+    this.content = content;
+    /**
+     * The alias(es) of the token.
+     *
+     * @type {string|string[]}
+     * @see GrammarToken
+     * @public
+     */
+    this.alias = alias;
+    // Copy of the full string this token was created from
+    this.length = (matchedStr || "").length | 0;
+  }
+
+  /**
+   * A token stream is an array of strings and {@link Token Token} objects.
+   *
+   * Token streams have to fulfill a few properties that are assumed by most functions (mostly internal ones) that process
+   * them.
+   *
+   * 1. No adjacent strings.
+   * 2. No empty strings.
+   *
+   *    The only exception here is the token stream that only contains the empty string and nothing else.
+   *
+   * @typedef {Array<string | Token>} TokenStream
+   * @global
+   * @public
+   */
+
+  /**
+   * Converts the given token or token stream to an HTML representation.
+   *
+   * The following hooks will be run:
+   * 1. `wrap`: On each {@link Token}.
+   *
+   * @param {string | Token | TokenStream} o The token or token stream to be converted.
+   * @param {string} language The name of current language.
+   * @returns {string} The HTML representation of the token or token stream.
+   * @memberof Token
+   * @static
+   */
+  Token.stringify = function stringify(o, language) {
+    if (typeof o == "string") {
+      return o;
+    }
+    if (Array.isArray(o)) {
+      var s = "";
+      o.forEach(function (e) {
+        s += stringify(e, language);
+      });
+      return s;
+    }
+
+    var env = {
+      type: o.type,
+      content: stringify(o.content, language),
+      tag: "span",
+      classes: ["token", o.type],
+      attributes: {},
+      language: language,
+    };
+
+    var aliases = o.alias;
+    if (aliases) {
+      if (Array.isArray(aliases)) {
+        Array.prototype.push.apply(env.classes, aliases);
+      } else {
+        env.classes.push(aliases);
+      }
+    }
+
+    _.hooks.run("wrap", env);
+
+    var attributes = "";
+    for (var name in env.attributes) {
+      attributes +=
+        " " +
+        name +
+        '="' +
+        (env.attributes[name] || "").replace(/"/g, "&quot;") +
+        '"';
+    }
+
+    return (
+      "<" +
+      env.tag +
+      ' class="' +
+      env.classes.join(" ") +
+      '"' +
+      attributes +
+      ">" +
+      env.content +
+      "</" +
+      env.tag +
+      ">"
+    );
+  };
+
+  /**
+   * @param {RegExp} pattern
+   * @param {number} pos
+   * @param {string} text
+   * @param {boolean} lookbehind
+   * @returns {RegExpExecArray | null}
+   */
+  function matchPattern(pattern, pos, text, lookbehind) {
+    pattern.lastIndex = pos;
+    var match = pattern.exec(text);
+    if (match && lookbehind && match[1]) {
+      // change the match to remove the text matched by the Prism lookbehind group
+      var lookbehindLength = match[1].length;
+      match.index += lookbehindLength;
+      match[0] = match[0].slice(lookbehindLength);
+    }
+    return match;
+  }
+
+  /**
+   * @param {string} text
+   * @param {LinkedList<string | Token>} tokenList
+   * @param {any} grammar
+   * @param {LinkedListNode<string | Token>} startNode
+   * @param {number} startPos
+   * @param {RematchOptions} [rematch]
+   * @returns {void}
+   * @private
+   *
+   * @typedef RematchOptions
+   * @property {string} cause
+   * @property {number} reach
+   */
+  function matchGrammar(
+    text,
+    tokenList,
+    grammar,
+    startNode,
+    startPos,
+    rematch
+  ) {
+    for (var token in grammar) {
+      if (!grammar.hasOwnProperty(token) || !grammar[token]) {
+        continue;
+      }
+
+      var patterns = grammar[token];
+      patterns = Array.isArray(patterns) ? patterns : [patterns];
+
+      for (var j = 0; j < patterns.length; ++j) {
+        if (rematch && rematch.cause == token + "," + j) {
+          return;
+        }
+
+        var patternObj = patterns[j];
+        var inside = patternObj.inside;
+        var lookbehind = !!patternObj.lookbehind;
+        var greedy = !!patternObj.greedy;
+        var alias = patternObj.alias;
+
+        if (greedy && !patternObj.pattern.global) {
+          // Without the global flag, lastIndex won't work
+          var flags = patternObj.pattern.toString().match(/[imsuy]*$/)[0];
+          patternObj.pattern = RegExp(patternObj.pattern.source, flags + "g");
+        }
+
+        /** @type {RegExp} */
+        var pattern = patternObj.pattern || patternObj;
+
+        for (
+          // iterate the token list and keep track of the current token/string position
+          var currentNode = startNode.next, pos = startPos;
+          currentNode !== tokenList.tail;
+          pos += currentNode.value.length, currentNode = currentNode.next
+        ) {
+          if (rematch && pos >= rematch.reach) {
+            break;
+          }
+
+          var str = currentNode.value;
+
+          if (tokenList.length > text.length) {
+            // Something went terribly wrong, ABORT, ABORT!
+            return;
+          }
+
+          if (str instanceof Token) {
+            continue;
+          }
+
+          var removeCount = 1; // this is the to parameter of removeBetween
+          var match;
+
+          if (greedy) {
+            match = matchPattern(pattern, pos, text, lookbehind);
+            if (!match || match.index >= text.length) {
+              break;
+            }
+
+            var from = match.index;
+            var to = match.index + match[0].length;
+            var p = pos;
+
+            // find the node that contains the match
+            p += currentNode.value.length;
+            while (from >= p) {
+              currentNode = currentNode.next;
+              p += currentNode.value.length;
+            }
+            // adjust pos (and p)
+            p -= currentNode.value.length;
+            pos = p;
+
+            // the current node is a Token, then the match starts inside another Token, which is invalid
+            if (currentNode.value instanceof Token) {
+              continue;
+            }
+
+            // find the last node which is affected by this match
+            for (
+              var k = currentNode;
+              k !== tokenList.tail && (p < to || typeof k.value === "string");
+              k = k.next
+            ) {
+              removeCount++;
+              p += k.value.length;
+            }
+            removeCount--;
+
+            // replace with the new match
+            str = text.slice(pos, p);
+            match.index -= pos;
+          } else {
+            match = matchPattern(pattern, 0, str, lookbehind);
+            if (!match) {
+              continue;
+            }
+          }
+
+          // eslint-disable-next-line no-redeclare
+          var from = match.index;
+          var matchStr = match[0];
+          var before = str.slice(0, from);
+          var after = str.slice(from + matchStr.length);
+
+          var reach = pos + str.length;
+          if (rematch && reach > rematch.reach) {
+            rematch.reach = reach;
+          }
+
+          var removeFrom = currentNode.prev;
+
+          if (before) {
+            removeFrom = addAfter(tokenList, removeFrom, before);
+            pos += before.length;
+          }
+
+          removeRange(tokenList, removeFrom, removeCount);
+
+          var wrapped = new Token(
+            token,
+            inside ? _.tokenize(matchStr, inside) : matchStr,
+            alias,
+            matchStr
+          );
+          currentNode = addAfter(tokenList, removeFrom, wrapped);
+
+          if (after) {
+            addAfter(tokenList, currentNode, after);
+          }
+
+          if (removeCount > 1) {
+            // at least one Token object was removed, so we have to do some rematching
+            // this can only happen if the current pattern is greedy
+
+            /** @type {RematchOptions} */
+            var nestedRematch = {
+              cause: token + "," + j,
+              reach: reach,
+            };
+            matchGrammar(
+              text,
+              tokenList,
+              grammar,
+              currentNode.prev,
+              pos,
+              nestedRematch
+            );
+
+            // the reach might have been extended because of the rematching
+            if (rematch && nestedRematch.reach > rematch.reach) {
+              rematch.reach = nestedRematch.reach;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @typedef LinkedListNode
+   * @property {T} value
+   * @property {LinkedListNode<T> | null} prev The previous node.
+   * @property {LinkedListNode<T> | null} next The next node.
+   * @template T
+   * @private
+   */
+
+  /**
+   * @template T
+   * @private
+   */
+  function LinkedList() {
+    /** @type {LinkedListNode<T>} */
+    var head = { value: null, prev: null, next: null };
+    /** @type {LinkedListNode<T>} */
+    var tail = { value: null, prev: head, next: null };
+    head.next = tail;
+
+    /** @type {LinkedListNode<T>} */
+    this.head = head;
+    /** @type {LinkedListNode<T>} */
+    this.tail = tail;
+    this.length = 0;
+  }
+
+  /**
+   * Adds a new node with the given value to the list.
+   *
+   * @param {LinkedList<T>} list
+   * @param {LinkedListNode<T>} node
+   * @param {T} value
+   * @returns {LinkedListNode<T>} The added node.
+   * @template T
+   */
+  function addAfter(list, node, value) {
+    // assumes that node != list.tail && values.length >= 0
+    var next = node.next;
+
+    var newNode = { value: value, prev: node, next: next };
+    node.next = newNode;
+    next.prev = newNode;
+    list.length++;
+
+    return newNode;
+  }
+  /**
+   * Removes `count` nodes after the given node. The given node will not be removed.
+   *
+   * @param {LinkedList<T>} list
+   * @param {LinkedListNode<T>} node
+   * @param {number} count
+   * @template T
+   */
+  function removeRange(list, node, count) {
+    var next = node.next;
+    for (var i = 0; i < count && next !== list.tail; i++) {
+      next = next.next;
+    }
+    node.next = next;
+    next.prev = node;
+    list.length -= i;
+  }
+  /**
+   * @param {LinkedList<T>} list
+   * @returns {T[]}
+   * @template T
+   */
+  function toArray(list) {
+    var array = [];
+    var node = list.head.next;
+    while (node !== list.tail) {
+      array.push(node.value);
+      node = node.next;
+    }
+    return array;
+  }
+
+  if (!_self.document) {
+    if (!_self.addEventListener) {
+      // in Node.js
+      return _;
+    }
+
+    if (!_.disableWorkerMessageHandler) {
+      // In worker
+      _self.addEventListener(
+        "message",
+        function (evt) {
+          var message = JSON.parse(evt.data);
+          var lang = message.language;
+          var code = message.code;
+          var immediateClose = message.immediateClose;
+
+          _self.postMessage(_.highlight(code, _.languages[lang], lang));
+          if (immediateClose) {
+            _self.close();
+          }
+        },
+        false
+      );
+    }
+
+    return _;
+  }
+
+  // Get current script and highlight
+  var script = _.util.currentScript();
+
+  if (script) {
+    _.filename = script.src;
+
+    if (script.hasAttribute("data-manual")) {
+      _.manual = true;
+    }
+  }
+
+  function highlightAutomaticallyCallback() {
+    if (!_.manual) {
+      _.highlightAll();
+    }
+  }
+
+  if (!_.manual) {
+    // If the document state is "loading", then we'll use DOMContentLoaded.
+    // If the document state is "interactive" and the prism.js script is deferred, then we'll also use the
+    // DOMContentLoaded event because there might be some plugins or languages which have also been deferred and they
+    // might take longer one animation frame to execute which can create a race condition where only some plugins have
+    // been loaded when Prism.highlightAll() is executed, depending on how fast resources are loaded.
+    // See https://github.com/PrismJS/prism/issues/2102
+    var readyState = document.readyState;
+    if (
+      readyState === "loading" ||
+      (readyState === "interactive" && script && script.defer)
+    ) {
+      document.addEventListener(
+        "DOMContentLoaded",
+        highlightAutomaticallyCallback
+      );
+    } else {
+      if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(highlightAutomaticallyCallback);
+      } else {
+        window.setTimeout(highlightAutomaticallyCallback, 16);
+      }
+    }
+  }
+
+  return _;
+})(_self);
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = Prism;
+}
+
+// hack for components to work correctly in node.js
+if (typeof global !== "undefined") {
+  global.Prism = Prism;
+}
+
+// some additional documentation/types
+
+/**
+ * The expansion of a simple `RegExp` literal to support additional properties.
+ *
+ * @typedef GrammarToken
+ * @property {RegExp} pattern The regular expression of the token.
+ * @property {boolean} [lookbehind=false] If `true`, then the first capturing group of `pattern` will (effectively)
+ * behave as a lookbehind group meaning that the captured text will not be part of the matched text of the new token.
+ * @property {boolean} [greedy=false] Whether the token is greedy.
+ * @property {string|string[]} [alias] An optional alias or list of aliases.
+ * @property {Grammar} [inside] The nested grammar of this token.
+ *
+ * The `inside` grammar will be used to tokenize the text value of each token of this kind.
+ *
+ * This can be used to make nested and even recursive language definitions.
+ *
+ * Note: This can cause infinite recursion. Be careful when you embed different languages or even the same language into
+ * each another.
+ * @global
+ * @public
+ */
+
+/**
+ * @typedef Grammar
+ * @type {Object<string, RegExp | GrammarToken | Array<RegExp | GrammarToken>>}
+ * @property {Grammar} [rest] An optional grammar object that will be appended to this grammar.
+ * @global
+ * @public
+ */
+
+/**
+ * A function which will invoked after an element was successfully highlighted.
+ *
+ * @callback HighlightCallback
+ * @param {Element} element The element successfully highlighted.
+ * @returns {void}
+ * @global
+ * @public
+ */
+
+/**
+ * @callback HookCallback
+ * @param {Object<string, any>} env The environment variables of the hook.
+ * @returns {void}
+ * @global
+ * @public
+ */
+Prism.languages.markup = {
+  comment: {
+    pattern: /<!--(?:(?!<!--)[\s\S])*?-->/,
+    greedy: true,
+  },
+  prolog: {
+    pattern: /<\?[\s\S]+?\?>/,
+    greedy: true,
+  },
+  doctype: {
+    // https://www.w3.org/TR/xml/#NT-doctypedecl
+    pattern:
+      /<!DOCTYPE(?:[^>"'[\]]|"[^"]*"|'[^']*')+(?:\[(?:[^<"'\]]|"[^"]*"|'[^']*'|<(?!!--)|<!--(?:[^-]|-(?!->))*-->)*\]\s*)?>/i,
+    greedy: true,
+    inside: {
+      "internal-subset": {
+        pattern: /(^[^\[]*\[)[\s\S]+(?=\]>$)/,
+        lookbehind: true,
+        greedy: true,
+        inside: null, // see below
+      },
+      string: {
+        pattern: /"[^"]*"|'[^']*'/,
+        greedy: true,
+      },
+      punctuation: /^<!|>$|[[\]]/,
+      "doctype-tag": /^DOCTYPE/i,
+      name: /[^\s<>'"]+/,
+    },
+  },
+  cdata: {
+    pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+    greedy: true,
+  },
+  tag: {
+    pattern:
+      /<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/,
+    greedy: true,
+    inside: {
+      tag: {
+        pattern: /^<\/?[^\s>\/]+/,
+        inside: {
+          punctuation: /^<\/?/,
+          namespace: /^[^\s>\/:]+:/,
+        },
+      },
+      "special-attr": [],
+      "attr-value": {
+        pattern: /=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+)/,
+        inside: {
+          punctuation: [
+            {
+              pattern: /^=/,
+              alias: "attr-equals",
+            },
+            /"|'/,
+          ],
+        },
+      },
+      punctuation: /\/?>/,
+      "attr-name": {
+        pattern: /[^\s>\/]+/,
+        inside: {
+          namespace: /^[^\s>\/:]+:/,
+        },
+      },
+    },
+  },
+  entity: [
+    {
+      pattern: /&[\da-z]{1,8};/i,
+      alias: "named-entity",
+    },
+    /&#x?[\da-f]{1,8};/i,
+  ],
+};
+
+Prism.languages.markup["tag"].inside["attr-value"].inside["entity"] =
+  Prism.languages.markup["entity"];
+Prism.languages.markup["doctype"].inside["internal-subset"].inside =
+  Prism.languages.markup;
+
+// Plugin to make entity title show the real entity, idea by Roman Komarov
+Prism.hooks.add("wrap", function (env) {
+  if (env.type === "entity") {
+    env.attributes["title"] = env.content.replace(/&amp;/, "&");
+  }
+});
+
+Object.defineProperty(Prism.languages.markup.tag, "addInlined", {
+  /**
+   * Adds an inlined language to markup.
+   *
+   * An example of an inlined language is CSS with `<style>` tags.
+   *
+   * @param {string} tagName The name of the tag that contains the inlined language. This name will be treated as
+   * case insensitive.
+   * @param {string} lang The language key.
+   * @example
+   * addInlined('style', 'css');
+   */
+  value: function addInlined(tagName, lang) {
+    var includedCdataInside = {};
+    includedCdataInside["language-" + lang] = {
+      pattern: /(^<!\[CDATA\[)[\s\S]+?(?=\]\]>$)/i,
+      lookbehind: true,
+      inside: Prism.languages[lang],
+    };
+    includedCdataInside["cdata"] = /^<!\[CDATA\[|\]\]>$/i;
+
+    var inside = {
+      "included-cdata": {
+        pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+        inside: includedCdataInside,
+      },
+    };
+    inside["language-" + lang] = {
+      pattern: /[\s\S]+/,
+      inside: Prism.languages[lang],
+    };
+
+    var def = {};
+    def[tagName] = {
+      pattern: RegExp(
+        /(<__[^>]*>)(?:<!\[CDATA\[(?:[^\]]|\](?!\]>))*\]\]>|(?!<!\[CDATA\[)[\s\S])*?(?=<\/__>)/.source.replace(
+          /__/g,
+          function () {
+            return tagName;
+          }
+        ),
+        "i"
+      ),
+      lookbehind: true,
+      greedy: true,
+      inside: inside,
+    };
+
+    Prism.languages.insertBefore("markup", "cdata", def);
+  },
+});
+Object.defineProperty(Prism.languages.markup.tag, "addAttribute", {
+  /**
+   * Adds an pattern to highlight languages embedded in HTML attributes.
+   *
+   * An example of an inlined language is CSS with `style` attributes.
+   *
+   * @param {string} attrName The name of the tag that contains the inlined language. This name will be treated as
+   * case insensitive.
+   * @param {string} lang The language key.
+   * @example
+   * addAttribute('style', 'css');
+   */
+  value: function (attrName, lang) {
+    Prism.languages.markup.tag.inside["special-attr"].push({
+      pattern: RegExp(
+        /(^|["'\s])/.source +
+          "(?:" +
+          attrName +
+          ")" +
+          /\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))/.source,
+        "i"
+      ),
+      lookbehind: true,
+      inside: {
+        "attr-name": /^[^\s=]+/,
+        "attr-value": {
+          pattern: /=[\s\S]+/,
+          inside: {
+            value: {
+              pattern: /(^=\s*(["']|(?!["'])))\S[\s\S]*(?=\2$)/,
+              lookbehind: true,
+              alias: [lang, "language-" + lang],
+              inside: Prism.languages[lang],
+            },
+            punctuation: [
+              {
+                pattern: /^=/,
+                alias: "attr-equals",
+              },
+              /"|'/,
+            ],
+          },
+        },
+      },
+    });
+  },
+});
+
+Prism.languages.html = Prism.languages.markup;
+Prism.languages.mathml = Prism.languages.markup;
+Prism.languages.svg = Prism.languages.markup;
+
+Prism.languages.xml = Prism.languages.extend("markup", {});
+Prism.languages.ssml = Prism.languages.xml;
+Prism.languages.atom = Prism.languages.xml;
+Prism.languages.rss = Prism.languages.xml;
+
+(function (Prism) {
+  var string =
+    /(?:"(?:\\(?:\r\n|[\s\S])|[^"\\\r\n])*"|'(?:\\(?:\r\n|[\s\S])|[^'\\\r\n])*')/;
+
+  Prism.languages.css = {
+    comment: /\/\*[\s\S]*?\*\//,
+    atrule: {
+      pattern: /@[\w-](?:[^;{\s]|\s+(?![\s{]))*(?:;|(?=\s*\{))/,
+      inside: {
+        rule: /^@[\w-]+/,
+        "selector-function-argument": {
+          pattern:
+            /(\bselector\s*\(\s*(?![\s)]))(?:[^()\s]|\s+(?![\s)])|\((?:[^()]|\([^()]*\))*\))+(?=\s*\))/,
+          lookbehind: true,
+          alias: "selector",
+        },
+        keyword: {
+          pattern: /(^|[^\w-])(?:and|not|only|or)(?![\w-])/,
+          lookbehind: true,
+        },
+        // See rest below
+      },
+    },
+    url: {
+      // https://drafts.csswg.org/css-values-3/#urls
+      pattern: RegExp(
+        "\\burl\\((?:" +
+          string.source +
+          "|" +
+          /(?:[^\\\r\n()"']|\\[\s\S])*/.source +
+          ")\\)",
+        "i"
+      ),
+      greedy: true,
+      inside: {
+        function: /^url/i,
+        punctuation: /^\(|\)$/,
+        string: {
+          pattern: RegExp("^" + string.source + "$"),
+          alias: "url",
+        },
+      },
+    },
+    selector: {
+      pattern: RegExp(
+        "(^|[{}\\s])[^{}\\s](?:[^{};\"'\\s]|\\s+(?![\\s{])|" +
+          string.source +
+          ")*(?=\\s*\\{)"
+      ),
+      lookbehind: true,
+    },
+    string: {
+      pattern: string,
+      greedy: true,
+    },
+    property: {
+      pattern:
+        /(^|[^-\w\xA0-\uFFFF])(?!\s)[-_a-z\xA0-\uFFFF](?:(?!\s)[-\w\xA0-\uFFFF])*(?=\s*:)/i,
+      lookbehind: true,
+    },
+    important: /!important\b/i,
+    function: {
+      pattern: /(^|[^-a-z0-9])[-a-z0-9]+(?=\()/i,
+      lookbehind: true,
+    },
+    punctuation: /[(){};:,]/,
+  };
+
+  Prism.languages.css["atrule"].inside.rest = Prism.languages.css;
+
+  var markup = Prism.languages.markup;
+  if (markup) {
+    markup.tag.addInlined("style", "css");
+    markup.tag.addAttribute("style", "css");
+  }
+})(Prism);
+
+Prism.languages.clike = {
+  comment: [
+    {
+      pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,
+      lookbehind: true,
+      greedy: true,
+    },
+    {
+      pattern: /(^|[^\\:])\/\/.*/,
+      lookbehind: true,
+      greedy: true,
+    },
+  ],
+  string: {
+    pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+    greedy: true,
+  },
+  "class-name": {
+    pattern:
+      /(\b(?:class|extends|implements|instanceof|interface|new|trait)\s+|\bcatch\s+\()[\w.\\]+/i,
+    lookbehind: true,
+    inside: {
+      punctuation: /[.\\]/,
+    },
+  },
+  keyword:
+    /\b(?:break|catch|continue|do|else|finally|for|function|if|in|instanceof|new|null|return|throw|try|while)\b/,
+  boolean: /\b(?:false|true)\b/,
+  function: /\b\w+(?=\()/,
+  number: /\b0x[\da-f]+\b|(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:e[+-]?\d+)?/i,
+  operator: /[<>]=?|[!=]=?=?|--?|\+\+?|&&?|\|\|?|[?*/~^%]/,
+  punctuation: /[{}[\];(),.:]/,
+};
+
+Prism.languages.javascript = Prism.languages.extend("clike", {
+  "class-name": [
+    Prism.languages.clike["class-name"],
+    {
+      pattern:
+        /(^|[^$\w\xA0-\uFFFF])(?!\s)[_$A-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\.(?:constructor|prototype))/,
+      lookbehind: true,
+    },
+  ],
+  keyword: [
+    {
+      pattern: /((?:^|\})\s*)catch\b/,
+      lookbehind: true,
+    },
+    {
+      pattern:
+        /(^|[^.]|\.\.\.\s*)\b(?:as|assert(?=\s*\{)|async(?=\s*(?:function\b|\(|[$\w\xA0-\uFFFF]|$))|await|break|case|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally(?=\s*(?:\{|$))|for|from(?=\s*(?:['"]|$))|function|(?:get|set)(?=\s*(?:[#\[$\w\xA0-\uFFFF]|$))|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)\b/,
+      lookbehind: true,
+    },
+  ],
+  // Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
+  function:
+    /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,
+  number: {
+    pattern: RegExp(
+      /(^|[^\w$])/.source +
+        "(?:" +
+        // constant
+        (/NaN|Infinity/.source +
+          "|" +
+          // binary integer
+          /0[bB][01]+(?:_[01]+)*n?/.source +
+          "|" +
+          // octal integer
+          /0[oO][0-7]+(?:_[0-7]+)*n?/.source +
+          "|" +
+          // hexadecimal integer
+          /0[xX][\dA-Fa-f]+(?:_[\dA-Fa-f]+)*n?/.source +
+          "|" +
+          // decimal bigint
+          /\d+(?:_\d+)*n/.source +
+          "|" +
+          // decimal number (integer or float) but no bigint
+          /(?:\d+(?:_\d+)*(?:\.(?:\d+(?:_\d+)*)?)?|\.\d+(?:_\d+)*)(?:[Ee][+-]?\d+(?:_\d+)*)?/
+            .source) +
+        ")" +
+        /(?![\w$])/.source
+    ),
+    lookbehind: true,
+  },
+  operator:
+    /--|\+\+|\*\*=?|=>|&&=?|\|\|=?|[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?\?=?|\?\.?|[~:]/,
+});
+
+Prism.languages.javascript["class-name"][0].pattern =
+  /(\b(?:class|extends|implements|instanceof|interface|new)\s+)[\w.\\]+/;
+
+Prism.languages.insertBefore("javascript", "keyword", {
+  regex: {
+    // eslint-disable-next-line regexp/no-dupe-characters-character-class
+    pattern:
+      /((?:^|[^$\w\xA0-\uFFFF."'\])\s]|\b(?:return|yield))\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*\]|\\.|[^/\\\[\r\n])+\/[dgimyus]{0,7}(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+    lookbehind: true,
+    greedy: true,
+    inside: {
+      "regex-source": {
+        pattern: /^(\/)[\s\S]+(?=\/[a-z]*$)/,
+        lookbehind: true,
+        alias: "language-regex",
+        inside: Prism.languages.regex,
+      },
+      "regex-delimiter": /^\/|\/$/,
+      "regex-flags": /^[a-z]+$/,
+    },
+  },
+  // This must be declared before keyword because we use "function" inside the look-forward
+  "function-variable": {
+    pattern:
+      /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*[=:]\s*(?:async\s*)?(?:\bfunction\b|(?:\((?:[^()]|\([^()]*\))*\)|(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*)\s*=>))/,
+    alias: "function",
+  },
+  parameter: [
+    {
+      pattern:
+        /(function(?:\s+(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*)?\s*\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\))/,
+      lookbehind: true,
+      inside: Prism.languages.javascript,
+    },
+    {
+      pattern:
+        /(^|[^$\w\xA0-\uFFFF])(?!\s)[_$a-z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*=>)/i,
+      lookbehind: true,
+      inside: Prism.languages.javascript,
+    },
+    {
+      pattern:
+        /(\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\)\s*=>)/,
+      lookbehind: true,
+      inside: Prism.languages.javascript,
+    },
+    {
+      pattern:
+        /((?:\b|\s|^)(?!(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)(?![$\w\xA0-\uFFFF]))(?:(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*\s*)\(\s*|\]\s*\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\)\s*\{)/,
+      lookbehind: true,
+      inside: Prism.languages.javascript,
+    },
+  ],
+  constant: /\b[A-Z](?:[A-Z_]|\dx?)*\b/,
+});
+
+Prism.languages.insertBefore("javascript", "string", {
+  hashbang: {
+    pattern: /^#!.*/,
+    greedy: true,
+    alias: "comment",
+  },
+  "template-string": {
+    pattern:
+      /`(?:\\[\s\S]|\$\{(?:[^{}]|\{(?:[^{}]|\{[^}]*\})*\})+\}|(?!\$\{)[^\\`])*`/,
+    greedy: true,
+    inside: {
+      "template-punctuation": {
+        pattern: /^`|`$/,
+        alias: "string",
+      },
+      interpolation: {
+        pattern:
+          /((?:^|[^\\])(?:\\{2})*)\$\{(?:[^{}]|\{(?:[^{}]|\{[^}]*\})*\})+\}/,
+        lookbehind: true,
+        inside: {
+          "interpolation-punctuation": {
+            pattern: /^\$\{|\}$/,
+            alias: "punctuation",
+          },
+          rest: Prism.languages.javascript,
+        },
+      },
+      string: /[\s\S]+/,
+    },
+  },
+  "string-property": {
+    pattern:
+      /((?:^|[,{])[ \t]*)(["'])(?:\\(?:\r\n|[\s\S])|(?!\2)[^\\\r\n])*\2(?=\s*:)/m,
+    lookbehind: true,
+    greedy: true,
+    alias: "property",
+  },
+});
+
+Prism.languages.insertBefore("javascript", "operator", {
+  "literal-property": {
+    pattern:
+      /((?:^|[,{])[ \t]*)(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*:)/m,
+    lookbehind: true,
+    alias: "property",
+  },
+});
+
+if (Prism.languages.markup) {
+  Prism.languages.markup.tag.addInlined("script", "javascript");
+
+  // add attribute support for all DOM events.
+  // https://developer.mozilla.org/en-US/docs/Web/Events#Standard_events
+  Prism.languages.markup.tag.addAttribute(
+    /on(?:abort|blur|change|click|composition(?:end|start|update)|dblclick|error|focus(?:in|out)?|key(?:down|up)|load|mouse(?:down|enter|leave|move|out|over|up)|reset|resize|scroll|select|slotchange|submit|unload|wheel)/
+      .source,
+    "javascript"
+  );
+}
+
+Prism.languages.js = Prism.languages.javascript;
+
+Prism.languages.python = {
+  comment: {
+    pattern: /(^|[^\\])#.*/,
+    lookbehind: true,
+    greedy: true,
+  },
+  "string-interpolation": {
+    pattern:
+      /(?:f|fr|rf)(?:("""|''')[\s\S]*?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
+    greedy: true,
+    inside: {
+      interpolation: {
+        // "{" <expression> <optional "!s", "!r", or "!a"> <optional ":" format specifier> "}"
+        pattern:
+          /((?:^|[^{])(?:\{\{)*)\{(?!\{)(?:[^{}]|\{(?!\{)(?:[^{}]|\{(?!\{)(?:[^{}])+\})+\})+\}/,
+        lookbehind: true,
+        inside: {
+          "format-spec": {
+            pattern: /(:)[^:(){}]+(?=\}$)/,
+            lookbehind: true,
+          },
+          "conversion-option": {
+            pattern: /![sra](?=[:}]$)/,
+            alias: "punctuation",
+          },
+          rest: null,
+        },
+      },
+      string: /[\s\S]+/,
+    },
+  },
+  "triple-quoted-string": {
+    pattern: /(?:[rub]|br|rb)?("""|''')[\s\S]*?\1/i,
+    greedy: true,
+    alias: "string",
+  },
+  string: {
+    pattern: /(?:[rub]|br|rb)?("|')(?:\\.|(?!\1)[^\\\r\n])*\1/i,
+    greedy: true,
+  },
+  function: {
+    pattern: /((?:^|\s)def[ \t]+)[a-zA-Z_]\w*(?=\s*\()/g,
+    lookbehind: true,
+  },
+  "class-name": {
+    pattern: /(\bclass\s+)\w+/i,
+    lookbehind: true,
+  },
+  decorator: {
+    pattern: /(^[\t ]*)@\w+(?:\.\w+)*/m,
+    lookbehind: true,
+    alias: ["annotation", "punctuation"],
+    inside: {
+      punctuation: /\./,
+    },
+  },
+  keyword:
+    /\b(?:_(?=\s*:)|and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|print|raise|return|try|while|with|yield)\b/,
+  builtin:
+    /\b(?:__import__|abs|all|any|apply|ascii|basestring|bin|bool|buffer|bytearray|bytes|callable|chr|classmethod|cmp|coerce|compile|complex|delattr|dict|dir|divmod|enumerate|eval|execfile|file|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|intern|isinstance|issubclass|iter|len|list|locals|long|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|raw_input|reduce|reload|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|unichr|unicode|vars|xrange|zip)\b/,
+  boolean: /\b(?:False|None|True)\b/,
+  number:
+    /\b0(?:b(?:_?[01])+|o(?:_?[0-7])+|x(?:_?[a-f0-9])+)\b|(?:\b\d+(?:_\d+)*(?:\.(?:\d+(?:_\d+)*)?)?|\B\.\d+(?:_\d+)*)(?:e[+-]?\d+(?:_\d+)*)?j?(?!\w)/i,
+  operator: /[-+%=]=?|!=|:=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]/,
+  punctuation: /[{}[\];(),.:]/,
+};
+
+Prism.languages.python["string-interpolation"].inside[
+  "interpolation"
+].inside.rest = Prism.languages.python;
+
+Prism.languages.py = Prism.languages.python;
+
+(function () {
+  if (typeof Prism === "undefined") {
+    return;
+  }
+
+  var assign =
+    Object.assign ||
+    function (obj1, obj2) {
+      for (var name in obj2) {
+        if (obj2.hasOwnProperty(name)) {
+          obj1[name] = obj2[name];
+        }
+      }
+      return obj1;
+    };
+
+  function NormalizeWhitespace(defaults) {
+    this.defaults = assign({}, defaults);
+  }
+
+  function toCamelCase(value) {
+    return value.replace(/-(\w)/g, function (match, firstChar) {
+      return firstChar.toUpperCase();
+    });
+  }
+
+  function tabLen(str) {
+    var res = 0;
+    for (var i = 0; i < str.length; ++i) {
+      if (str.charCodeAt(i) == "\t".charCodeAt(0)) {
+        res += 3;
+      }
+    }
+    return str.length + res;
+  }
+
+  NormalizeWhitespace.prototype = {
+    setDefaults: function (defaults) {
+      this.defaults = assign(this.defaults, defaults);
+    },
+    normalize: function (input, settings) {
+      settings = assign(this.defaults, settings);
+
+      for (var name in settings) {
+        var methodName = toCamelCase(name);
+        if (
+          name !== "normalize" &&
+          methodName !== "setDefaults" &&
+          settings[name] &&
+          this[methodName]
+        ) {
+          input = this[methodName].call(this, input, settings[name]);
+        }
+      }
+
+      return input;
+    },
+
+    /*
+     * Normalization methods
+     */
+    leftTrim: function (input) {
+      return input.replace(/^\s+/, "");
+    },
+    rightTrim: function (input) {
+      return input.replace(/\s+$/, "");
+    },
+    tabsToSpaces: function (input, spaces) {
+      spaces = spaces | 0 || 4;
+      return input.replace(/\t/g, new Array(++spaces).join(" "));
+    },
+    spacesToTabs: function (input, spaces) {
+      spaces = spaces | 0 || 4;
+      return input.replace(RegExp(" {" + spaces + "}", "g"), "\t");
+    },
+    removeTrailing: function (input) {
+      return input.replace(/\s*?$/gm, "");
+    },
+    // Support for deprecated plugin remove-initial-line-feed
+    removeInitialLineFeed: function (input) {
+      return input.replace(/^(?:\r?\n|\r)/, "");
+    },
+    removeIndent: function (input) {
+      var indents = input.match(/^[^\S\n\r]*(?=\S)/gm);
+
+      if (!indents || !indents[0].length) {
+        return input;
+      }
+
+      indents.sort(function (a, b) {
+        return a.length - b.length;
+      });
+
+      if (!indents[0].length) {
+        return input;
+      }
+
+      return input.replace(RegExp("^" + indents[0], "gm"), "");
+    },
+    indent: function (input, tabs) {
+      return input.replace(
+        /^[^\S\n\r]*(?=\S)/gm,
+        new Array(++tabs).join("\t") + "$&"
+      );
+    },
+    breakLines: function (input, characters) {
+      characters = characters === true ? 80 : characters | 0 || 80;
+
+      var lines = input.split("\n");
+      for (var i = 0; i < lines.length; ++i) {
+        if (tabLen(lines[i]) <= characters) {
+          continue;
+        }
+
+        var line = lines[i].split(/(\s+)/g);
+        var len = 0;
+
+        for (var j = 0; j < line.length; ++j) {
+          var tl = tabLen(line[j]);
+          len += tl;
+          if (len > characters) {
+            line[j] = "\n" + line[j];
+            len = tl;
+          }
+        }
+        lines[i] = line.join("");
+      }
+      return lines.join("\n");
+    },
+  };
+
+  // Support node modules
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = NormalizeWhitespace;
+  }
+
+  Prism.plugins.NormalizeWhitespace = new NormalizeWhitespace({
+    "remove-trailing": true,
+    "remove-indent": false,
+    "left-trim": false,
+    "right-trim": true,
+    /*'break-lines': 80,
+		'indent': 2,
+		'remove-initial-line-feed': false,
+		'tabs-to-spaces': 4,
+		'spaces-to-tabs': 4*/
+  });
+
+  Prism.hooks.add("before-sanity-check", function (env) {
+    var Normalizer = Prism.plugins.NormalizeWhitespace;
+
+    // Check settings
+    if (env.settings && env.settings["whitespace-normalization"] === false) {
+      return;
+    }
+
+    // Check classes
+    if (!Prism.util.isActive(env.element, "whitespace-normalization", true)) {
+      return;
+    }
+
+    // Simple mode if there is no env.element
+    if ((!env.element || !env.element.parentNode) && env.code) {
+      env.code = Normalizer.normalize(env.code, env.settings);
+      return;
+    }
+
+    // Normal mode
+    var pre = env.element.parentNode;
+    if (!env.code || !pre || pre.nodeName.toLowerCase() !== "pre") {
+      return;
+    }
+
+    var children = pre.childNodes;
+    var before = "";
+    var after = "";
+    var codeFound = false;
+
+    // Move surrounding whitespace from the <pre> tag into the <code> tag
+    for (var i = 0; i < children.length; ++i) {
+      var node = children[i];
+
+      if (node == env.element) {
+        codeFound = true;
+      } else if (node.nodeName === "#text") {
+        if (codeFound) {
+          after += node.nodeValue;
+        } else {
+          before += node.nodeValue;
+        }
+
+        pre.removeChild(node);
+        --i;
+      }
+    }
+
+    if (!env.element.children.length || !Prism.plugins.KeepMarkup) {
+      env.code = before + env.code + after;
+      env.code = Normalizer.normalize(env.code, env.settings);
+    } else {
+      // Preserve markup for keep-markup plugin
+      var html = before + env.element.innerHTML + after;
+      env.element.innerHTML = Normalizer.normalize(html, env.settings);
+      env.code = env.element.textContent;
+    }
+  });
+})();
+      
+</script>
+		       <script>
+(function () {
+  function Tablesort(el, options) {
+    if (!(this instanceof Tablesort)) return new Tablesort(el, options);
+
+    if (!el || el.tagName !== "TABLE") {
+      throw new Error("Element must be a table");
+    }
+    this.init(el, options || {});
+  }
+
+  var sortOptions = [];
+
+  var createEvent = function (name) {
+    var evt;
+
+    if (!window.CustomEvent || typeof window.CustomEvent !== "function") {
+      evt = document.createEvent("CustomEvent");
+      evt.initCustomEvent(name, false, false, undefined);
+    } else {
+      evt = new CustomEvent(name);
+    }
+
+    return evt;
+  };
+
+  var getInnerText = function (el, options) {
+    return (
+      el.getAttribute(options.sortAttribute || "data-sort") ||
+      el.textContent ||
+      el.innerText ||
+      ""
+    );
+  };
+
+  // Default sort method if no better sort method is found
+  var caseInsensitiveSort = function (a, b) {
+    a = a.trim().toLowerCase();
+    b = b.trim().toLowerCase();
+
+    if (a === b) return 0;
+    if (a < b) return 1;
+
+    return -1;
+  };
+
+  var getCellByKey = function (cells, key) {
+    return [].slice.call(cells).find(function (cell) {
+      return cell.getAttribute("data-sort-column-key") === key;
+    });
+  };
+
+  // Stable sort function
+  // If two elements are equal under the original sort function,
+  // then there relative order is reversed
+  var stabilize = function (sort, antiStabilize) {
+    return function (a, b) {
+      var unstableResult = sort(a.td, b.td);
+
+      if (unstableResult === 0) {
+        if (antiStabilize) return b.index - a.index;
+        return a.index - b.index;
+      }
+
+      return unstableResult;
+    };
+  };
+
+  Tablesort.extend = function (name, pattern, sort) {
+    if (typeof pattern !== "function" || typeof sort !== "function") {
+      throw new Error("Pattern and sort must be a function");
+    }
+
+    sortOptions.push({
+      name: name,
+      pattern: pattern,
+      sort: sort,
+    });
+  };
+
+  Tablesort.prototype = {
+    init: function (el, options) {
+      var that = this,
+        firstRow,
+        defaultSort,
+        i,
+        cell;
+
+      that.table = el;
+      that.thead = false;
+      that.options = options;
+
+      if (el.rows && el.rows.length > 0) {
+        if (el.tHead && el.tHead.rows.length > 0) {
+          for (i = 0; i < el.tHead.rows.length; i++) {
+            if (el.tHead.rows[i].getAttribute("data-sort-method") === "thead") {
+              firstRow = el.tHead.rows[i];
+              break;
+            }
+          }
+          if (!firstRow) {
+            firstRow = el.tHead.rows[el.tHead.rows.length - 1];
+          }
+          that.thead = true;
+        } else {
+          firstRow = el.rows[0];
+        }
+      }
+
+      if (!firstRow) return;
+
+      var onClick = function () {
+        if (that.current && that.current !== this) {
+          that.current.removeAttribute("aria-sort");
+        }
+
+        that.current = this;
+        that.sortTable(this);
+      };
+
+      // Assume first row is the header and attach a click handler to each.
+      for (i = 0; i < firstRow.cells.length; i++) {
+        cell = firstRow.cells[i];
+        cell.setAttribute("role", "columnheader");
+        if (cell.getAttribute("data-sort-method") !== "none") {
+          cell.tabindex = 0;
+          cell.addEventListener("click", onClick, false);
+
+          if (cell.getAttribute("data-sort-default") !== null) {
+            defaultSort = cell;
+          }
+        }
+      }
+
+      if (defaultSort) {
+        that.current = defaultSort;
+        that.sortTable(defaultSort);
+      }
+    },
+
+    sortTable: function (header, update) {
+      var that = this,
+        columnKey = header.getAttribute("data-sort-column-key"),
+        column = header.cellIndex,
+        sortFunction = caseInsensitiveSort,
+        item = "",
+        items = [],
+        i = that.thead ? 0 : 1,
+        sortMethod = header.getAttribute("data-sort-method"),
+        sortOrder = header.getAttribute("aria-sort");
+
+      that.table.dispatchEvent(createEvent("beforeSort"));
+
+      // If updating an existing sort, direction should remain unchanged.
+      if (!update) {
+        if (sortOrder === "ascending") {
+          sortOrder = "descending";
+        } else if (sortOrder === "descending") {
+          sortOrder = "ascending";
+        } else {
+          sortOrder = that.options.descending ? "descending" : "ascending";
+        }
+
+        header.setAttribute("aria-sort", sortOrder);
+      }
+
+      if (that.table.rows.length < 2) return;
+
+      // If we force a sort method, it is not necessary to check rows
+      if (!sortMethod) {
+        var cell;
+        while (items.length < 3 && i < that.table.tBodies[0].rows.length) {
+          if (columnKey) {
+            cell = getCellByKey(that.table.tBodies[0].rows[i].cells, columnKey);
+          } else {
+            cell = that.table.tBodies[0].rows[i].cells[column];
+          }
+
+          // Treat missing cells as empty cells
+          item = cell ? getInnerText(cell, that.options) : "";
+
+          item = item.trim();
+
+          if (item.length > 0) {
+            items.push(item);
+          }
+
+          i++;
+        }
+
+        if (!items) return;
+      }
+
+      for (i = 0; i < sortOptions.length; i++) {
+        item = sortOptions[i];
+
+        if (sortMethod) {
+          if (item.name === sortMethod) {
+            sortFunction = item.sort;
+            break;
+          }
+        } else if (items.every(item.pattern)) {
+          sortFunction = item.sort;
+          break;
+        }
+      }
+
+      that.col = column;
+
+      for (i = 0; i < that.table.tBodies.length; i++) {
+        var newRows = [],
+          noSorts = {},
+          j,
+          totalRows = 0,
+          noSortsSoFar = 0;
+
+        if (that.table.tBodies[i].rows.length < 2) continue;
+
+        for (j = 0; j < that.table.tBodies[i].rows.length; j++) {
+          var cell;
+
+          item = that.table.tBodies[i].rows[j];
+          if (item.getAttribute("data-sort-method") === "none") {
+            // keep no-sorts in separate list to be able to insert
+            // them back at their original position later
+            noSorts[totalRows] = item;
+          } else {
+            if (columnKey) {
+              cell = getCellByKey(item.cells, columnKey);
+            } else {
+              cell = item.cells[that.col];
+            }
+            // Save the index for stable sorting
+            newRows.push({
+              tr: item,
+              td: cell ? getInnerText(cell, that.options) : "",
+              index: totalRows,
+            });
+          }
+          totalRows++;
+        }
+        // Before we append should we reverse the new array or not?
+        // If we reverse, the sort needs to be `anti-stable` so that
+        // the double negatives cancel out
+        if (sortOrder === "descending") {
+          newRows.sort(stabilize(sortFunction, true));
+        } else {
+          newRows.sort(stabilize(sortFunction, false));
+          newRows.reverse();
+        }
+
+        // append rows that already exist rather than creating new ones
+        for (j = 0; j < totalRows; j++) {
+          if (noSorts[j]) {
+            // We have a no-sort row for this position, insert it here.
+            item = noSorts[j];
+            noSortsSoFar++;
+          } else {
+            item = newRows[j - noSortsSoFar].tr;
+          }
+
+          // appendChild(x) moves x if already present somewhere else in the DOM
+          that.table.tBodies[i].appendChild(item);
+        }
+      }
+
+      that.table.dispatchEvent(createEvent("afterSort"));
+    },
+
+    refresh: function () {
+      if (this.current !== undefined) {
+        this.sortTable(this.current, true);
+      }
+    },
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = Tablesort;
+  } else {
+    window.Tablesort = Tablesort;
+  }
+})();
+</script>
+		       <script>
+(function () {
+  var cleanNumber = function (i) {
+      return i.replace(/[^\-?0-9.]/g, "");
+    },
+    compareNumber = function (a, b) {
+      a = parseFloat(a);
+      b = parseFloat(b);
+
+      a = isNaN(a) ? 0 : a;
+      b = isNaN(b) ? 0 : b;
+
+      return a - b;
+    };
+
+  Tablesort.extend(
+    "number",
+    function (item) {
+      return (
+        item.match(/^[-+]?[£\x24Û¢´€]?\d+\s*([,\.]\d{0,2})/) || // Prefixed currency
+        item.match(/^[-+]?\d+\s*([,\.]\d{0,2})?[£\x24Û¢´€]/) || // Suffixed currency
+        item.match(/^[-+]?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/)
+      ); // Number
+    },
+    function (a, b) {
+      a = cleanNumber(a);
+      b = cleanNumber(b);
+
+      return compareNumber(b, a);
+    }
+  );
+})();
+			 
+		       </script>
+    <script>
+      const profile = {{ profile }}
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/vega@5.21.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.2.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.20.0"></script>
+  </head>
+  <body>
+    <a href="https://github.com/plasma-umass/scalene">
+      <p class="text-center">
+	<img src="https://github.com/plasma-umass/scalene/raw/master/scalene/scalene-gui/scalene-image.png" height="100">
+      </p>
+    </a>
+    <p />
+    <form id="jsonFile" name="jsonFile" enctype="multipart/form-data" method="post">
+      <div class="form-group">
+	<div class="d-flex justify-content-center">
+	  <label for='fileinput' style="padding: 5px 5px; border-radius: 5px; border: 1px ridge black; font-size: 0.8rem; height: auto;">Select a profile (.json)</label>
+	  <input style="height: 0; width: 10; opacity:0" type='file' id='fileinput' accept='.json' onchange="loadFile();">
+	  <!-- <label for='demoinput' style="padding: 5px 5px; border-radius: 5px; border: 1px ridge black; font-size: 0.8rem; height: auto;">demo</label>
+	  <input style="height: 0; width: 0; opacity:0" type='button' id='demoinput' accept='.json' onclick="loadDemo();">
+-->
+	</div>
+      </div>
+    </form>
+    <div id="profile">
+    </div>
+    <script type="text/javascript">
+      {{ gui_js }}
+      window.addEventListener("load", () => load(profile));
+      //load(profile);
+    </script>
+  </body>
+</html>

--- a/scalene/scalene_arguments.py
+++ b/scalene/scalene_arguments.py
@@ -1,12 +1,15 @@
 import argparse
-
+import platform
+import sys
 
 class ScaleneArguments(argparse.Namespace):
     """Encapsulates all arguments and default values for Scalene."""
 
     def __init__(self) -> None:
         super().__init__()
-        self.cpu_only = False
+        self.cpu = True
+        self.gpu = platform.system() != "Darwin"
+        self.memory = sys.platform != "win32"
         self.cpu_percent_threshold = 1
         # mean seconds between interrupts for CPU sampling.
         self.cpu_sampling_rate = 0.01

--- a/scalene/scalene_magics.py
+++ b/scalene/scalene_magics.py
@@ -29,7 +29,7 @@ with contextlib.suppress(Exception):
             filename = f"ipython-input-{len(IPython.get_ipython().history_manager.input_hist_raw)-1}-profile"
             with open(filename, "w+") as tmpfile:
                 tmpfile.write(code)
-            args.cpu_only = True  # full Scalene is not yet working, force to use CPU-only mode
+            args.memory = False  # full Scalene is not yet working, force to not profile memory
             scalene_profiler.Scalene.set_initialized()
             scalene_profiler.Scalene.run_profiler(
                 args, [filename], is_jupyter=True

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -178,6 +178,14 @@ for the process ID that Scalene reports. For example:
             help="profile CPU time (default: [blue] True [/blue])",
         )
         parser.add_argument(
+            "--cpu-only",
+            dest="cpu",
+            action="store_const",
+            const=True,
+            default=None,
+            help="profile CPU time ([red] deprecated - use --cpu [/red])",
+        )
+        parser.add_argument(
             "--gpu",
             dest="gpu",
             action="store_const",

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -183,7 +183,7 @@ for the process ID that Scalene reports. For example:
             action="store_const",
             const=True,
             default=None,
-            help="profile CPU time ([red] deprecated - use --cpu [/red])",
+            help="profile CPU time ([red]deprecated: use --cpu [/red])",
         )
         parser.add_argument(
             "--gpu",

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -8,6 +8,7 @@ from typing import Any, List, NoReturn, Optional, Tuple
 from scalene.scalene_arguments import ScaleneArguments
 from scalene.scalene_version import scalene_version, scalene_date
 
+scalene_gui_url = "https://plasma-umass.org/scalene-gui/"
 
 class RichArgParser(argparse.ArgumentParser):
     def __init__(self, *args: Any, **kwargs: Any):
@@ -137,7 +138,7 @@ for the process ID that Scalene reports. For example:
             action="store_const",
             const=True,
             default=defaults.web,
-            help="writes 'profile.json' and opens the web UI (http://plasma-umass.org/scalene-gui/)",
+            help="writes 'profile.json' and opens the profile in the local web UI",
         )
         parser.add_argument(
             "--port",
@@ -145,6 +146,14 @@ for the process ID that Scalene reports. For example:
             type=int,
             default=defaults.port,
             help=f"binds the web UI server to this port (default: {defaults.port})",
+        )
+        parser.add_argument(
+            "--viewer",
+            dest="viewer",
+            action="store_const",
+            const=True,
+            default=False,
+            help=f"only opens the web UI ({scalene_gui_url})",
         )
         parser.add_argument(
             "--reduced-profile",
@@ -312,6 +321,15 @@ for the process ID that Scalene reports. For example:
         args, left = parser.parse_known_args()
         left += args.unused_args
         import re
+
+        # Launch the UI if `--viewer` was selected.
+        if args.viewer:
+            import webbrowser
+            if webbrowser.get() and type(webbrowser.get()).__name__ != "GenericBrowser":
+                webbrowser.open(scalene_gui_url)
+            else:
+                print(f"Scalene: could not open {scalene_gui_url}.")
+            sys.exit(0)
 
         # If any of the individual profiling metrics were specified,
         # disable the unspecified ones (set as None).

--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -23,7 +23,7 @@ class ScalenePreload:
         # Set environment variables for loading the Scalene dynamic library,
         # which interposes on allocation and copying functions.
         if sys.platform == "darwin":
-            if not args.cpu_only:
+            if args.memory:
                 env["DYLD_INSERT_LIBRARIES"] = os.path.join(
                     scalene.__path__[0].replace(" ", r"\ "), "libscalene.dylib"
                 )
@@ -34,7 +34,7 @@ class ScalenePreload:
             env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
 
         elif sys.platform == "linux":
-            if not args.cpu_only:
+            if args.memory:
                 # Prepend the Scalene library to the LD_PRELOAD list, if any
                 new_ld_preload = os.path.join(
                     scalene.__path__[0].replace(" ", r"\ "), "libscalene.so"
@@ -49,8 +49,8 @@ class ScalenePreload:
                     del env["PYTHONMALLOC"]
 
         elif sys.platform == "win32":
-            # Force CPU only on Windows for now.
-            args.cpu_only = True
+            # Force no memory profiling on Windows for now.
+            args.memory = False
 
         return env
 
@@ -64,11 +64,11 @@ class ScalenePreload:
 
         # First, check that we are on a supported platform.
         # (x86-64 and ARM only for now.)
-        if not args.cpu_only and (
+        if args.memory and (
             platform.machine() not in ["x86_64", "AMD64", "arm64", "aarch64"]
             or struct.calcsize("P") != 8
         ):
-            args.cpu_only = True
+            args.memory = False
             print(
                 "Scalene warning: currently only 64-bit x86-64 and ARM platforms are supported for memory and copy profiling."
             )

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -19,7 +19,6 @@ import builtins
 import contextlib
 import functools
 import gc
-import http.server
 import inspect
 import json
 import math
@@ -129,8 +128,7 @@ class Scalene:
     __last_profiled_invalidated = False
     __gui_dir = "scalene-gui"
     __profile_filename = "profile.json"
-    __localhost = "http://localhost"
-    __profiler_html = "profiler.html"
+    __profiler_html = "profile.html"
     __error_message = "Error in program being profiled"
     BYTES_PER_MB = 1024 * 1024
 
@@ -1618,7 +1616,7 @@ class Scalene:
             os.remove(f"/tmp/scalene-malloc-lock{os.getpid()}")
 
     @staticmethod
-    def generate_html(profile_fname="profile.json", output_fname="profile.html"):
+    def generate_html(profile_fname, output_fname):
         """Apply a template to generate a single HTML payload containing the current profile."""
 
         import os
@@ -1697,9 +1695,9 @@ class Scalene:
             ):
                 return exit_status
 
-            Scalene.generate_html(profile_fname="profile.json", output_fname="profile.html")
+            Scalene.generate_html(profile_fname=Scalene.__profile_filename, output_fname=Scalene.__profiler_html)
             webbrowser.open(
-                f"file:///{os.getcwd()}/profile.html"
+                f"file:///{os.getcwd()}/{Scalene.__profiler_html}"
             )
 
         return exit_status

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,7 @@ setup(
         "rich>=9.2.0",
         "cloudpickle>=1.5.0",
         "pynvml>=11.0.0",
+        "Jinja2>=3.0.3",
     ],
     ext_modules=([get_line_atomic, pywhere] if sys.platform != 'win32' else []),
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
Two changes:

1. Scalene now generates a single "self-contained" HTML payload (called `profile.html`) containing the profile, and then launches a web browser to load it. No more web server! This HTML file will soon replace the existing `--html` output, which just was an HTML version of the text CLI.

2. New command-line behavior (breaks past command-line slightly, because we will deprecate `--cpu-only`).

* `--cpu` will only profile CPU, not GPU (change of behavior from `--cpu-only`, which actually did both)
* `--cpu --gpu` will only profile CPU and GPU, not memory
* `--cpu --memory` will only profile CPU and memory, not GPU
* `--cpu --gpu --memory` profiles everything - this is the same as specifying nothing

  Two notes:
  1. Windows currently doesn't support memory profiling, and Mac does not support GPU profiling, so the presence or absence of those flags on those platforms has no effect.
  2. It is currently not possible to profile anything without CPU profiling (in effect, `--cpu` is always on).

I am hoping this behavior is more intuitive; comments welcome.