### PR TITLE
fix_args_list_if_none

### DIFF
--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -89,7 +89,7 @@ class FileDetail(BaseModel):
 
 class ScaleneJSONSchema(BaseModel):
     alloc_samples: NonNegativeInt
-    args: List[str]
+    args: Optional[List[str]]
     elapsed_time_sec: NonNegativeFloat
     entrypoint_dir: str
     filename: str


### PR DESCRIPTION
fix error:
scalene --cli --json --outfile scalene_aggregator.json --profile-interval 60 main.py

pipeline-1  | Warning: JSON failed validation:
pipeline-1  | 1 validation error for ScaleneJSONSchema
pipeline-1  | args
pipeline-1  |   Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
pipeline-1  |     For further information visit https://errors.pydantic.dev/2.10/v/list_type
