### PR TITLE
fixed: add astunparser to python<3.9 wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ install_requires_list = [
     "psutil>=5.9.2"
 ]
 
-if (sys.version_info.major == 3) and (sys.version_info.minor < 3.9):
+if sys.version_info < (3, 9):
     install_requires_list.append("astunparse>=1.6.3")
 
 setup(


### PR DESCRIPTION
`sys.version_info.minor` only returns the minor part of the version info. This check was never True and the wheel did not contain the extra dependency for python versions < 3.9.