### PR TITLE
Import `ctypes` early

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -29,6 +29,7 @@ import argparse
 import atexit
 import builtins
 import contextlib
+import ctypes # noqa: F401
 import functools
 import gc
 import inspect


### PR DESCRIPTION
Scalene apparently needs to import `ctypes` early or some breakage occurs because of the change to `sys.executable` (needed to support multiprocessing). This fixes  https://github.com/plasma-umass/scalene/issues/894.