### PR TITLE
Fix C should_trace to support OS-specific path separators

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,8 +6,8 @@ C_SOURCES = src/source/*.cpp src/include/*.h*
 
 .PHONY: black clang-format prettier format upload vendor-deps
 
-# CXXFLAGS = -std=c++17 -g -O0 # FIXME
-CXXFLAGS = -std=c++17 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden
+# CXXFLAGS = -std=c++14 -g -O0 # FIXME
+CXXFLAGS = -std=c++14 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden
 # CXX = g++
 
 INCLUDES  = -Isrc -Isrc/include
@@ -23,7 +23,7 @@ ifeq ($(shell uname -s),Darwin)
   else
     ARCH := -arch x86_64
   endif
-  CXXFLAGS := -std=c++17 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden -flto -ftls-model=initial-exec -ftemplate-depth=1024 $(ARCH) -compatibility_version 1 -current_version 1 -dynamiclib
+  CXXFLAGS := -std=c++14 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden -flto -ftls-model=initial-exec -ftemplate-depth=1024 $(ARCH) -compatibility_version 1 -current_version 1 -dynamiclib
   SED_INPLACE = -i ''
 
 else # non-Darwin

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ def compiler_archs(compiler: str):
 def extra_compile_args():
     """Returns extra compiler args for platform."""
     if sys.platform == 'win32':
-        return ['/std:c++17'] # for Visual Studio C++
+        return ['/std:c++14'] # for Visual Studio C++
 
-    return ['-std=c++17']
+    return ['-std=c++14']
 
 def make_command():
 #    return 'nmake' if sys.platform == 'win32' else 'make'  # 'nmake' isn't found on github actions' VM

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ def compiler_archs(compiler: str):
 def extra_compile_args():
     """Returns extra compiler args for platform."""
     if sys.platform == 'win32':
-        return ['/std:c++14'] # for Visual Studio C++
+        return ['/std:c++17'] # for Visual Studio C++
 
-    return ['-std=c++14']
+    return ['-std=c++17']
 
 def make_command():
 #    return 'nmake' if sys.platform == 'win32' else 'make'  # 'nmake' isn't found on github actions' VM

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -6,8 +6,11 @@
 
 #include <mutex>
 #include <vector>
+#include <filesystem>
 #include <unordered_map>
+
 #include <unistd.h>
+
 
 // NOTE: uncomment for debugging, but this causes issues
 // for production builds on Alpine
@@ -39,7 +42,13 @@ class TraceConfig {
     if ( res != _memoize.end()) {
       return res->second;
     }
-    if (strstr(filename, "site-packages") || strstr(filename, "/lib/python")) {
+    // Build up the paths that we filter out (the Python and Scalene libraries).
+    auto python_lib_path = std::filesystem::path("lib");
+    python_lib_path /= std::filesystem::path("python");
+    auto scalene_path = std::filesystem::path("scalene");
+    scalene_path /= std::filesystem::path("scalene");
+
+    if (strstr(filename, "site-packages") || strstr(filename, python_lib_path.c_str())) {
       _memoize.insert(std::pair<std::string, bool>(std::string(filename), false));
       return false;
     }
@@ -49,7 +58,7 @@ class TraceConfig {
       return true;
     }
 
-    if (strstr(filename, "scalene/scalene")) {
+    if (strstr(filename, scalene_path.c_str())) {
       _memoize.insert(std::pair<std::string, bool>(std::string(filename), false));
       return false;
     }


### PR DESCRIPTION
This PR addresses a Windows compatibility issue and an inconsistency between two implementations of the `should_trace` in the C++ vs. the Python code. One thing that `should_trace` does is filtering out Python libraries, so Scalene doesn't profile Python itself. The C++ version of `should_trace` in `pywhere.cpp` uses hard-coded Unix/Mac OS X path separators (`/`) while the Python version correctly uses platform-specific separators. This PR builds paths with the platform-appropriate separators. The C++ version also now filters out Anaconda libraries, matching the functionality of the Python version.