### PR TITLE
Add scalene_done to pywhere

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1567,10 +1567,20 @@ class Scalene:
         Scalene.__start_time = time.monotonic_ns()
         Scalene.__done = False
 
+        if Scalene.__args.memory:
+            from scalene import pywhere  # type: ignore
+            pywhere.set_scalene_done_false()
+
+
     @staticmethod
     def stop() -> None:
         """Complete profiling."""
         Scalene.__done = True
+        if Scalene.__args.memory:
+            from scalene import pywhere  # type: ignore
+            pywhere.set_scalene_done_true()
+
+
         Scalene.disable_signals()
         Scalene.__stats.stop_clock()
         if Scalene.__args.outfile:

--- a/src/include/pywhere.hpp
+++ b/src/include/pywhere.hpp
@@ -16,6 +16,8 @@ extern "C" int whereInPython(std::string& filename, int& lineno, int& bytei);
  */
 extern "C" std::atomic<decltype(whereInPython)*> p_whereInPython;
 
+extern "C" std::atomic<bool> p_scalene_done;
+
 /**
  * Returns whether the Python interpreter was detected.
  * It's possible (and in fact happens for any fork/exec from within Python,

--- a/src/include/sampleheap.hpp
+++ b/src/include/sampleheap.hpp
@@ -145,6 +145,7 @@ class SampleHeap : public SuperHeap {
   }
   inline void register_malloc(size_t realSize, void* ptr,
                               bool inPythonAllocator = true) {
+    if (p_scalene_done) return;
     assert(realSize);
     // If this is the special NEWLINE value, trigger an update.
     if (unlikely(realSize == NEWLINE)) {
@@ -205,6 +206,7 @@ class SampleHeap : public SuperHeap {
   }
 
   inline void register_free(size_t realSize, void* ptr) {
+    if (p_scalene_done) return;
     size_t sampleFreeSize;
     auto sampleFree =
         _allocationSampler.decrement(realSize, ptr, sampleFreeSize);

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -238,6 +238,8 @@ class MakeLocalAllocator {
 decltype(p_whereInPython) __attribute((visibility("default")))
 p_whereInPython{nullptr};
 
+std::atomic_bool __attribute((visibility("default"))) p_scalene_done{true};
+
 static MakeLocalAllocator<PYMEM_DOMAIN_MEM> l_mem;
 static MakeLocalAllocator<PYMEM_DOMAIN_OBJ> l_obj;
 

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -227,11 +227,33 @@ PyObject* set_last_profiled_invalidated_true(PyObject* self, PyObject* args) {
   Py_RETURN_NONE;
 }
 
-
 PyObject* set_last_profiled_invalidated_false(PyObject* self, PyObject* args) {
   last_profiled_invalidated = false;
   Py_RETURN_NONE;
 }
+
+
+PyObject* set_scalene_done_true(PyObject* self, PyObject* args) {
+    auto scalene_done =
+      (std::atomic_bool*)dlsym(RTLD_DEFAULT, "p_scalene_done");
+    if (scalene_done == nullptr) {
+      PyErr_SetString(PyExc_Exception, "Unable to find p_scalene_done");
+      return NULL;
+    }
+  *scalene_done = true;
+  Py_RETURN_NONE;
+}
+PyObject* set_scalene_done_false(PyObject* self, PyObject* args) {
+    auto scalene_done =
+      (std::atomic_bool*)dlsym(RTLD_DEFAULT, "p_scalene_done");
+    if (scalene_done == nullptr) {
+      PyErr_SetString(PyExc_Exception, "Unable to find p_whereInPython");
+      return NULL;
+    }
+  *scalene_done = false;
+  Py_RETURN_NONE;
+}
+
 int whereInPython(std::string& filename, int& lineno, int& bytei) {
   if (!Py_IsInitialized()) {  // No python, no python stack.
     return 0;
@@ -488,6 +510,10 @@ static PyMethodDef EmbMethods[] = {
     {"get_last_profiled_invalidated", get_last_profiled_invalidated, METH_NOARGS, ""},
     {"set_last_profiled_invalidated_true", set_last_profiled_invalidated_true, METH_NOARGS, ""},
     {"set_last_profiled_invalidated_false", set_last_profiled_invalidated_false, METH_NOARGS, ""},
+    {"set_scalene_done_true", set_scalene_done_true, METH_NOARGS, ""},
+    {"set_scalene_done_false", set_scalene_done_false, METH_NOARGS, ""},
+
+
     {NULL, NULL, 0, NULL}};
 
 static PyModuleDef EmbedModule = {PyModuleDef_HEAD_INIT,


### PR DESCRIPTION
Fixes #487. Adds a flag, `p_scalene_done`, to libscalene that is updated by `pywhere`, which accesses it using `dlsym`. This is updated every time the corresponding flag is updated in the Python side of the profiler. 

This approach has two weaknesses:
1. There are two different flags here, one in Python-land and one in C-land. I can see no way this would cause issues, but it may be undesirable
2. Every time `p_scalene_done` is set, `dlsym` is called. For a high volume of calls to `scalene_profiler.start()` and `scalene_profiler.stop()`, this may incur significant overhead. I have seen no evidence of this sort of usage pattern from any users of Scalene that I have interacted with.   
