### PR TITLE
Remove vsnprintf definition from printf.h

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -60,6 +60,7 @@ vendor/printf/printf.cpp:
 	mkdir -p vendor && cd vendor && git clone https://github.com/mpaland/printf
 	cd vendor/printf && ln -s printf.c printf.cpp
 	sed -e 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h > /tmp/printf.h.$$ && mv /tmp/printf.h.$$ vendor/printf/printf.h
+	sed -e 's/^#define vsnprintf vsnprintf_/\/\/&/' vendor/printf/printf.h > /tmp/printf.h.$$ && mv /tmp/printf.h.$$ vendor/printf/printf.h
 	#	sed $(SED_INPLACE) -e 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h
 
 clear-vendor-dirs:


### PR DESCRIPTION
This definition will break STL string, starting from GCC13.

Although GCC13 will not being widely used soon, we have encountered such problem on Arch Linux for loong64.
 