### PR TITLE
Remove unnecessary argument override.

### DIFF
--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -87,8 +87,7 @@ class ScaleneJSON:
             new_samples = sorted(
                 random.sample(new_samples, self.max_sparkline_samples)
             )
-        samples = new_samples
-        return samples
+        return new_samples
 
     # Profile output methods
     def output_profile_line(


### PR DESCRIPTION
This override is a noop, since `samples` is not used below, but is somewhat confusing and adds extra overhead.