### PR TITLE
Add handling of TypeError case to is_native

### DIFF
--- a/scalene/scalene_analysis.py
+++ b/scalene/scalene_analysis.py
@@ -31,6 +31,9 @@ class ScaleneAnalysis:
         except AttributeError:
             # No __file__, meaning it's built-in. Let's call it native.
             result = True
+        except TypeError:
+            # __file__ is there, but empty (os.path.dirname() returns TypeError).  Let's call it native.
+            result = True
         except ModuleNotFoundError:
             # This module is not installed; fail gracefully.
             result = False


### PR DESCRIPTION
This should address https://github.com/plasma-umass/scalene/issues/587 which has more information, but basically the check for native fails on at least my system because package.__file__ exists, but is None, so os.path.dirname() returns a TypeError.