### PR TITLE
ci: re-enable py3.12

### DIFF
--- a/.github/workflows/test-smoketests.yml
+++ b/.github/workflows/test-smoketests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ] # disabling windows-latest for now
-        python: [ '3.8', '3.9', '3.10', '3.11'] # disabling '3.12' for now
+        python: [ '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,11 @@ Cython>=0.29.28
 git+https://github.com/plasma-umass/crdp.git#egg=crdp
 ipython>=8.10
 Jinja2==3.0.3
-lxml==4.9.1
+lxml==5.1.0
 packaging==20.9
 psutil>=5.9.2
 pyperf==2.0.0
 rich>=10.7.0
 setuptools>=65.5.1
-pip~=21.1.2
 pynvml~=11.0.0
 wheel~=0.38.1


### PR DESCRIPTION
This PR re-enables testing with Python 3.12 and addresses the [issue](https://github.com/plasma-umass/scalene/actions/runs/7561817150/job/20591132945) that was preventing CI from passing before.

Notable changes:
`lxml` updated to latest version to enable compatibility with py3.12
`pip` version lock is removed because we are using the latest version in CI through `python -m pip install --upgrade pip`