### PR TITLE
Improve multiprocessing and module support

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -677,7 +677,10 @@ class Scalene:
                 + os.environ["PATH"]
             )
             # Force the executable (if anyone invokes it later) to point to one of our aliases.
-            sys.executable = Scalene.__all_python_names[0]
+            sys.executable = os.path.join(
+                Scalene.__python_alias_dir,
+                Scalene.__all_python_names[0],
+            )
 
         # Register the exit handler to run when the program terminates or we quit.
         atexit.register(Scalene.exit_handler)

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -20,6 +20,7 @@ import contextlib
 import functools
 import gc
 import http.server
+import importlib.util
 import inspect
 import json
 import math
@@ -38,8 +39,21 @@ import time
 import traceback
 import webbrowser
 from collections import defaultdict
-from types import FrameType
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
+from importlib.abc import SourceLoader
+from importlib.machinery import ModuleSpec
+from types import CodeType, FrameType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from scalene.scalene_arguments import ScaleneArguments
 from scalene.scalene_client_timer import ScaleneClientTimer
@@ -112,6 +126,73 @@ def start() -> None:
 def stop() -> None:
     """Stop profiling."""
     Scalene.stop()
+
+
+def _get_module_details(
+    mod_name: str,
+    error: Type[Exception] = ImportError,
+) -> Tuple[str, ModuleSpec, CodeType]:
+    """Copy of `runpy._get_module_details`, but not private."""
+    if mod_name.startswith("."):
+        raise error("Relative module names not supported")
+    pkg_name, _, _ = mod_name.rpartition(".")
+    if pkg_name:
+        # Try importing the parent to avoid catching initialization errors
+        try:
+            __import__(pkg_name)
+        except ImportError as e:
+            # If the parent or higher ancestor package is missing, let the
+            # error be raised by find_spec() below and then be caught. But do
+            # not allow other errors to be caught.
+            if e.name is None or (e.name != pkg_name and
+                    not pkg_name.startswith(e.name + ".")):
+                raise
+        # Warn if the module has already been imported under its normal name
+        existing = sys.modules.get(mod_name)
+        if existing is not None and not hasattr(existing, "__path__"):
+            from warnings import warn
+            msg = "{mod_name!r} found in sys.modules after import of " \
+                "package {pkg_name!r}, but prior to execution of " \
+                "{mod_name!r}; this may result in unpredictable " \
+                "behaviour".format(mod_name=mod_name, pkg_name=pkg_name)
+            warn(RuntimeWarning(msg))
+
+    try:
+        spec = importlib.util.find_spec(mod_name)
+    except (ImportError, AttributeError, TypeError, ValueError) as ex:
+        # This hack fixes an impedance mismatch between pkgutil and
+        # importlib, where the latter raises other errors for cases where
+        # pkgutil previously raised ImportError
+        msg = "Error while finding module specification for {!r} ({}: {})"
+        if mod_name.endswith(".py"):
+            msg += (f". Try using '{mod_name[:-3]}' instead of "
+                    f"'{mod_name}' as the module name.")
+        raise error(msg.format(mod_name, type(ex).__name__, ex)) from ex
+    if spec is None:
+        raise error("No module named %s" % mod_name)
+    if spec.submodule_search_locations is not None:
+        if mod_name == "__main__" or mod_name.endswith(".__main__"):
+            raise error("Cannot use package as __main__ module")
+        try:
+            pkg_main_name = mod_name + ".__main__"
+            return _get_module_details(pkg_main_name, error)
+        except error as e:
+            if mod_name not in sys.modules:
+                raise  # No module loaded; being a package is irrelevant
+            raise error(("%s; %r is a package and cannot " +
+                               "be directly executed") %(e, mod_name))
+    loader = spec.loader
+    # use isinstance instead of `is None` to placate mypy
+    if not isinstance(loader, SourceLoader):
+        raise error("%r is a namespace package and cannot be executed"
+                                                                 % mod_name)
+    try:
+        code = loader.get_code(mod_name)
+    except ImportError as e:
+        raise error(format(e)) from e
+    if code is None:
+        raise error("No code object available for %s" % mod_name)
+    return mod_name, spec, code
 
 
 class Scalene:
@@ -1829,6 +1910,23 @@ class Scalene:
             progs = None
             exit_status = 0
             try:
+                if len(sys.argv) >= 2 and sys.argv[0] == "-m":
+                    module = True
+
+                    # Remove -m and the provided module name
+                    _, mod_name, *sys.argv = sys.argv
+
+                    # Given `some.module`, find the path of the corresponding
+                    # some/module/__main__.py or some/module.py file to run.
+                    _, spec, _ = _get_module_details(mod_name)
+                    if not spec.origin:
+                        raise FileNotFoundError
+
+                    # Prepend the found .py file to arguments
+                    sys.argv.insert(0, spec.origin)
+                else:
+                    module = False
+
                 # Look for something ending in '.py'. Treat the first one as our executable.
                 progs = [x for x in sys.argv if re.match(r".*\.py$", x)]
                 # Just in case that didn't work, try sys.argv[0] and __file__.
@@ -1850,7 +1948,9 @@ class Scalene:
                         sys.exit(1)
                     # Push the program's path.
                     program_path = os.path.dirname(os.path.abspath(progs[0]))
-                    sys.path.insert(0, program_path)
+                    if not module:
+                        sys.path.insert(0, program_path)
+
                     # If a program path was specified at the command-line, use it.
                     if len(args.program_path) > 0:
                         Scalene.__program_path = os.path.abspath(

--- a/test/issues/test-issue126.py
+++ b/test/issues/test-issue126.py
@@ -1,0 +1,14 @@
+import sys
+import os.path
+print(sys.executable)
+print()
+
+assert os.path.isabs(sys.executable)
+assert os.path.exists(sys.executable)
+
+import platform
+print(platform.platform())
+
+x = 0
+for _ in range(1_000_000):
+    x += 1

--- a/test/issues/test-issue244.py
+++ b/test/issues/test-issue244.py
@@ -1,0 +1,13 @@
+import sys
+import subprocess
+
+modname = "test.testme"
+
+print(
+    "\n"
+    f"Both `scalene {sys.argv[0]}` and `scalene -m {modname}` "
+    f"should run and profile the {modname} module."
+    "\n"
+)
+
+subprocess.run([sys.executable, "-m", modname])


### PR DESCRIPTION
Fixes #126

By setting `sys.executable` to an absolute path.

---

Fixes #391 
Fixes #244

By replacing `-m some.module` by the path to this module (eg `/usr/lib/python3.10/site-packages/some/module.py` or `/usr/lib/python3.10/site-packages/some/module/__main__.py`).

---

Let me know if you have any suggestions/questions.