### PR TITLE
Fixed algorithmic issues in C tracing

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -562,26 +562,30 @@ class Scalene:
         # First, see if we have now executed a different line of code.
         # If so, increment.
         # TODO: assess the necessity of the following block
-        invalidated = Scalene.__last_profiled_invalidated
+        invalidated = pywhere.get_last_profiled_invalidated()
         (fname, lineno, lasti) = Scalene.__last_profiled
+        # Requesting review on this, I think this is semantically more correct
+        # but I'm not fully sure
         if not invalidated and not (
-            fname == Filename(f.f_code.co_filename)
-            and lineno == LineNumber(f.f_lineno)
+            Scalene.on_stack(this_frame, fname, lineno)
+            # fname == Filename(f.f_code.co_filename)
+            # and lineno == LineNumber(f.f_lineno)
         ):
+            
             with Scalene.__invalidate_mutex:
                 Scalene.__invalidate_queue.append(
-                    (Filename(f.f_code.co_filename), LineNumber(f.f_lineno))
+                    (Scalene.__last_profiled[0], Scalene.__last_profiled[1])
                 )
                 Scalene.update_line()
+        pywhere.set_last_profiled_invalidated_false()
         Scalene.__last_profiled[0] = Filename(f.f_code.co_filename)
         Scalene.__last_profiled[1] = LineNumber(f.f_lineno)
         Scalene.__last_profiled[2] = ByteCodeIndex(f.f_lasti)
-        sys.settrace(Scalene.invalidate_lines_python)
-        f.f_trace = Scalene.invalidate_lines_python
-
-        f.f_trace_lines = True
+        # sys.settrace(Scalene.invalidate_lines_python)
+        # f.f_trace = Scalene.invalidate_lines_python
+        # f.f_trace_lines = True
         Scalene.__alloc_sigq.put([0])
-        # pywhere.enable_settrace()
+        pywhere.enable_settrace()
         del this_frame
 
     @staticmethod
@@ -1739,7 +1743,7 @@ class Scalene:
     ) -> int:
         """Initiate execution and profiling."""
         # If --off is set, tell all children to not profile and stop profiling before we even start.
-        # pywhere.populate_struct()
+        pywhere.populate_struct()
         if "off" not in Scalene.__args or not Scalene.__args.off:
             self.start()
         # Run the code being profiled.
@@ -1759,9 +1763,10 @@ class Scalene:
             exit_status = 1
         finally:
             self.stop()
-            # pywhere.disable_settrace()
-            # pywhere.depopulate_struct()
-            sys.settrace(None)
+            pywhere.disable_settrace()
+            pywhere.depopulate_struct()
+            # Leaving here in case of reversion
+            # sys.settrace(None)
             stats = Scalene.__stats
             (last_file, last_line, _) = Scalene.__last_profiled
             stats.memory_malloc_count[last_file][last_line] += 1


### PR DESCRIPTION
After seeing performance issues, we reverted the previous attempt at introducing this new tracer. The main missing element in the old version of the C settrace callback was not marking irrelevant
frames as irrelevant, which has been resolved. This involves making some assumptions about the memory layout of 3.11+ `PyFrameObject`s﻿. In a worst-case scenario program,
 `test/expensive_benchmarks/bm_pprint.py`, this change achieves more than a 2x speedup compared to the original implementation. 
