### PR TITLE
WIP: ensure LD_PRELOAD never has any spaces

### DIFF
--- a/scalene/scalene_preload.py
+++ b/scalene/scalene_preload.py
@@ -37,12 +37,13 @@ class ScalenePreload:
             if args.memory:
                 # Prepend the Scalene library to the LD_PRELOAD list, if any
                 libscalene_path = os.path.join(
-                    scalene.__path__[0].replace(" ", r"\ "), "libscalene.so"
+                    scalene.__path__[0], "libscalene.so"
                 )
                 # create symlink to libscalene.so in a temporary directory
-                os.symlink(libscalene_path, new_ld_preload)
                 new_ld_preload = os.path.join(scalene_link_dir.name, "libscalene.so")
 
+                os.symlink(libscalene_path, new_ld_preload)
+            
                 if "LD_PRELOAD" in env:
                     old_ld_preload = env["LD_PRELOAD"]
                     env["LD_PRELOAD"] = new_ld_preload + ":" + old_ld_preload

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -751,7 +751,9 @@ class Scalene:
             # Add the --pid field so we can propagate it to the child.
             cmdline += f" --pid={os.getpid()} ---"
             # Build the commands to pass along other arguments
-            environ = ScalenePreload.get_preload_environ(Scalene.__args)
+            libscalene_link_dir = tempfile.TemporaryDirectory()
+
+            environ = ScalenePreload.get_preload_environ(Scalene.__args, libscalene_link_dir)
             if sys.platform == "win32":
                 preface = "\n".join(
                     f"set {k}={str(v)}\n" for (k, v) in environ.items()


### PR DESCRIPTION
Will fix #400. @whinee presented [a theory](https://github.com/plasma-umass/scalene/issues/400#issuecomment-2335178806) that the issue was being caused by some irregular argument parsing that ended up splitting LD_PRELOAD on spaces. Whinee pointed to [a stack overflow thread](https://stackoverflow.com/questions/10072609/how-to-escape-spaces-in-library-path-appended-to-ld-preload/10073337#10073337) which in turn pointed to [a thread on ubuntuforms](https://ubuntuforums.org/showthread.php?t=1142062), which confirms that LD_PRELOAD cannot have spaces in it. One proposed fix is to make a symlink to the library, which is what I am attempting.