### PR TITLE
Avoid unnecessary slice in sparkline.generate.

### DIFF
--- a/scalene/sparkline.py
+++ b/scalene/sparkline.py
@@ -18,7 +18,7 @@ def generate(
 
     # Prevent negative memory output due to sampling error.
     samples = [i if i > 0 else 0.0 for i in arr]
-    return _create(samples[: len(arr)], minimum, maximum)
+    return _create(samples, minimum, maximum)
 
 
 def _create(


### PR DESCRIPTION
`samples` is constructed using list comprehension from `arr` so `len(samples) == len(arr)` is always `True` and consequently `samples == samples[: len(arr)]`. Even for small `arr` this slice creation still wastes resources:
```python
In [8]: arr = [-1, 0, 1, 2, 3, -2]

In [9]: samples = [i if i > 0 else 0.0 for i in arr]

In [10]: samples
Out[10]: [0.0, 0.0, 1, 2, 3, 0.0]

In [11]: samples[: len(arr)] == samples
Out[11]: True

In [12]: %timeit samples[:len(arr)]
82 ns ± 0.109 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```