### PR TITLE
Fix CPU-only profiling failing with "AttributeError: module 'pynvml' …

### DIFF
--- a/scalene/scalene_gpu.py
+++ b/scalene/scalene_gpu.py
@@ -92,7 +92,7 @@ class ScaleneGPU:
             else:
                 try:
                     utilization += pynvml.nvmlDeviceGetUtilizationRates(h).gpu
-                except pynvml.nvml.NVMLError_Unknown:
+                except pynvml.NVMLError_Unknown:
                     # Silently ignore NVML errors. "Fixes" https://github.com/plasma-umass/scalene/issues/471.
                     pass
         return (utilization / ngpus) / 100.0


### PR DESCRIPTION
…has no attribute 'nvml'"

The error suppression does not work for an environment with `nvidia-ml-py==12.555.43` and `nvidia-ml-py3==7.352.0`