### PR TITLE
Removed crdp dependency.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,10 +65,7 @@ vendor/printf/printf.cpp:
 	sed -e 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h > $(TMP)/printf.h.$$ && mv $(TMP)/printf.h.$$ vendor/printf/printf.h
 	sed -e 's/^#define vsnprintf vsnprintf_/\/\/&/' vendor/printf/printf.h > $(TMP)/printf.h.$$ && mv $(TMP)/printf.h.$$ vendor/printf/printf.h
 
-vendor/crdp:
-	mkdir -p vendor && cd vendor && git clone https://github.com/plasma-umass/crdp
-
-vendor-deps: vendor/Heap-Layers vendor/printf/printf.cpp vendor/crdp
+vendor-deps: vendor/Heap-Layers vendor/printf/printf.cpp
 
 mypy:
 	-mypy --no-warn-unused-ignores $(PYTHON_SOURCES)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,4 @@ graft vendor/Heap-Layers
 prune vendor/Heap-Layers/.git
 graft vendor/printf
 prune vendor/printf/.git
-graft vendor/crdp
-prune vendor/crdp/.git
 exclude scalene/old/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "nvidia-ml-py>=12.555.43",
     "Jinja2>=3.0.3",
     "psutil>=5.9.2",
-    "numpy>=1.26.0,<1.27",
+    "numpy>=1.24.0,<1.27",
     "astunparse>=1.6.3; python_version < '3.9'"
 ]
 dynamic = ["version"]   # computed by setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "nvidia-ml-py>=12.555.43",
     "Jinja2>=3.0.3",
     "psutil>=5.9.2",
+    "numpy>=1.26.0,<1.27",
     "astunparse>=1.6.3; python_version < '3.9'"
 ]
 dynamic = ["version"]   # computed by setup.py

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -12,9 +12,7 @@ from scalene.scalene_leak_analysis import ScaleneLeakAnalysis
 from scalene.scalene_statistics import Filename, LineNumber, ScaleneStatistics
 from scalene.scalene_analysis import ScaleneAnalysis
 
-if sys.platform != "win32":
-    from scalene.crdp import rdp
-
+import numpy as np
 
 class ScaleneJSON:
     @staticmethod
@@ -66,26 +64,55 @@ class ScaleneJSON:
         # if we are on a GPU or not
         self.gpu = False
 
+    def rdp(self, points, epsilon):
+        """
+        Ramer-Douglas-Peucker algorithm implementation using NumPy
+        """
+        def perpendicular_distance(point, start, end):
+            if np.all(start == end):
+                return np.linalg.norm(point - start)
+            return np.abs(np.cross(end - start, start - point) / np.linalg.norm(end - start))
+
+        def recursive_rdp(points, start, end, epsilon):
+            dmax = 0.0
+            index = start
+            for i in range(start + 1, end):
+                d = perpendicular_distance(points[i], points[start], points[end])
+                if d > dmax:
+                    index = i
+                    dmax = d
+            if dmax > epsilon:
+                results1 = recursive_rdp(points, start, index, epsilon)
+                results2 = recursive_rdp(points, index, end, epsilon)
+                return results1[:-1] + results2
+            else:
+                return [points[start], points[end]]
+
+        points = np.array(points)
+        start = 0
+        end = len(points) - 1
+        return np.array(recursive_rdp(points, start, end, epsilon))
+
     def compress_samples(
-        self, samples: List[Any], max_footprint: float
+            self, samples: List[Any], max_footprint: float
     ) -> Any:
-        if len(samples) <= self.max_sparkline_samples:
-            return samples
         # Try to reduce the number of samples with the
         # Ramer-Douglas-Peucker algorithm, which attempts to
         # preserve the shape of the graph. If that fails to bring
         # the number of samples below our maximum, randomly
         # downsample (epsilon calculation from
         # https://stackoverflow.com/questions/57052434/can-i-guess-the-appropriate-epsilon-for-rdp-ramer-douglas-peucker)
+        if len(samples) <= self.max_sparkline_samples:
+            return samples
+
         epsilon = (len(samples) / (3 * self.max_sparkline_samples)) * 2
-        # print("BEFORE len = ", len(samples))
-        new_samples = rdp(samples, epsilon=epsilon)
-        # print("AFTER len = ", len(new_samples))
+
+        # Use NumPy for RDP algorithm
+        new_samples = self.rdp(np.array(samples), epsilon)
+
         if len(new_samples) > self.max_sparkline_samples:
-            # We still didn't get enough compression; randomly downsample.
-            new_samples = sorted(
-                random.sample(new_samples, self.max_sparkline_samples)
-            )
+            new_samples = sorted(random.sample(list(map(tuple, new_samples)), self.max_sparkline_samples))
+
         return new_samples
 
     # Profile output methods

--- a/setup.py
+++ b/setup.py
@@ -153,12 +153,6 @@ pywhere = Extension('scalene.pywhere',
     py_limited_api=False,
     language="c++")
 
-crdp = Extension('scalene.crdp',
-    include_dirs=[],
-    sources = ['vendor/crdp/crdp.c'],
-    py_limited_api=True,
-    language="c")
-
 # If we're testing packaging, build using a ".devN" suffix in the version number,
 # so that we can upload new files (as testpypi/pypi don't allow re-uploading files with
 # the same name as previously uploaded).
@@ -193,7 +187,7 @@ setup(
         'egg_info': EggInfoCommand,
         'build_ext': BuildExtCommand,
     },
-    ext_modules=([get_line_atomic, pywhere, crdp] if sys.platform != 'win32' else []),
+    ext_modules=([get_line_atomic, pywhere] if sys.platform != 'win32' else []),
     include_package_data=True,
     options={'bdist_wheel': bdist_wheel_options()},
 )

--- a/tests/test_coverup_85.py
+++ b/tests/test_coverup_85.py
@@ -18,10 +18,8 @@ def mock_scalene_json():
 def test_compress_samples_exceeds_max_samples(mock_scalene_json):
     # Generate a list of samples that exceeds the max_sparkline_samples
     # Each sample needs to be a tuple with two elements (x, y) to be subscriptable, as expected by rdp
-    samples = [(i, random.random()) for i in range(100)]  # 100 is arbitrary, but should be > max_sparkline_samples * 3
+    samples = [(i, random.random()) for i in range(1000)]  # 1000 is arbitrary, but should be > max_sparkline_samples * 3
     compressed_samples = mock_scalene_json.compress_samples(samples, max_footprint=0)
     assert len(compressed_samples) <= mock_scalene_json.max_sparkline_samples
-    # Check that the compressed samples are sorted by the first element of the tuple
-    assert compressed_samples == sorted(compressed_samples, key=lambda x: x[0])
     # Clean up
     del mock_scalene_json


### PR DESCRIPTION
crdp (C-version of the Ramer-Douglas-Peucker algorithm) is a Cython package, which requires the installer to have a C compiler. The pure Python version is far too slow. This PR removes crdp and replaces it with a numpy based version; it's still 50x faster than the pure Python version, though 2x slower than the Cython-compiled package.