### PR TITLE
Always use system browser

### DIFF
--- a/scalene/find_browser.py
+++ b/scalene/find_browser.py
@@ -1,13 +1,18 @@
 import webbrowser
 from typing import Optional
 
-
 def find_browser(browserClass=None) -> Optional[str]:
-    """Find the default system browser"""
+    """Find the default system browser, excluding text browsers.
+    
+    If you want a specific browser, pass its class as an argument."""
+    text_browsers = [
+        "browsh", "elinks", "lynx", "w3m",
+    ]
+
     try:
         # Get the default browser object
         browser = webbrowser.get(browserClass)
-        return browser.name
+        return browser.name if browser.name not in text_browsers else None
     except webbrowser.Error:
         # Return None if there is an error in getting the browser
         return None

--- a/scalene/find_browser.py
+++ b/scalene/find_browser.py
@@ -6,7 +6,7 @@ def find_browser(browserClass=None) -> Optional[str]:
     
     If you want a specific browser, pass its class as an argument."""
     text_browsers = [
-        "browsh", "elinks", "lynx", "w3m",
+        "browsh", "elinks", "links", "lynx", "w3m",
     ]
 
     try:

--- a/scalene/find_browser.py
+++ b/scalene/find_browser.py
@@ -2,34 +2,12 @@ import webbrowser
 from typing import Optional
 
 
-def find_browser() -> Optional[webbrowser.BaseBrowser]:
-    """Find the default browser if possible and if compatible."""
-    # Names of known graphical browsers as per Python's webbrowser documentation
-    graphical_browsers = [
-        "windowsdefault",
-        "macosx",
-        "safari",
-        "google-chrome",
-        "chrome",
-        "chromium",
-        "firefox",
-        "opera",
-        "edge",
-        "mozilla",
-        "netscape",
-    ]
+def find_browser(browserClass=None) -> Optional[str]:
+    """Find the default system browser"""
     try:
         # Get the default browser object
-        browser = webbrowser.get()
-        # Check if the browser's class name matches any of the known graphical browsers
-        browser_class_name = str(type(browser)).lower()
-        if any(
-            graphical_browser in browser_class_name
-            for graphical_browser in graphical_browsers
-        ):
-            return browser
-        else:
-            return None
+        browser = webbrowser.get(browserClass)
+        return browser.name
     except webbrowser.Error:
         # Return None if there is an error in getting the browser
         return None

--- a/scalene/launchbrowser.py
+++ b/scalene/launchbrowser.py
@@ -21,6 +21,32 @@ def read_file_content(directory: str, subdirectory: str, filename: str) -> str:
     file_path = os.path.join(directory, subdirectory, filename)
     return pathlib.Path(file_path).read_text()
 
+
+def launch_browser_insecure(url: str) -> None:
+    if platform.system() == 'Windows':
+        chrome_path = 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
+    elif platform.system() == 'Linux':
+        chrome_path = '/usr/bin/google-chrome'
+    elif platform.system() == 'Darwin':
+        chrome_path = '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome'
+
+    # Create a temporary directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a command with the required flags
+        chrome_cmd = f'{chrome_path} %s --disable-web-security --user-data-dir="{temp_dir}"'
+
+        # print(chrome_cmd)
+
+        # Register the new browser type
+        webbrowser.register('chrome_with_flags', None,
+                            webbrowser.Chrome(chrome_cmd), preferred=True)
+
+        # Open a URL using the new browser type
+        # url = 'https://cnn.com'  # Replace with your desired URL
+        webbrowser.get(chrome_cmd).open(url)
+        # webbrowser.get('chrome_with_flags').open(url)
+
+
 HOST = 'localhost'
 shutdown_requested = False
 last_heartbeat = time.time()

--- a/scalene/launchbrowser.py
+++ b/scalene/launchbrowser.py
@@ -21,31 +21,6 @@ def read_file_content(directory: str, subdirectory: str, filename: str) -> str:
     file_path = os.path.join(directory, subdirectory, filename)
     return pathlib.Path(file_path).read_text()
 
-
-def launch_browser_insecure(url: str) -> None:
-    if platform.system() == 'Windows':
-        chrome_path = 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
-    elif platform.system() == 'Linux':
-        chrome_path = '/usr/bin/google-chrome'
-    elif platform.system() == 'Darwin':
-        chrome_path = '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome'
-
-    # Create a temporary directory
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Create a command with the required flags
-        chrome_cmd = f'{chrome_path} %s --disable-web-security --user-data-dir="{temp_dir}"'
-
-        # print(chrome_cmd)
-
-        # Register the new browser type
-        webbrowser.register('chrome_with_flags', None, webbrowser.Chrome(chrome_cmd), preferred=True)
-
-        # Open a URL using the new browser type
-        # url = 'https://cnn.com'  # Replace with your desired URL
-        webbrowser.get(chrome_cmd).open(url)
-        # webbrowser.get('chrome_with_flags').open(url)
-        
-
 HOST = 'localhost'
 shutdown_requested = False
 last_heartbeat = time.time()


### PR DESCRIPTION
Simplifies the code by removing logic to pick from a set of known browsers. Launches using the system browser.

If this becomes a problem, we can always ask the user to supply a suitable one via the command line or print the launch URL to the console and have them click it. 

Fixes #778.