### PR TITLE
Fix crash when frame.f_lineno is None in Python 3.11+

### DIFF
--- a/scalene/scalene_cpu_profiler.py
+++ b/scalene/scalene_cpu_profiler.py
@@ -117,7 +117,7 @@ class ScaleneCPUProfiler:
 
         enter_function_meta(main_thread_frame, should_trace, self._stats)
         fname = Filename(main_thread_frame.f_code.co_filename)
-        lineno = LineNumber(main_thread_frame.f_lineno)
+        lineno = LineNumber(main_thread_frame.f_lineno) if main_thread_frame.f_lineno is not None else LineNumber(main_thread_frame.f_code.co_firstlineno)
 
         main_tid = cast(int, threading.main_thread().ident)
         if not is_thread_sleeping[main_tid]:
@@ -150,7 +150,7 @@ class ScaleneCPUProfiler:
             )
 
             fname = Filename(frame.f_code.co_filename)
-            lineno = LineNumber(frame.f_lineno)
+            lineno = LineNumber(frame.f_lineno) if frame.f_lineno is not None else LineNumber(frame.f_code.co_firstlineno)
             enter_function_meta(frame, should_trace, self._stats)
 
             if is_thread_sleeping[tident]:

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -629,7 +629,7 @@ class Scalene:
         # made the object held in `pywhere.cpp` out of date, and caused the profiler to not update the last profiled line.
         Scalene.__last_profiled[:] = [
             Filename(f.f_code.co_filename),
-            LineNumber(f.f_lineno),
+            LineNumber(f.f_lineno) if f.f_lineno is not None else LineNumber(f.f_code.co_firstlineno),
             ByteCodeIndex(f.f_lasti),
         ]
         Scalene.__alloc_sigq.put([0])

--- a/scalene/scalene_utility.py
+++ b/scalene/scalene_utility.py
@@ -32,7 +32,7 @@ def enter_function_meta(
 ) -> None:
     """Update tracking info so we can correctly report line number info later."""
     fname = Filename(frame.f_code.co_filename)
-    lineno = LineNumber(frame.f_lineno)
+    lineno = LineNumber(frame.f_lineno) if frame.f_lineno is not None else LineNumber(frame.f_code.co_firstlineno)
 
     f = frame
     try:
@@ -134,7 +134,7 @@ def add_stack(
                 StackFrame(
                     filename=str(f.f_code.co_filename),
                     function_name=str(get_fully_qualified_name(f)),
-                    line_number=int(f.f_lineno),
+                    line_number=int(f.f_lineno) if f.f_lineno is not None else int(f.f_code.co_firstlineno),
                 ),
             )
         f = f.f_back


### PR DESCRIPTION
## Summary

Fixes #975

This PR fixes a crash that occurs when profiling multiprocessing workloads on Python 3.11+.

## Problem

In Python 3.11+, `frame.f_lineno` can return `None` in certain edge cases, particularly:
- When frames are accessed after a process terminates during multiprocessing operations
- When frames go out of scope in rare timing conditions

This caused a `TypeError` crash:
```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

The crash occurred at `scalene_utility.py:137` in the `add_stack()` function when attempting to convert `f.f_lineno` to an integer.

## Solution

Added null checks with fallback to `f.f_code.co_firstlineno` (the function's first line number) in all locations where `f_lineno` is accessed:

| File | Function | Line |
|------|----------|------|
| `scalene_utility.py` | `enter_function_meta()` | 35 |
| `scalene_utility.py` | `add_stack()` | 137 |
| `scalene_cpu_profiler.py` | CPU signal handler (main thread) | 120 |
| `scalene_cpu_profiler.py` | CPU signal handler (other threads) | 153 |
| `scalene_profiler.py` | `alloc_signal_handler()` | 632 |

The fix uses the pattern:
```python
f.f_lineno if f.f_lineno is not None else f.f_code.co_firstlineno
```

This provides a reasonable approximation (the function's first line number) rather than crashing. While not perfectly accurate, it's preferable to crashing and is consistent with how Python itself handles this edge case internally.

## Testing

- All existing tests pass (169 passed, 1 skipped)
- Linting passes (mypy, ruff)

## References

- Issue: #975
- Python 3.11 changed frame semantics: [What's New in Python 3.11](https://docs.python.org/3/whatsnew/3.11.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)