### PR TITLE
Handle signals more gracefully

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -265,6 +265,7 @@ class Scalene:
     __orig_signal = signal.signal
     __orig_exit = os._exit
     __orig_raise_signal = signal.raise_signal
+    __lifecycle_disabled = False
 
     __orig_kill = os.kill
     if sys.platform != "win32":
@@ -278,6 +279,16 @@ class Scalene:
         Used by replacement_signal_fns.py to shim signals used by the client program.
         """
         return set(Scalene.__signals.get_all_signals())
+    @staticmethod
+    def get_lifecycle_signals() -> Tuple[signal.Signals, signal.Signals]:
+        return Scalene.__signals.get_lifecycle_signals()
+
+    @staticmethod
+    def disable_lifecycle():
+        Scalene.__lifecycle_disabled = True
+    @staticmethod
+    def get_lifecycle_disabled() -> bool:
+        return Scalene.__lifecycle_disabled
 
     @staticmethod
     def get_timer_signals() -> Tuple[int, signal.Signals]:

--- a/scalene/scalene_signals.py
+++ b/scalene/scalene_signals.py
@@ -57,7 +57,8 @@ class ScaleneSignals:
             Returns 2-tuple of the integers representing the CPU timer signal and the CPU signal.
         """
         return self.cpu_timer_signal, self.cpu_signal
-
+    def get_lifecycle_signals(self):
+        return (self.start_profiling_signal, self.stop_profiling_signal)
     def get_all_signals(self) -> List[int]:
         """
         Return all the signals used for controlling profiling, except the CPU timer.


### PR DESCRIPTION
Added warning message when `start_profiling_signal` and `stop_profiling_signal` are used rather than failing immediately
