### PR TITLE
Remove unnecessary list creation in scalene_analysis.py

### DIFF
--- a/scalene/scalene_analysis.py
+++ b/scalene/scalene_analysis.py
@@ -134,8 +134,6 @@ class ScaleneAnalysis:
         # Filter out any magic lines (starting with %) if in a Jupyter notebook
         import re
 
-        srclines = list(
-            map(lambda x: re.sub(r"^\%.*", "", x), source.split("\n"))
-        )
+        srclines = map(lambda x: re.sub(r"^\%.*", "", x), source.split("\n"))
         source = "\n".join(srclines)
         return source


### PR DESCRIPTION
`join` takes an iterable, so passing the result of `map` works and doesn't incur extra memory and CPU cost required to construct `list`.