### PR TITLE
Reimplemented settrace callback in C

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -292,49 +292,48 @@ class Scalene:
         """Mark a new line by allocating the trigger number of bytes."""
         bytearray(NEWLINE_TRIGGER_LENGTH)
 
-    @staticmethod
-    def invalidate_lines(frame: FrameType, _event: str, _arg: str) -> Any:
-        """Mark the last_profiled information as invalid as soon as we execute a different line of code."""
-        try:
-            # If we are still on the same line, return.
-            ff = frame.f_code.co_filename
-            fl = frame.f_lineno
-            (fname, lineno, lasti) = Scalene.__last_profiled
-            if (ff == fname) and (fl == lineno):
-                return Scalene.invalidate_lines
-            # Different line: stop tracing this frame.
-            
-            # If we are not in a file we should be tracing, return.
-            if not Scalene.should_trace(ff):
-                return Scalene.invalidate_lines
-            if f := Scalene.on_stack(frame, fname, lineno):
-                # We are still on the same line, but somewhere up the stack
-                # (since we returned when it was the same line in this
-                # frame). Stop tracing in this frame.
-                return Scalene.invalidate_lines
-            # We are on a different line; stop tracing and increment the count.
-            sys.settrace(None)
-            frame.f_trace = None
-            frame.f_trace_lines = False
-            with Scalene.__invalidate_mutex:
-                Scalene.__invalidate_queue.append(
-                    (Scalene.__last_profiled[0], Scalene.__last_profiled[1])
-                )
-                Scalene.update_line()
-            Scalene.__last_profiled_invalidated = False
-            Scalene.__last_profiled = [
-                Filename(ff),
-                LineNumber(fl),
-                ByteCodeIndex(frame.f_lasti),
-            ]
-            return None
-        except AttributeError:
-            # This can happen when Scalene shuts down.
-            return None
-        except Exception as e:
-            print(f"{Scalene.__error_message}:\n", e)
-            traceback.print_exc()
-            return None
+    # @staticmethod
+    # def invalidate_lines(frame: FrameType, _event: str, _arg: str) -> Any:
+    #     """Mark the last_profiled information as invalid as soon as we execute a different line of code."""
+    #     try:
+    #         # If we are still on the same line, return.
+    #         ff = frame.f_code.co_filename
+    #         fl = frame.f_lineno
+    #         (fname, lineno, lasti) = Scalene.__last_profiled
+    #         if (ff == fname) and (fl == lineno):
+    #             return Scalene.invalidate_lines
+    #         # Different line: stop tracing this frame.
+    #         # If we are not in a file we should be tracing, return.
+    #         if not Scalene.should_trace(ff):
+    #             return Scalene.invalidate_lines
+    #         if f := Scalene.on_stack(frame, fname, lineno):
+    #             # We are still on the same line, but somewhere up the stack
+    #             # (since we returned when it was the same line in this
+    #             # frame). Stop tracing in this frame.
+    #             return Scalene.invalidate_lines
+    #         # We are on a different line; stop tracing and increment the count.
+    #         sys.settrace(None)
+    #         frame.f_trace = None
+    #         frame.f_trace_lines = False
+    #         with Scalene.__invalidate_mutex:
+    #             Scalene.__invalidate_queue.append(
+    #                 (Scalene.__last_profiled[0], Scalene.__last_profiled[1])
+    #             )
+    #             Scalene.update_line()
+    #         Scalene.__last_profiled_invalidated = False
+    #         Scalene.__last_profiled = [
+    #             Filename(ff),
+    #             LineNumber(fl),
+    #             ByteCodeIndex(frame.f_lasti),
+    #         ]
+    #         return None
+    #     except AttributeError:
+    #         # This can happen when Scalene shuts down.
+    #         return None
+    #     except Exception as e:
+    #         print(f"{Scalene.__error_message}:\n", e)
+    #         traceback.print_exc()
+    #         return None
 
     @classmethod
     def clear_metrics(cls) -> None:
@@ -495,23 +494,11 @@ class Scalene:
         #             (Filename(f.f_code.co_filename), LineNumber(f.f_lineno))
         #         )
         #         Scalene.update_line()
-        Scalene.__last_profiled = (
-            Filename(f.f_code.co_filename),
-            LineNumber(f.f_lineno),
-            ByteCodeIndex(f.f_lasti),
-        )
+        Scalene.__last_profiled[0] = Filename(f.f_code.co_filename)
+        Scalene.__last_profiled[1] = LineNumber(f.f_lineno)
+        Scalene.__last_profiled[2] = ByteCodeIndex(f.f_lasti)
         Scalene.__alloc_sigq.put([0])
-        # Start tracing.
-        # from scalene import pywhere
-        # print("ALLOC")
         pywhere.enable_settrace()
-        # print("ENABLED")
-        # sys.settrace(Scalene.invalidate_lines)
-        # f.f_trace = Scalene.invalidate_lines
-        # f.f_trace_lines = True
-        # sys.settrace(Scalene.nulltrace)
-        # f.f_trace = Scalene.nulltrace
-        # f.f_trace_lines = True
         del this_frame
 
     @staticmethod
@@ -1310,8 +1297,6 @@ class Scalene:
                 stats.total_memory_malloc_samples += count
                 # Update current and max footprints for this file & line.
                 stats.memory_current_footprint[fname][lineno] += count
-                if lineno == 12:
-                    print(f"count {count} footprint {stats.memory_current_footprint[fname][lineno]}")
                 if (
                     stats.memory_current_footprint[fname][lineno]
                     > stats.memory_current_highwater_mark[fname][lineno]

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1269,8 +1269,6 @@ class Scalene:
                 last_file, last_line = Scalene.__invalidate_queue.pop(0)
                 # print(last_file, last_line, stats.memory_malloc_count[last_file][last_line])
                 stats.memory_malloc_count[last_file][last_line] += 1
-                if last_line == 12:
-                    print("===")
                     # print(stats.memory_current_highwater_mark[last_file][last_line])
                 stats.memory_aggregate_footprint[last_file][
                     last_line
@@ -1322,8 +1320,6 @@ class Scalene:
                 stats.memory_free_count[fname][lineno] += 1
                 stats.total_memory_free_samples += count
                 stats.memory_current_footprint[fname][lineno] -= count
-                if lineno == 12:
-                    print(f"count {-count} footprint {stats.memory_current_footprint[fname][lineno]}")
                 # Ensure that we never drop the current footprint below 0.
                 stats.memory_current_footprint[fname][lineno] = max(
                     0, stats.memory_current_footprint[fname][lineno]

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -495,7 +495,6 @@ class Scalene:
         #             (Filename(f.f_code.co_filename), LineNumber(f.f_lineno))
         #         )
         #         Scalene.update_line()
-        Scalene.__last_profiled_invalidated = False
         Scalene.__last_profiled = (
             Filename(f.f_code.co_filename),
             LineNumber(f.f_lineno),
@@ -1281,7 +1280,11 @@ class Scalene:
             is_malloc = action == Scalene.MALLOC_ACTION
             if is_malloc and count == NEWLINE_TRIGGER_LENGTH + 1:
                 last_file, last_line = Scalene.__invalidate_queue.pop(0)
+                # print(last_file, last_line, stats.memory_malloc_count[last_file][last_line])
                 stats.memory_malloc_count[last_file][last_line] += 1
+                if last_line == 12:
+                    print("===")
+                    # print(stats.memory_current_highwater_mark[last_file][last_line])
                 stats.memory_aggregate_footprint[last_file][
                     last_line
                 ] += stats.memory_current_highwater_mark[last_file][last_line]
@@ -1301,10 +1304,14 @@ class Scalene:
                 stats.memory_python_samples[fname][lineno] += (
                     python_fraction * count
                 )
+                # if lineno == 12:
+                #     print(fname, lineno, stats.memory_current_footprint[fname][lineno])
                 stats.malloc_samples[fname] += 1
                 stats.total_memory_malloc_samples += count
                 # Update current and max footprints for this file & line.
                 stats.memory_current_footprint[fname][lineno] += count
+                if lineno == 12:
+                    print(f"count {count} footprint {stats.memory_current_footprint[fname][lineno]}")
                 if (
                     stats.memory_current_footprint[fname][lineno]
                     > stats.memory_current_highwater_mark[fname][lineno]
@@ -1330,6 +1337,8 @@ class Scalene:
                 stats.memory_free_count[fname][lineno] += 1
                 stats.total_memory_free_samples += count
                 stats.memory_current_footprint[fname][lineno] -= count
+                if lineno == 12:
+                    print(f"count {-count} footprint {stats.memory_current_footprint[fname][lineno]}")
                 # Ensure that we never drop the current footprint below 0.
                 stats.memory_current_footprint[fname][lineno] = max(
                     0, stats.memory_current_footprint[fname][lineno]

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -382,11 +382,11 @@ static int trace_func(PyObject* obj, PyFrameObject* frame, int what, PyObject* a
         PyUnicode_AsASCIIString(static_cast<PyCodeObject*>(code)->co_filename);
     
   auto current_fname_s = PyBytes_AsString(static_cast<PyObject*>(current_fname_unicode));
-  printf("%d NEWLINE AT %s:%d\n", gettid(), current_fname_s, lineno);
+
+  PyList_SetItem(module_pointers.scalene_last_profiled, 2, PyLong_FromLong(PyFrame_GetLasti(static_cast<PyFrameObject*>(frame))));
   allocate_newline();
   PyList_Append(static_cast<PyObject*>(module_pointers.invalidate_queue), last_profiled_ret);
 
-  PyList_SetItem(module_pointers.scalene_last_profiled, 2, PyLong_FromLong(PyFrame_GetLasti(static_cast<PyFrameObject*>(frame))));
   return 0;
 }
 

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -321,6 +321,7 @@ static bool on_stack(char* outer_filename, int lineno, PyFrameObject* frame) {
   // printf("BEGIN ITERATION\n");
   while(frame != nullptr) {
     int iter_lineno = PyFrame_GetLineNumber(frame);
+    Py_DECREF(frame);
     PyPtr<PyCodeObject> code =
           PyFrame_GetCode(static_cast<PyFrameObject*>(frame));
     PyPtr<> co_filename =
@@ -367,7 +368,8 @@ static int trace_func(PyObject* obj, PyFrameObject* frame, int what, PyObject* a
   if(! x) {
     return 0;
   }
-
+  // Needed because decref will be called later
+  Py_INCREF(frame);
   if (on_stack(last_fname_s, lineno_l, static_cast<PyFrameObject*>(frame))) {
     return 0;
   }

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -343,6 +343,9 @@ static void allocate_newline() {
 }
 
 static int trace_func(PyObject* obj, PyFrameObject* frame, int what, PyObject* arg) {
+  if (what != PyTrace_LINE) {
+    return 0;
+  }
   int lineno = PyFrame_GetLineNumber(frame);
   PyPtr<PyCodeObject> code =
         PyFrame_GetCode(static_cast<PyFrameObject*>(frame));
@@ -373,17 +376,21 @@ static int trace_func(PyObject* obj, PyFrameObject* frame, int what, PyObject* a
   PyList_SetItem(module_pointers.scalene_last_profiled, 0, static_cast<PyCodeObject*>(code)->co_filename);
   Py_IncRef( static_cast<PyCodeObject*>(code)->co_filename);
   auto qqq = PyLong_FromLong(lineno);
-  Py_IncRef(qqq);
+  
   PyList_SetItem(module_pointers.scalene_last_profiled, 1,  qqq);
-  PyObject* last_profiled_ret(PyTuple_Pack(2, static_cast<PyCodeObject*>(code)->co_filename,qqq ));
-  Py_IncRef( static_cast<PyCodeObject*>(code)->co_filename);
   Py_IncRef(qqq);
+  PyObject* last_profiled_ret(PyTuple_Pack(2, last_fname,last_lineno ));
+  Py_IncRef(last_fname);
+  Py_IncRef(last_lineno);
+  // Py_IncRef( static_cast<PyCodeObject*>(code)->co_filename);
+  // Py_IncRef(qqq);
     PyPtr<> current_fname_unicode =
         PyUnicode_AsASCIIString(static_cast<PyCodeObject*>(code)->co_filename);
     
   auto current_fname_s = PyBytes_AsString(static_cast<PyObject*>(current_fname_unicode));
 
   PyList_SetItem(module_pointers.scalene_last_profiled, 2, PyLong_FromLong(PyFrame_GetLasti(static_cast<PyFrameObject*>(frame))));
+  // printf("NEWLINE REACHED, WAS ON %s %d, NOW ON %s %d\n", last_fname_s, lineno_l, current_fname_s, lineno);
   allocate_newline();
   PyList_Append(static_cast<PyObject*>(module_pointers.invalidate_queue), last_profiled_ret);
 


### PR DESCRIPTION
Because the use of `sys.settrace` created a large amount of overhead and was partially incorrect, we decided to reimplement the functionality in C. This is a relatively naive translation from Python to C. In addition, the `__last_profiled` field was set to a list so it could be cached in the C code, and some caching was added to `should_trace`