### PR TITLE
Support CUDA 12 via  pynvml 11.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ psutil>=5.9.2
 pyperf==2.0.0
 rich>=10.7.0
 setuptools>=65.5.1
-pynvml~=11.0.0
+pynvml>=11.0,<=11.5
 wheel~=0.38.1

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ install_requires_list = [
     "wheel>=0.36.1",
     "rich>=10.7.0",
     "cloudpickle>=2.2.1",
-    "pynvml>=11.0.0,<11.5",
+    "pynvml>=11.0.0,<=11.5",
     "Jinja2>=3.0.3",
     "psutil>=5.9.2"
 ]


### PR DESCRIPTION
pynvml 11.5 is backwards compatible ands supports CUDA 12. Earlier versions of scalene set <11.5 as a cutoff, this moves that up to <=11.5.

Fixes #786