### PR TITLE
fixed encoding problem

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1759,7 +1759,7 @@ class Scalene:
 
         # Write the rendered content to the specified output file.
         try:
-            with open(output_fname, "w") as f:
+            with open(output_fname, "w", encoding="utf-8") as f:
                 f.write(rendered_content)
         except OSError:
             pass


### PR DESCRIPTION
Fixed the bug from https://stackoverflow.com/questions/74606510/scalene-an-exception-of-type-unicodeencodeerror

Got the same error related to cp1250. Set in scalene_profiler.py the concrete encoding="utf-8"