### PR TITLE
Moved up assignment so __profiler_base is always defined.

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -751,6 +751,7 @@ class Scalene:
                 sys.exit(1)
 
         Scalene.__signals.set_timer_signals(arguments.use_virtual_time)
+        Scalene.__profiler_base = str(os.path.dirname(__file__))
         if arguments.pid:
             # Child process.
             # We need to use the same directory as the parent.
@@ -798,7 +799,6 @@ class Scalene:
                 sys.executable,
                 cmdline,
             )
-            Scalene.__profiler_base = str(os.path.dirname(__file__))
             # Now create all the files.
             for name in Scalene.__all_python_names:
                 fname = os.path.join(Scalene.__python_alias_dir, name)


### PR DESCRIPTION
Fixes Scalene behavior for the following test case:

```Python

import os
from django.conf import settings
from django.core.wsgi import get_wsgi_application
from django.http import HttpResponse
from django.urls import path

# Settings
settings.configure(
    DEBUG=True,
    ROOT_URLCONF=__name__,
    SECRET_KEY=os.urandom(32),
    ALLOWED_HOSTS=['*'],
    WSGI_APPLICATION='__main__.application',
)

# Simple view
def hello_world(request):
    return HttpResponse("Hello, Django!")

# URL configuration
urlpatterns = [
    path('', hello_world),
]

application = get_wsgi_application()

if __name__ == "__main__":
    from django.core.management import execute_from_command_line
    execute_from_command_line([__file__, 'runserver'])
```
