### PR TITLE
Fix Python 3.14 compatibility for eval()/exec() keyword arguments

### DIFF
--- a/scalene/replacement_exec.py
+++ b/scalene/replacement_exec.py
@@ -58,15 +58,19 @@ def replacement_exec(scalene: Scalene) -> None:  # noqa: ARG001
 
     def exec_replacement(
         __source: Any,
-        __globals: Optional[Dict[str, Any]] = None,
-        __locals: Optional[Dict[str, Any]] = None,
         /,
+        globals: Optional[Dict[str, Any]] = None,
+        locals: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         """Replacement for exec() that tracks source code.
 
         When given a string, we compile it with a unique virtual filename
         and register the source in linecache for profiling.
+
+        Note: In Python 3.14+, exec() accepts globals/locals as keyword arguments,
+        plus a keyword-only 'closure' parameter. We use 'globals' and 'locals'
+        as parameter names (shadowing builtins) to match the built-in signature.
         """
         # Get caller frame - needed both for virtual filename and for
         # getting globals/locals when not provided
@@ -80,26 +84,30 @@ def replacement_exec(scalene: Scalene) -> None:  # noqa: ARG001
 
         # When globals/locals are not specified, exec() uses the caller's frame.
         # Since we're wrapping exec, we need to explicitly get the caller's frame.
-        if __globals is None:
-            __globals = caller_frame.f_globals
-            if __locals is None:
-                __locals = caller_frame.f_locals
+        if globals is None:
+            globals = caller_frame.f_globals
+            if locals is None:
+                locals = caller_frame.f_locals
 
-        if __locals is None:
-            orig_exec(__source, __globals)
+        if locals is None:
+            orig_exec(__source, globals, **kwargs)
         else:
-            orig_exec(__source, __globals, __locals, **kwargs)
+            orig_exec(__source, globals, locals, **kwargs)
 
     def eval_replacement(
         __source: Any,
-        __globals: Optional[Dict[str, Any]] = None,
-        __locals: Optional[Dict[str, Any]] = None,
         /,
+        globals: Optional[Dict[str, Any]] = None,
+        locals: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """Replacement for eval() that tracks source code.
 
         When given a string, we compile it with a unique virtual filename
         and register the source in linecache for profiling.
+
+        Note: In Python 3.14+, eval() accepts globals/locals as keyword arguments.
+        We use 'globals' and 'locals' as parameter names (shadowing builtins)
+        to match the built-in signature exactly.
         """
         # Get caller frame - needed both for virtual filename and for
         # getting globals/locals when not provided
@@ -113,15 +121,15 @@ def replacement_exec(scalene: Scalene) -> None:  # noqa: ARG001
 
         # When globals/locals are not specified, eval() uses the caller's frame.
         # Since we're wrapping eval, we need to explicitly get the caller's frame.
-        if __globals is None:
-            __globals = caller_frame.f_globals
-            if __locals is None:
-                __locals = caller_frame.f_locals
+        if globals is None:
+            globals = caller_frame.f_globals
+            if locals is None:
+                locals = caller_frame.f_locals
 
-        if __locals is None:
-            return orig_eval(__source, __globals)
+        if locals is None:
+            return orig_eval(__source, globals)
         else:
-            return orig_eval(__source, __globals, __locals)
+            return orig_eval(__source, globals, locals)
 
     def compile_replacement(
         source: Any,

--- a/scalene/replacement_signal_fns.py
+++ b/scalene/replacement_signal_fns.py
@@ -1,7 +1,7 @@
 import os
 import signal
 import sys
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 from scalene.scalene_profiler import Scalene
 
@@ -27,7 +27,7 @@ def replacement_signal_fns(scalene: Scalene) -> None:
         new_cpu_signal = signal.SIGFPE
 
     # Track which warnings we've already printed to avoid spam
-    _warned_signals: set[int] = set()
+    _warned_signals: Set[int] = set()
 
     # On Linux, we can use real-time signals (SIGRTMIN+n) for cleaner signal redirection.
     # Real-time signals are guaranteed to be delivered and queued, and are rarely used by libraries.
@@ -36,7 +36,7 @@ def replacement_signal_fns(scalene: Scalene) -> None:
 
     # Map original signals to their alternate (redirected) signals
     # On Linux: use real-time signals; on other platforms: None (use chaining)
-    _signal_redirects: dict[int, int] = {}
+    _signal_redirects: Dict[int, int] = {}
     if _use_rt_signals:
         # Allocate real-time signals for each Scalene signal that might conflict
         # SIGRTMIN+0 is often used by threading libraries, so start from SIGRTMIN+1
@@ -57,7 +57,7 @@ def replacement_signal_fns(scalene: Scalene) -> None:
 
     # Store chained handlers for platforms without real-time signal support
     # Maps signal number -> user's handler
-    _chained_handlers: dict[int, Any] = {}
+    _chained_handlers: Dict[int, Any] = {}
 
     def _make_chained_handler(scalene_handler: Any, user_handler: Any) -> Any:
         """Create a handler that calls both Scalene's handler and the user's handler."""

--- a/scalene/scalene_funcutils.py
+++ b/scalene/scalene_funcutils.py
@@ -2,7 +2,7 @@ import dis
 import sys
 from functools import lru_cache
 from types import CodeType
-from typing import FrozenSet, Optional
+from typing import FrozenSet, List, Optional, Set, Tuple
 
 from scalene.scalene_statistics import ByteCodeIndex
 
@@ -37,7 +37,7 @@ class ScaleneFuncUtils:
 
     @staticmethod
     @lru_cache(maxsize=None)
-    def get_loop_body_lines(code: CodeType, lineno: int) -> Optional[tuple[int, ...]]:
+    def get_loop_body_lines(code: CodeType, lineno: int) -> Optional[Tuple[int, ...]]:
         """Return all lines of the innermost loop whose first body line is *lineno*.
 
         When CPython's eval-breaker fires at a backward jump instruction
@@ -48,7 +48,7 @@ class ScaleneFuncUtils:
 
         Returns ``None`` if *lineno* is not the first body line of any loop.
         """
-        best: Optional[tuple[int, ...]] = None
+        best: Optional[Tuple[int, ...]] = None
         all_instrs = ScaleneFuncUtils._instructions_with_lines(code)
 
         for instr, _ in all_instrs:
@@ -63,8 +63,8 @@ class ScaleneFuncUtils:
 
             # Collect distinct source lines in [target, instr.offset]
             # and check whether any CALL instructions appear in the body.
-            lines: list[int] = []
-            seen: set[int] = set()
+            lines: List[int] = []
+            seen: Set[int] = set()
             has_call = False
             for i2, line in all_instrs:
                 if i2.offset < target:
@@ -116,14 +116,14 @@ class ScaleneFuncUtils:
     @staticmethod
     def _instructions_with_lines(
         code: CodeType,
-    ) -> list[tuple[dis.Instruction, Optional[int]]]:
+    ) -> List[Tuple[dis.Instruction, Optional[int]]]:
         """Return instructions paired with their effective line number.
 
         On Python < 3.13, ``starts_line`` is only set on the first
         instruction of each source line.  This helper propagates the
         line forward so every instruction has a line number.
         """
-        result: list[tuple[dis.Instruction, Optional[int]]] = []
+        result: List[Tuple[dis.Instruction, Optional[int]]] = []
         current_line: Optional[int] = None
         for instr in dis.get_instructions(code):
             line = ScaleneFuncUtils._instr_line(instr)

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 from textwrap import dedent
-from typing import Any, List, NoReturn, Optional, Tuple, Union
+from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
 
 import yaml
 from rich.text import Text as RichText
@@ -160,7 +160,7 @@ class ScaleneParseArgs:
     }
 
     @staticmethod
-    def _load_config_file(config_path: str) -> dict[str, Any]:
+    def _load_config_file(config_path: str) -> Dict[str, Any]:
         """Load and parse a YAML configuration file.
 
         Args:
@@ -196,7 +196,7 @@ class ScaleneParseArgs:
         return config
 
     @staticmethod
-    def _apply_config_to_args(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    def _apply_config_to_args(args: argparse.Namespace, config: Dict[str, Any]) -> None:
         """Apply configuration from a YAML file to parsed arguments.
 
         Config file values are used as defaults - command line arguments take precedence.
@@ -559,7 +559,7 @@ class ScaleneParseArgs:
 
     @staticmethod
     def _display_profile_cli(
-        profile_data: dict[str, Any],
+        profile_data: Dict[str, Any],
         column_width: int = 132,
         reduced_profile: bool = False,
     ) -> None:
@@ -847,7 +847,7 @@ class ScaleneParseArgs:
                 highlighted_line = Text.from_ansi(capture.get().rstrip())
 
                 # Build row based on what was profiled
-                row: list[Any] = [str(lineno), python_str, native_str, sys_str]
+                row: List[Any] = [str(lineno), python_str, native_str, sys_str]
 
                 if has_gpu:
                     row.append(gpu_str)

--- a/scalene/scalene_signal_manager.py
+++ b/scalene/scalene_signal_manager.py
@@ -11,7 +11,7 @@ import signal
 import sys
 import threading
 import time
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, Optional, Set, TypeVar
 
 from scalene.scalene_signals import ScaleneSignals, SignalHandlerFunction
 from scalene.scalene_sigqueue import ScaleneSigQueue
@@ -231,7 +231,7 @@ class ScaleneSignalManager(Generic[T]):
         self.__orig_signal(signal.SIGINT, interruption_handler)
 
     def send_signal_to_children(
-        self, child_pids: "set[int]", signal_type: signal.Signals
+        self, child_pids: "Set[int]", signal_type: signal.Signals
     ) -> None:
         """Send a signal to all child processes."""
         for pid in child_pids:

--- a/scalene/sorted_reservoir.py
+++ b/scalene/sorted_reservoir.py
@@ -1,7 +1,7 @@
 import math
 import random
 import sys
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Union
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -53,7 +53,7 @@ class sorted_reservoir:
         """Return the number of items currently in the reservoir."""
         return self.count
 
-    def __iadd__(self: Self, other: "sorted_reservoir | List[Any]") -> Self:
+    def __iadd__(self: Self, other: "Union[sorted_reservoir, List[Any]]") -> Self:
         """Merge another reservoir or list into this one via repeated append."""
         items = other.reservoir_ if isinstance(other, sorted_reservoir) else other
         for item in items:
@@ -61,7 +61,7 @@ class sorted_reservoir:
         return self
 
     @property
-    def reservoir(self: Self) -> "list[Any]":
+    def reservoir(self: Self) -> "List[Any]":
         """Returns a sorted reservoir."""
         if not self.sorted_:
             self.reservoir_ = sorted(self.reservoir_, key=self.key)


### PR DESCRIPTION
## Summary

- Fix Python 3.14 compatibility issue where `eval()` and `exec()` replacements failed when called with keyword arguments
- Python 3.14 changed signatures to `eval(source, /, globals=None, locals=None)` allowing keyword args
- Fix type annotation compatibility for Python 3.8/3.9 using `typing` module generics

Fixes #1000

## Changes

**`replacement_exec.py`**:
- Updated `eval_replacement` and `exec_replacement` signatures to accept `globals` and `locals` as keyword arguments (matching Python 3.14's built-in signatures)

**Type annotation fixes** (for Python 3.8/3.9 compatibility):
- `sorted_reservoir.py`: `list[Any]` → `List[Any]`, `X | Y` → `Union[X, Y]`
- `scalene_signal_manager.py`: `set[int]` → `Set[int]`
- `replacement_signal_fns.py`: `set[int]` → `Set[int]`, `dict[...]` → `Dict[...]`
- `scalene_funcutils.py`: `tuple[...]` → `Tuple[...]`, `list[...]` → `List[...]`, `set[...]` → `Set[...]`
- `scalene_parseargs.py`: `dict[...]` → `Dict[...]`, `list[...]` → `List[...]`

## Test plan

- [x] All 256 existing tests pass
- [x] Ruff linter passes
- [x] Verified Python 3.14 keyword argument pattern works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)