### PR TITLE
Handle missing temp files during output without crashing

### DIFF
--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -373,7 +373,10 @@ class ScaleneOutput:
                     ),
                 )
 
-        null = tempfile.TemporaryFile(mode="w+")
+        try: 
+            null = tempfile.TemporaryFile(mode="w+")
+        except FileNotFoundError:
+            null = open(os.devnull, "w")
 
         console = Console(
             width=column_width,


### PR DESCRIPTION
Scalene currently crashes during output step after successful profiling if temp files have been removed; this makes it difficult to use with any libraries that clean their own temp files. Suggest try/except to still proceed even if a temp file is missing.

On second thought I'm not actually sure if this will fix the similar issue that I linked in the commit; but it did fix an issue I encountered where scalene would crash when running on a program that used pybedtools.