### PR TITLE
Fixed LD_LIBRARY_PATH squashing

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -760,7 +760,7 @@ class Scalene:
                 )
             else:
                 preface = " ".join(
-                    "=".join((k, str(v))) for (k, v) in environ.items()
+                    "=".join((k, f"'{str(v)}'")) for (k, v) in environ.items()
                 )
 
             Scalene.__orig_python = redirect_python(

--- a/tests/test_coverup_5.py
+++ b/tests/test_coverup_5.py
@@ -39,7 +39,7 @@ def test_get_preload_environ_linux_memory(args, clean_environ):
             env = scalene.scalene_preload.ScalenePreload.get_preload_environ(args)
             assert 'LD_PRELOAD' in env
             assert 'libscalene.so' in env['LD_PRELOAD']
-            assert 'PYTHONMALLOC' not in env
+            assert env['PYTHONMALLOC'] == 'default'
 
 def test_get_preload_environ_linux_no_memory(args, clean_environ):
     


### PR DESCRIPTION
Because of how the current environment is checked, `LD_LIBRARY_PATH` and `LD_PRELOAD` are squashed if present, rather than prepended to. This commit prevents this.

Also preemptively fixed a potential issue where `PYTHONMALLOC` would not be properly squashed if present. 