### PR TITLE
Disable GCC's "unused-result" warnings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ C_SOURCES = src/source/*.cpp src/include/*.h*
 .PHONY: black clang-format prettier format upload vendor-deps
 
 # CXXFLAGS = -std=c++14 -g -O0 # FIXME
-CXXFLAGS = -std=c++14 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden
+CXXFLAGS = -std=c++14 -Wall -g -O3 -DNDEBUG -D_REENTRANT=1 -DHL_USE_XXREALLOC=1 -pipe -fno-builtin-malloc -fvisibility=hidden -Wno-unused-result
 # CXX = g++
 
 INCLUDES  = -Isrc -Isrc/include


### PR DESCRIPTION
GCC fails when building as it doesn't like the printf redefinition using ::write. Write apprently returns a value, even if nobody really wants it.

The addition of unused result checking caused all kinds of griping in the GCC userbase. This turns that check off globally. (Note, with the check on, the only failing line is the printf redefinition).
