### PR TITLE
Add and use clear-vendor-dirs target to prevent stale vendored deps (closes #509)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -61,7 +61,10 @@ vendor/printf/printf.cpp:
 	cd vendor/printf && ln -s printf.c printf.cpp
 	sed $(SED_INPLACE) -e 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h
 
-vendor-deps: vendor/Heap-Layers vendor/printf/printf.cpp
+clear-vendor-dirs:
+	rm -fr vendor/
+
+vendor-deps: clear-vendor-dirs vendor/Heap-Layers vendor/printf/printf.cpp
 
 mypy:
 	-mypy $(PYTHON_SOURCES)


### PR DESCRIPTION
This PR adds a `clear-vendor-dirs` target to `GNUMakefile` to prevent stale vendored dependencies, see #509 for details.