### PR TITLE
Ensure --outfile isn't a directory

### DIFF
--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -37,6 +37,8 @@ class ScaleneParseArgs:
         """Replacement for sys.exit that exits cleanly from within Jupyter notebooks."""
         raise StopJupyterExecution
 
+
+
     @staticmethod
     def parse_args() -> Tuple[argparse.Namespace, List[str]]:
         # In IPython, intercept exit cleanly (because sys.exit triggers a backtrace).
@@ -352,6 +354,10 @@ for the process ID that Scalene reports. For example:
         # Parse out all Scalene arguments.
         # https://stackoverflow.com/questions/35733262/is-there-any-way-to-instruct-argparse-python-2-7-to-remove-found-arguments-fro
         args, left = parser.parse_known_args()
+
+        # Validate file/directory arguments
+        if args.outfile and os.path.isdir(args.outfile):
+            parser.error(f"outfile {args.outfile} is a directory")
 
         # Hack to simplify functionality for Windows platforms.
         if sys.platform == "win32":

--- a/test/issues/test-issue691.py
+++ b/test/issues/test-issue691.py
@@ -1,0 +1,10 @@
+import sys
+import subprocess
+import tempfile
+
+dir = tempfile.TemporaryDirectory()
+cmd = [sys.executable, "-m", "scalene", "--cli", "--outfile", dir.name, "../testme.py", "--cpu-only"]
+
+print(cmd)
+print(f'If bug 691 is fixed, you will see \n    scalene: error: outfile {dir.name} is a directory')
+proc = subprocess.run(cmd)


### PR DESCRIPTION
Adds check whether `args.outfiles` is a directory (and failing) immediately after parsing the args.

Fixes #691