### PR TITLE
Fix python aliases

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -299,6 +299,9 @@ class Scalene:
 
     # Likely names for the Python interpreter.
     __all_python_names = [
+        "python",
+        "python" + str(sys.version_info.major),
+        "python" + str(sys.version_info.major) + "." + str(sys.version_info.minor),
         os.path.basename(sys.executable),
         os.path.basename(sys.executable) + str(sys.version_info.major),
         os.path.basename(sys.executable)

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1322,11 +1322,12 @@ class Scalene:
         while f and f.f_back and f.f_back.f_code:
             if "self" in f.f_locals:
                 prepend_name = f.f_locals["self"].__class__.__name__
-                fn_name = Filename(f"{prepend_name}.{fn_name}")
+                if "Scalene" not in prepend_name:
+                    fn_name = Filename(f"{prepend_name}.{fn_name}")
                 break
             if "cls" in f.f_locals:
                 prepend_name = getattr(f.f_locals["cls"], "__name__", None)
-                if not prepend_name:
+                if not prepend_name or "Scalene" in prepend_name:
                     break
                 fn_name = Filename(f"{prepend_name}.{fn_name}")
                 break


### PR DESCRIPTION
This fixes a bug where the executable is invoked as `python3.10` (for example), and later a call to `subprocess.Popen` invokes a child using the executable name `python3`; because `python3` would not be created as an alias, capturing child process profiles did not work.

We should deprecate the `sys.executable` logic; I am only leaving it intact in case there is some edge case where using the obvious names does not work.
