### PR TITLE
Remove setuptools pin from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ scalene = "scalene.__main__:main"
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=65.5.1,<71.0", # Pin to setuptools<71.0 to avoid this bug: https://github.com/pypa/setuptools/issues/4496
+    "setuptools>=65.5.0",
     "setuptools_scm>=8",
     "wheel",
     "cython",


### PR DESCRIPTION
Missed this one: need to change in both requirements and pyproject.