### PR TITLE
record the fully_qualified_name when using --stacks

### DIFF
--- a/scalene/scalene_utility.py
+++ b/scalene/scalene_utility.py
@@ -30,7 +30,7 @@ def add_stack(
     f: Optional[FrameType] = frame
     while f:
         if should_trace(Filename(f.f_code.co_filename), f.f_code.co_name):
-            stk.insert(0, (f.f_code.co_filename, f.f_code.co_name, f.f_lineno))
+            stk.insert(0, (f.f_code.co_filename, get_fully_qualified_name(f), f.f_lineno))
         f = f.f_back
     if tuple(stk) not in stacks:
         stacks[tuple(stk)] = (1, python_time, c_time, cpu_samples)


### PR DESCRIPTION
As the title says, this PR make sure to record the fully qualified name of a function when saving data with `--stacks`.

It seems a good idea by itself, but in addition let me explain what is my personal use case for that.

I'd like to produce *per-function* flamegraphs: i.e., I want to ignore the line number reported by a each sample and consider only the function.

The problem is that the current code saves `co_name`, but in case of multiple function with the same name, there is no easy way to distinguish them [1]. This is something which happens quite often in case of a method overridden in multiple subclasses.

([1] I know that there are "hard ways": I could e.g. use the line number and walk backwards in the source code until I find a `def` statement, but this is slow, complicated and error-prone.)

An example if better than thousands words. This is the code which I use for generating the flamegraphs:
```python
"""
To create a flamegraph:

$ python -m scalene --json --no-browser --stacks --cpu-sampling-rate 0.001 richards.py
$ python foldstack.py profile.json | /tmp/FlameGraph/flamegraph.pl > flamegraph.html
"""

import sys
import json

def main():
    fname = sys.argv[1]
    with open(fname) as f:
        data = json.load(f)

    for frames, stats in data['stacks']:
        count, py_time, c_time, cpu_samples = stats
        lines = [f'{fn}:{filename}' for filename, fn, lineno in frames]
        folded = ';'.join(lines)
        print(f'{folded} {count}')

if __name__ == '__main__':
    main()
```

I have tried it on the venerable [richards.py](https://gist.github.com/antocuni/aac6bc866c9e46f2a423b9f1e58ca796#file-richards-py).

This is what I get on master: note that all the `fn` functions are folded into a single one:
![image](https://github.com/user-attachments/assets/5155dc14-f7c7-4b83-9210-c26b773da9ca)

This is what I get on my branch: all the `fn` functions are correctly separated and reported as `DeviceTask.fn`, `HandlerTask.fn`, etc.:
![image](https://github.com/user-attachments/assets/682685d4-ae8b-4448-8215-3dde546e0c17)

Tried this with Python 3.12.
All the code and the HTML output of both flamegraphs are available in this gist:
https://gist.github.com/antocuni/aac6bc866c9e46f2a423b9f1e58ca796