### PR TITLE
[perf] Speed up spark creation in sparkline.

### DIFF
--- a/scalene/sparkline.py
+++ b/scalene/sparkline.py
@@ -32,10 +32,8 @@ def _create(
     spark = "".join(
         __bars[
             min(
-                [
-                    __bar_count - 1,
-                    int((n - min_) / extent * __bar_count),
-                ]
+                __bar_count - 1,
+                int((n - min_) / extent * __bar_count),
             )
         ]
         for n in numbers


### PR DESCRIPTION
`min` [supports](https://docs.python.org/3/library/functions.html#min) both iterable and scalar args and creating list is not free, so passing args directly is more efficient.
```python
In [16]: %timeit min([1, 2])
121 ns ± 0.0535 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [17]: %timeit min(1, 2)
96.2 ns ± 0.245 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```