### PR TITLE
Fix module import issues for deeply nested modules (e.g., x.y.z).

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -2123,7 +2123,7 @@ class Scalene:
                     the_globals["__spec__"] = None
                     if spec is not None:
                         name = spec.name
-                        the_globals["__package__"] = name.split(".")[0]
+                        the_globals["__package__"] = name.rsplit(".", 1)[0]
                     # Do a GC before we start.
                     gc.collect()
                     # Start the profiler.


### PR DESCRIPTION
Turns out the issue https://github.com/plasma-umass/scalene/issues/539 still persists for deeply nested modules, e.g.:
```
scalene -m x.y.z
```
This PR fixes this behaviour by enhancing the solution introduced in https://github.com/plasma-umass/scalene/pull/646
