### PR TITLE
Handle text browsers explicitly to support unlisted GUI browsers

### DIFF
--- a/scalene/find_browser.py
+++ b/scalene/find_browser.py
@@ -1,0 +1,12 @@
+def find_browser():
+    """Find the default browser if possible and if compatible."""
+    import webbrowser
+
+    # Mostly taken from the standard library webbrowser module. Search "console browsers" in there.
+    # In general, a browser belongs on this list of the scalene web GUI doesn't work in it.
+    # See https://github.com/plasma-umass/scalene/issues/723.
+    incompatible_browsers = {"www-browser", "links", "elinks", "lynx", "w3m", "links2", "links-g"}
+
+    browser = webbrowser.get()
+
+    return None if browser.name in incompatible_browsers else browser

--- a/scalene/find_browser.py
+++ b/scalene/find_browser.py
@@ -7,6 +7,9 @@ def find_browser():
     # See https://github.com/plasma-umass/scalene/issues/723.
     incompatible_browsers = {"www-browser", "links", "elinks", "lynx", "w3m", "links2", "links-g"}
 
-    browser = webbrowser.get()
+    try:
+        browser = webbrowser.get()
+    except webbrowser.Error:
+        return None
 
     return None if browser.name in incompatible_browsers else browser

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -5,6 +5,7 @@ import sys
 from textwrap import dedent
 from typing import Any, List, NoReturn, Optional, Tuple
 
+from scalene.find_browser import find_browser
 from scalene.scalene_arguments import ScaleneArguments
 from scalene.scalene_version import scalene_version, scalene_date
 
@@ -354,13 +355,8 @@ for the process ID that Scalene reports. For example:
 
         # Launch the UI if `--viewer` was selected.
         if args.viewer:
-            import webbrowser
-
-            if (
-                webbrowser.get()
-                and type(webbrowser.get()).__name__ != "GenericBrowser"
-            ):
-                webbrowser.open(scalene_gui_url)
+            if browser := find_browser():
+                browser.open(scalene_gui_url)
             else:
                 print(f"Scalene: could not open {scalene_gui_url}.")
             sys.exit(0)

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -41,6 +41,9 @@ import webbrowser
 
 # For debugging purposes
 from rich.console import Console
+
+from scalene.find_browser import find_browser
+
 console = Console(style="white on blue")
 def nada(*args):
     pass
@@ -1765,13 +1768,9 @@ class Scalene:
         ):
             # First, check for a browser.
             try:
-                if (
-                    not webbrowser.get()
-                    or type(webbrowser.get()).__name__ == "GenericBrowser"
-                ):
+                if not find_browser():
                     # Could not open a graphical web browser tab;
                     # act as if --web was not specified
-                    # (GenericBrowser means text-based browsers like Lynx.)
                     Scalene.__args.web = False
                 else:
                     # Force JSON output to profile.json.


### PR DESCRIPTION
Ref: https://github.com/plasma-umass/scalene/issues/723

I tested by:

- Setting BROWSER to lynx and making sure it still defaulted to printing to the console instead of opening the html file.
- Setting BROWSER to vivaldi and making sure it did open the web view by default.
- Setting BROWSER to chromium and making sure it still opened the web view by default.
- Passing --cli with BROWSER=vivaldi to make sure it just printed to the console.
- Installing jupyter-lab to the venv, opening it, and running `%scrun` and `%%scalene` on some cells. I got the iframe to render with profile results.