### PR TITLE
Upgrades manylinux building to 2_28, and adds manylinux2014

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -27,7 +27,6 @@ jobs:
 
   build-and-upload:
     needs: pick-devN
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python_version: ['3.8', '3.9', '3.10', '3.11']
@@ -56,6 +55,7 @@ jobs:
           - plat: windows-latest
             python_version: 3.11
 
+    runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 
     steps:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -32,11 +32,11 @@ jobs:
         python_version: ['3.8', '3.9', '3.10', '3.11']
         plat: ['manylinux2014', 'manylinux_2_28', 'macos-latest', 'windows-latest']
         include:
-          - os: manylinux2014
+          - plat: manylinux2014
             os: ubuntu-latest
             container: quay.io/pypa/manylinux2014_x86_64  # https://github.com/pypa/manylinux
 
-          - os: manylinux_2_28
+          - plat: manylinux_2_28
             os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64  # https://github.com/pypa/manylinux
 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -31,15 +31,29 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.8', '3.9', '3.10', '3.11']
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        plat: ['manylinux2014', 'manylinux_2_28', 'macos-latest', 'windows-latest']
         include:
-          - os: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_24_x86_64  # https://github.com/pypa/manylinux
-          - os: macos-latest
+          - os: manylinux2014
+            os: ubuntu-latest
+            container: quay.io/pypa/manylinux2014_x86_64  # https://github.com/pypa/manylinux
+
+          - os: manylinux_2_28
+            os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64  # https://github.com/pypa/manylinux
+
+          - plat: macos-latest
+            os: macos-latest
+
+          - plat: macos-latest
+            os: macos-latest
             python_version: 3.11
             upload_source: true   # just need ONE of them to do it
+
+          - plat: windows-latest
+            os: windows-latest
+
         exclude:
-          - os: windows-latest
+          - plat: windows-latest
             python_version: 3.11
 
     container: ${{ matrix.container }}


### PR DESCRIPTION
This PR upgrades [manylinux](https://github.com/pypa/manylinux) building from 2_24, which has reached EOL, and also adds building on `manylinux2014`, so as to resolve #670.

There seem to be pros and cons to both manylinux2014 and manylinux_2_28, with groups of users able to use the one but not the other, so we're generating both versions now and letting `pip` pick what it will.