### PR TITLE
Added outermost loop to JSON

### DIFF
--- a/scalene/scalene_analysis.py
+++ b/scalene/scalene_analysis.py
@@ -167,15 +167,16 @@ class ScaleneAnalysis:
 
                 for line in range(node.lineno, node.end_lineno + 1):
                     # NOTE: we update child nodes first (in the recursive call),
-                    # so what we want this statement to do is attribute any lines that we haven't alre
+                    # so what we want this statement to do is attribute any lines that we haven't already
+                    # attributed a region to.
                     if line not in regions:
                         if current_outermost_region and outermost_is_loop:
-                            # NOTE: this accounts for the case in which `node`
+                            # NOTE: this additionally accounts for the case in which `node`
                             # is a loop. Any loop within another loop should take on the entirety of the
                             # outermost loop too
                             regions[
                                 line
-                            ] = current_outermost_region  # if  current_outermost_region else (line, line)
+                            ] = current_outermost_region
                         elif (
                             curr_is_block_not_loop
                             and len(srclines[line - 1].strip()) > 0

--- a/scalene/scalene_analysis.py
+++ b/scalene/scalene_analysis.py
@@ -130,6 +130,77 @@ class ScaleneAnalysis:
         return regions
 
     @staticmethod
+    def find_outermost_loop(src: str) -> Dict[int, Tuple[int, int]]:
+        # Filter out the first line if in a Jupyter notebook and it starts with a magic (% or %%).
+        src = ScaleneAnalysis.strip_magic_line(src)
+        srclines = src.split("\n")
+        tree = ast.parse(src)
+        regions = {}
+
+        def walk(node, current_outermost_region, outer_class):
+            nonlocal regions
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) or (
+                isinstance(node, (ast.For, ast.While, ast.AsyncFor, ast.If))
+                and (
+                    outer_class is ast.FunctionDef
+                    or outer_class is ast.AsyncFunctionDef
+                    or outer_class is ast.ClassDef
+                    or outer_class is None
+                )
+            ):
+                current_outermost_region = (node.lineno, node.end_lineno)
+                outer_class = node.__class__
+
+            # elif isinstance(node, (ast.For, ast.While, ast.AsyncFor)) and (
+            #     outer_class is ast.FunctionDef
+            #     or outer_class is ast.AsyncFunctionDef
+            #     or outer_class is ast.ClassDef
+            # ):
+            #     pass
+            for child_node in ast.iter_child_nodes(node):
+                walk(child_node, current_outermost_region, outer_class)
+            if (
+                    isinstance(node, ast.stmt)
+                # and not isinstance(
+                #     node,
+                #     (
+                #         ast.ClassDef,
+                #         ast.FunctionDef,
+                #         ast.AsyncFunctionDef,
+                #         ast.For,
+                #         ast.While,
+                #         ast.AsyncFor,
+                #     ),
+                # )
+            ):
+                outermost_is_loop = outer_class in [ast.For, ast.AsyncFor, ast.While]
+                curr_is_block_not_loop = node.__class__ in [ast.With, ast.If, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef]
+
+                for line in range(node.lineno, node.end_lineno + 1):
+                    # NOTE: we update child nodes first (in the recursive call),
+                    # so what we want this statement to do is attribute any lines that we haven't alre
+                    if line not in regions:
+                        if current_outermost_region and outermost_is_loop:
+                            # NOTE: this accounts for the case in which `node`
+                            # is a loop. Any loop within another loop should take on the entirety of the
+                            # outermost loop too
+                            regions[line] = current_outermost_region # if  current_outermost_region else (line, line)
+                        elif curr_is_block_not_loop and len(srclines[line - 1].strip()) > 0:
+                            # This deals with the case in which the current block is the header of another block, like
+                            # a function or a class. Since the children are iterated over beforehand, if they're not
+                            # in a loop, they are already in the region table.
+                            regions[line] = (node.lineno, node.end_lineno)
+                        else:
+                            regions[line] =  (line, line)
+
+        walk(tree, None, None)
+        for lineno, line in enumerate(srclines, 1):
+            regions[lineno] = regions.get(lineno, (lineno, lineno))
+
+        return regions
+
+
+    @staticmethod
     def strip_magic_line(source: str) -> str:
         # Filter out any magic lines (starting with %) if in a Jupyter notebook
         import re

--- a/scalene/scalene_analysis.py
+++ b/scalene/scalene_analysis.py
@@ -139,7 +139,9 @@ class ScaleneAnalysis:
 
         def walk(node, current_outermost_region, outer_class):
             nonlocal regions
-            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) or (
+            if isinstance(
+                node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ) or (
                 isinstance(node, (ast.For, ast.While, ast.AsyncFor, ast.If))
                 and (
                     outer_class is ast.FunctionDef
@@ -151,30 +153,17 @@ class ScaleneAnalysis:
                 current_outermost_region = (node.lineno, node.end_lineno)
                 outer_class = node.__class__
 
-            # elif isinstance(node, (ast.For, ast.While, ast.AsyncFor)) and (
-            #     outer_class is ast.FunctionDef
-            #     or outer_class is ast.AsyncFunctionDef
-            #     or outer_class is ast.ClassDef
-            # ):
-            #     pass
             for child_node in ast.iter_child_nodes(node):
                 walk(child_node, current_outermost_region, outer_class)
-            if (
-                    isinstance(node, ast.stmt)
-                # and not isinstance(
-                #     node,
-                #     (
-                #         ast.ClassDef,
-                #         ast.FunctionDef,
-                #         ast.AsyncFunctionDef,
-                #         ast.For,
-                #         ast.While,
-                #         ast.AsyncFor,
-                #     ),
-                # )
-            ):
+            if isinstance(node, ast.stmt):
                 outermost_is_loop = outer_class in [ast.For, ast.AsyncFor, ast.While]
-                curr_is_block_not_loop = node.__class__ in [ast.With, ast.If, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef]
+                curr_is_block_not_loop = node.__class__ in [
+                    ast.With,
+                    ast.If,
+                    ast.ClassDef,
+                    ast.FunctionDef,
+                    ast.AsyncFunctionDef,
+                ]
 
                 for line in range(node.lineno, node.end_lineno + 1):
                     # NOTE: we update child nodes first (in the recursive call),
@@ -184,21 +173,25 @@ class ScaleneAnalysis:
                             # NOTE: this accounts for the case in which `node`
                             # is a loop. Any loop within another loop should take on the entirety of the
                             # outermost loop too
-                            regions[line] = current_outermost_region # if  current_outermost_region else (line, line)
-                        elif curr_is_block_not_loop and len(srclines[line - 1].strip()) > 0:
+                            regions[
+                                line
+                            ] = current_outermost_region  # if  current_outermost_region else (line, line)
+                        elif (
+                            curr_is_block_not_loop
+                            and len(srclines[line - 1].strip()) > 0
+                        ):
                             # This deals with the case in which the current block is the header of another block, like
                             # a function or a class. Since the children are iterated over beforehand, if they're not
                             # in a loop, they are already in the region table.
                             regions[line] = (node.lineno, node.end_lineno)
                         else:
-                            regions[line] =  (line, line)
+                            regions[line] = (line, line)
 
         walk(tree, None, None)
         for lineno, line in enumerate(srclines, 1):
             regions[lineno] = regions.get(lineno, (lineno, lineno))
 
         return regions
-
 
     @staticmethod
     def strip_magic_line(source: str) -> str:

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -415,6 +415,7 @@ class ScaleneJSON:
             code_str = "".join(code_lines)
 
             enclosing_regions = ScaleneAnalysis.find_regions(code_str)
+            outer_loop = ScaleneAnalysis.find_outermost_loop(code_str)
             imports = ScaleneAnalysis.get_native_imported_modules(code_str)
 
             output["files"][fname_print] = {
@@ -446,7 +447,8 @@ class ScaleneJSON:
                     profile_line["end_region_line"] = enclosing_regions[
                         lineno
                     ][1]
-
+                    profile_line["start_outermost_loop"] = outer_loop[lineno][0]
+                    profile_line["end_outermost_loop"] = outer_loop[lineno][1]
                     # When reduced-profile set, only output if the payload for the line is non-zero.
                     if reduced_profile:
                         profile_line_copy = copy.copy(profile_line)


### PR DESCRIPTION
Added a new pair of fields to JSON, `start_outermost_loop` and `end_outermost_loop`, which keeps track of the outermost loop in the current scope that a given line belongs to. For instance,
```python
for i in a:
   for j in b:
      for k in c:
         pass
```

The `pass` statement in the above snippet would be reported as being contained in the outermost for loop, which iterates over `i`. However,


```python
for i in a:
   def b():
      for j in c:
         pass
```

the pass statement in the above snippet would be said to have an outermost for loop `for j in c:`, since the loop iterating over i is not in the same scope. 