### PR TITLE
Refined attribution approach for C vs. Python

### DIFF
--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -333,7 +333,9 @@ class Scalene:
             cpu_count = os.cpu_count()
             Scalene.__availableCPUs = cpu_count if cpu_count is not None else 1
         Scalene.__cpu_profiler = ScaleneCPUProfiler(
-            Scalene.__stats, Scalene.__availableCPUs
+            Scalene.__stats,
+            Scalene.__availableCPUs,
+            Scalene.__args.use_virtual_time,
         )
         Scalene.__tracing = ScaleneTracing(
             Scalene.__args,


### PR DESCRIPTION
Corrects attribution of native time for short-lived native calls by checking to see if the last instruction was a CALL.

Fixes https://github.com/plasma-umass/scalene/issues/999.