### PR TITLE
Immediately resolve output filename so it ends up in expected location

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1950,7 +1950,7 @@ class Scalene:
         )
         Scalene.__output.html = args.html
         if args.outfile:
-            Scalene.__output.output_file = str(pathlib.Path(args.outfile).resolve())
+            Scalene.__output.output_file = os.path.abspath(os.path.expanduser(args.outfile))
         Scalene.__is_child = args.pid != 0
         # the pid of the primary profiler
         Scalene.__parent_pid = args.pid if Scalene.__is_child else os.getpid()

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1949,7 +1949,8 @@ class Scalene:
             time.perf_counter() + Scalene.__args.profile_interval
         )
         Scalene.__output.html = args.html
-        Scalene.__output.output_file = args.outfile
+        if args.outfile:
+            Scalene.__output.output_file = str(pathlib.Path(args.outfile).resolve())
         Scalene.__is_child = args.pid != 0
         # the pid of the primary profiler
         Scalene.__parent_pid = args.pid if Scalene.__is_child else os.getpid()


### PR DESCRIPTION
Executing `os.chdir` in the Python script was causing output to go to the then-current directory instead of the invoked directory (if it was a relative path).

Fixes https://github.com/plasma-umass/scalene/issues/598.