### PR TITLE
Fix memory explosion and extreme slowness during profiling

### DIFF
--- a/benchmarks/bench_torch_memory.py
+++ b/benchmarks/bench_torch_memory.py
@@ -1,0 +1,64 @@
+"""Torch-heavy workload that exposes profiler memory explosion (#991).
+
+Run under Scalene to observe memory behaviour:
+
+    scalene run benchmarks/bench_torch_memory.py
+
+On master (before the fix), the Scalene process RSS grows continuously
+because:
+  1. torch.profiler accumulates events with full Python stacks for
+     every torch operation for the entire profiling duration.
+  2. cpu_samples_list appends a wallclock timestamp on every CPU sample
+     without any bound.
+
+After the fix, both are bounded via reservoir sampling / periodic
+profiler flushing, so RSS stays roughly constant.
+
+Use ``benchmarks/measure_profiler_memory.py`` to automatically measure
+and compare peak RSS.
+"""
+
+import sys
+import time
+
+try:
+    import torch
+except ImportError:
+    print("ERROR: PyTorch is required.  pip install torch", file=sys.stderr)
+    sys.exit(1)
+
+DURATION_SECONDS = 60  # wall-clock runtime (longer = more event accumulation)
+MATRIX_SIZE = 256      # small matrices -> many ops per second
+
+
+def main() -> None:
+    print(f"Running torch workload for ~{DURATION_SECONDS}s "
+          f"(matrix size {MATRIX_SIZE}) ...")
+
+    ops = 0
+    t0 = time.perf_counter()
+    deadline = t0 + DURATION_SECONDS
+
+    a = torch.randn(MATRIX_SIZE, MATRIX_SIZE)
+    b = torch.randn(MATRIX_SIZE, MATRIX_SIZE)
+
+    while time.perf_counter() < deadline:
+        # Each iteration generates multiple torch profiler events
+        c = a @ b
+        c = c + a
+        c = c.relu()
+        a, b = b, c
+        ops += 3  # matmul + add + relu
+
+        # Re-normalise occasionally to avoid overflow / underflow
+        if ops % 3000 == 0:
+            a = torch.randn(MATRIX_SIZE, MATRIX_SIZE)
+            b = torch.randn(MATRIX_SIZE, MATRIX_SIZE)
+
+    elapsed = time.perf_counter() - t0
+    print(f"Completed {ops:,} torch ops in {elapsed:.1f}s "
+          f"({ops / elapsed:,.0f} ops/s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/measure_profiler_memory.py
+++ b/benchmarks/measure_profiler_memory.py
@@ -1,0 +1,215 @@
+"""Measure Scalene's peak RSS while profiling a torch-heavy workload.
+
+Usage
+-----
+    # On the current branch (should be the fix branch):
+    python benchmarks/measure_profiler_memory.py
+
+    # Compare against master:
+    python benchmarks/measure_profiler_memory.py --compare-master
+
+The ``--compare-master`` flag will:
+  1. Run the benchmark on the *current* branch and record peak RSS.
+  2. Check out ``master``, run the benchmark again, then restore the
+     original branch.
+  3. Print a side-by-side comparison.
+
+Without the flag it simply profiles and reports peak RSS for the
+current checkout.
+
+Requirements: torch (``pip install torch``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import resource
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+BENCH_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "bench_torch_memory.py")
+SAMPLE_INTERVAL = 0.5  # seconds between RSS samples
+
+
+# --- RSS monitoring ----------------------------------------------------------
+
+def _get_rss_mb(pid: int) -> float | None:
+    """Return the RSS of *pid* in MiB, or None if unavailable."""
+    try:
+        if platform.system() == "Darwin":
+            # macOS: use ps (reading /proc is not available)
+            out = subprocess.check_output(
+                ["ps", "-o", "rss=", "-p", str(pid)],
+                stderr=subprocess.DEVNULL,
+            )
+            return int(out.strip()) / 1024  # ps reports KiB on macOS
+        else:
+            # Linux: read from /proc
+            with open(f"/proc/{pid}/status") as f:
+                for line in f:
+                    if line.startswith("VmRSS:"):
+                        return int(line.split()[1]) / 1024  # KiB -> MiB
+    except (subprocess.CalledProcessError, FileNotFoundError, ProcessLookupError,
+            ValueError, OSError):
+        pass
+    return None
+
+
+class RSSMonitor:
+    """Sample RSS of a subprocess at regular intervals in a background thread."""
+
+    def __init__(self, pid: int, interval: float = SAMPLE_INTERVAL) -> None:
+        self.pid = pid
+        self.interval = interval
+        self.samples: list[float] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            rss = _get_rss_mb(self.pid)
+            if rss is not None:
+                self.samples.append(rss)
+            self._stop.wait(self.interval)
+
+    @property
+    def peak_mb(self) -> float:
+        return max(self.samples) if self.samples else 0.0
+
+    @property
+    def final_mb(self) -> float:
+        return self.samples[-1] if self.samples else 0.0
+
+
+# --- Run benchmark under Scalene --------------------------------------------
+
+def run_scalene_benchmark(bench_script: str) -> tuple[float, float, float]:
+    """Profile the workload with Scalene and return (peak_rss_mb, final_rss_mb, elapsed_s)."""
+    # Run in a temp dir so scalene-profile.json doesn't pollute the repo
+    work_dir = tempfile.mkdtemp(prefix="scalene-bench-")
+    cmd = [
+        sys.executable, "-m", "scalene", "run",
+        bench_script,
+    ]
+    print(f"  Command: {' '.join(cmd)}")
+    t0 = time.perf_counter()
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=work_dir,
+    )
+    monitor = RSSMonitor(proc.pid)
+    monitor.start()
+    stdout, _ = proc.communicate()
+    monitor.stop()
+    elapsed = time.perf_counter() - t0
+
+    # Print the workload output (indented)
+    for line in stdout.decode(errors="replace").splitlines():
+        print(f"    {line}")
+
+    # Also grab rusage as a cross-check
+    rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    rusage_bytes = rusage.ru_maxrss
+    if platform.system() != "Darwin":
+        # Linux reports KiB; convert to bytes
+        rusage_bytes *= 1024
+    rusage_mib = rusage_bytes / (1024 * 1024)
+
+    print(f"  RSS samples collected: {len(monitor.samples)}")
+    print(f"  Peak RSS (sampled):  {monitor.peak_mb:,.1f} MiB")
+    print(f"  Final RSS (sampled): {monitor.final_mb:,.1f} MiB")
+    print(f"  Peak RSS (rusage):   {rusage_mib:,.1f} MiB")
+    print(f"  Wall time:           {elapsed:.1f}s")
+
+    # Clean up temp dir
+    shutil.rmtree(work_dir, ignore_errors=True)
+
+    return monitor.peak_mb, monitor.final_mb, elapsed
+
+
+# --- Git helpers for --compare-master ----------------------------------------
+
+def git(*args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args], stderr=subprocess.STDOUT,
+    ).decode().strip()
+
+
+def compare_master() -> None:
+    original_branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    print(f"Current branch: {original_branch}\n")
+
+    # Copy the benchmark script to a temp file so it's available on both branches
+    tmp_fd, tmp_bench_name = tempfile.mkstemp(prefix="bench_torch_memory_", suffix=".py")
+    os.close(tmp_fd)
+    try:
+        shutil.copy2(BENCH_SCRIPT, tmp_bench_name)
+
+        # --- Run on current branch -------------------------------------------
+        print(f"=== Benchmarking on {original_branch} ===")
+        fix_peak, fix_final, fix_elapsed = run_scalene_benchmark(tmp_bench_name)
+
+        # --- Switch to master ------------------------------------------------
+        print()
+        print("=== Benchmarking on master ===")
+        git("checkout", "master")
+        try:
+            master_peak, master_final, master_elapsed = run_scalene_benchmark(tmp_bench_name)
+        finally:
+            # Always restore original branch
+            print(f"\nRestoring branch {original_branch} ...")
+            git("checkout", original_branch)
+    finally:
+        os.unlink(tmp_bench_name)
+
+    # --- Report --------------------------------------------------------------
+    print()
+    print("=" * 60)
+    print(f"{'':30s} {'master':>12s}  {'fix':>12s}")
+    print("-" * 60)
+    print(f"{'Peak RSS (MiB)':30s} {master_peak:12,.1f}  {fix_peak:12,.1f}")
+    print(f"{'Final RSS (MiB)':30s} {master_final:12,.1f}  {fix_final:12,.1f}")
+    print(f"{'Wall time (s)':30s} {master_elapsed:12.1f}  {fix_elapsed:12.1f}")
+    if master_peak > 0:
+        reduction = (1 - fix_peak / master_peak) * 100
+        print(f"{'Peak RSS reduction':30s} {reduction:11.1f}%")
+    print("=" * 60)
+
+
+# --- Main --------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--compare-master", action="store_true",
+        help="Run on both the current branch and master, then compare.",
+    )
+    args = parser.parse_args()
+
+    if args.compare_master:
+        compare_master()
+    else:
+        print("=== Benchmarking on current checkout ===")
+        run_scalene_benchmark(BENCH_SCRIPT)
+
+
+if __name__ == "__main__":
+    main()

--- a/scalene/scalene_config.py
+++ b/scalene/scalene_config.py
@@ -12,3 +12,8 @@ NEWLINE_TRIGGER_LENGTH = 98820  # SampleHeap<...>::NEWLINE-1
 # Maximum number of memory footprint samples to retain (via reservoir sampling).
 # Used for both global and per-line memory sparklines.
 MEMORY_FOOTPRINT_RESERVOIR_SIZE = 100
+
+# Maximum number of CPU wallclock timestamp samples to retain per line
+# (via reservoir sampling). Bounds memory when CPU profiling runs for
+# a long time. See https://github.com/plasma-umass/scalene/issues/991
+CPU_SAMPLES_RESERVOIR_SIZE = 500

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -342,7 +342,7 @@ class ScaleneJSON:
             "line": line,
             "lineno": line_no,
             "memory_samples": per_line_samples,
-            "cpu_samples_list": stats.cpu_stats.cpu_samples_list[fname][line_no],
+            "cpu_samples_list": stats.cpu_stats.cpu_samples_list[fname][line_no].reservoir,
             "n_avg_mb": n_avg_mb,
             "n_copy_mb_s": n_copy_mb_s,
             "n_core_utilization": mean_core_util,

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -754,6 +754,12 @@ class Scalene:
                 Scalene.__last_signal_time,
                 Scalene.__is_thread_sleeping,
             )
+            # Advance library profiler schedules (e.g., torch profiler
+            # periodic flush) to keep memory bounded.
+            # See https://github.com/plasma-umass/scalene/issues/991
+            if Scalene.__torch_profiler is not None:
+                Scalene.__torch_profiler.step()
+
             elapsed = now.wallclock - Scalene.__last_signal_time.wallclock
             # Store the latest values as the previously recorded values.
             Scalene.__last_signal_time = now

--- a/scalene/scalene_torch.py
+++ b/scalene/scalene_torch.py
@@ -7,10 +7,14 @@ JIT-compiled PyTorch code on both CPU and GPU.
 See https://github.com/plasma-umass/scalene/issues/908
 """
 
+import re
 import time
 from typing import Any, List
 
 from scalene.scalene_library_profiler import ScaleneLibraryProfiler
+
+# Pre-compile the regex used for every stack frame.
+_FRAME_RE = re.compile(r"(.+)\((\d+)\):")
 
 # Check if PyTorch is available at import time
 _torch_available = False
@@ -52,12 +56,35 @@ class TorchProfiler(ScaleneLibraryProfiler):
     stack trace collection to attribute operation time back to the Python
     source lines that initiated them. When CUDA is available, it also
     captures GPU kernel execution time.
+
+    To prevent unbounded memory growth (see #991), the profiler is
+    periodically restarted to discard accumulated events.  Only a
+    fraction of restart windows are processed (controlled by
+    ``_PROCESS_EVERY``) to minimize throughput impact while still
+    collecting representative profiling data across the full run.
     """
+
+    # Restart the profiler every N step() calls to flush accumulated
+    # events.  With a ~10ms CPU sampling interval, 100 ≈ every ~1s.
+    # Each restart briefly pauses recording while we swap profiler
+    # instances.
+    _STEP_INTERVAL: int = 100
+
+    # Only process events from every Nth restart window.  The expensive
+    # key_averages() + regex parsing dominates restart cost (~2.7s per
+    # window at 22k ops/s).  By processing only 1-in-N windows we cut
+    # that overhead proportionally while still getting representative
+    # profiling data across the full run.  Non-processed windows are
+    # still restarted to bound memory.
+    _PROCESS_EVERY: int = 5
 
     def __init__(self) -> None:
         super().__init__()
         self._profiler: Any = None
         self._gpu_enabled: bool = False
+        self._step_count: int = 0
+        self._restart_count: int = 0
+        self._activities: List[Any] = []
         # MPS (Apple Silicon GPU) timing
         self._mps_enabled: bool = False
         self._mps_start_time: float = 0.0
@@ -72,26 +99,45 @@ class TorchProfiler(ScaleneLibraryProfiler):
     def name(self) -> str:
         return "PyTorch"
 
-    def start(self) -> None:
-        """Start the PyTorch profiler."""
-        if not _torch_available or _torch is None:
-            return
+    def _start_profiler(self) -> bool:
+        """Create and enter a new torch profiler instance.
+
+        Returns True on success, False on failure.
+        """
         try:
-            # Build list of activities to profile
-            activities: List[Any] = [_torch.profiler.ProfilerActivity.CPU]
-
-            # Add CUDA activity if available
-            if _cuda_available:
-                activities.append(_torch.profiler.ProfilerActivity.CUDA)
-                self._gpu_enabled = True
-
-            # Use torch.profiler (newer API) with stack recording
             self._profiler = _torch.profiler.profile(
-                activities=activities,
+                activities=self._activities,
                 with_stack=True,  # Capture Python call stacks
                 record_shapes=False,
             )
             self._profiler.__enter__()
+            return True
+        except Exception:
+            self._profiler = None
+            return False
+
+    def start(self) -> None:
+        """Start the PyTorch profiler.
+
+        Uses an unscheduled profiler for minimal per-event overhead.
+        Memory is bounded by periodically restarting the profiler via
+        step(), which processes accumulated events and starts a fresh
+        instance.
+        See https://github.com/plasma-umass/scalene/issues/991
+        """
+        if not _torch_available or _torch is None:
+            return
+        try:
+            # Build list of activities to profile
+            self._activities = [_torch.profiler.ProfilerActivity.CPU]
+
+            # Add CUDA activity if available
+            if _cuda_available:
+                self._activities.append(_torch.profiler.ProfilerActivity.CUDA)
+                self._gpu_enabled = True
+
+            if not self._start_profiler():
+                raise RuntimeError("Failed to start torch profiler")
             self._enabled = True
 
             # Start MPS timing if available (and CUDA is not)
@@ -111,7 +157,7 @@ class TorchProfiler(ScaleneLibraryProfiler):
             self._profiler = None
 
     def stop(self) -> None:
-        """Stop the PyTorch profiler and process collected events."""
+        """Stop the PyTorch profiler and process remaining events."""
         if not self._enabled or self._profiler is None:
             return
 
@@ -127,32 +173,29 @@ class TorchProfiler(ScaleneLibraryProfiler):
 
         try:
             self._profiler.__exit__(None, None, None)
-            self._process_events()
+            # Process the final batch of events
+            self._process_events_from(self._profiler)
         except Exception:
-            # Silently handle any errors during profiler shutdown
             pass
         finally:
+            self._profiler = None
             self._enabled = False
             self._gpu_enabled = False
-            self._profiler = None
 
-    def _process_events(self) -> None:
-        """Extract timing from profiler events and attribute to source lines."""
-        if self._profiler is None:
+    def _process_events_from(self, prof: Any) -> None:
+        """Extract timing from a profiler instance and attribute to source lines."""
+        if prof is None:
             return
 
-        import re
-
         try:
-            events = self._profiler.key_averages(group_by_stack_n=10)
+            events = prof.key_averages(group_by_stack_n=10)
             for event in events:
                 # Get the stack trace for this event
                 if hasattr(event, "stack") and event.stack:
                     # Stack is a list of strings like "filename(lineno): funcname"
                     for frame_str in event.stack:
-                        # Parse the frame string
-                        # Format: "filename(lineno): funcname"
-                        match = re.match(r"(.+)\((\d+)\):", frame_str)
+                        # Parse the frame string: "filename(lineno): funcname"
+                        match = _FRAME_RE.match(frame_str)
                         if match:
                             filename = match.group(1)
                             lineno = int(match.group(2))
@@ -163,7 +206,6 @@ class TorchProfiler(ScaleneLibraryProfiler):
                                     self.line_times[filename][
                                         lineno
                                     ] += event.cpu_time_total
-
                                 # Attribute CUDA/GPU time if available
                                 # cuda_time_total is the total GPU kernel time in microseconds
                                 if self._gpu_enabled and hasattr(
@@ -177,6 +219,35 @@ class TorchProfiler(ScaleneLibraryProfiler):
         except Exception:
             # Silently handle any errors during event processing
             pass
+
+    def step(self) -> None:
+        """Periodically restart the profiler to bound memory usage.
+
+        Called on every CPU signal (~10ms).  Every ``_STEP_INTERVAL``
+        calls, the current profiler is stopped and a fresh instance
+        started.  Events are only processed from every
+        ``_PROCESS_EVERY``-th window to minimize throughput impact.
+        """
+        if not self._enabled or self._profiler is None:
+            return
+        self._step_count += 1
+        if self._step_count < self._STEP_INTERVAL:
+            return
+        self._step_count = 0
+        try:
+            # Stop current profiler
+            self._profiler.__exit__(None, None, None)
+            # Only process events from sampled windows to reduce overhead;
+            # non-sampled windows are discarded (memory still bounded).
+            if self._restart_count % self._PROCESS_EVERY == 0:
+                self._process_events_from(self._profiler)
+            self._restart_count += 1
+            # Start a fresh profiler instance immediately
+            if not self._start_profiler():
+                self._enabled = False
+        except Exception:
+            self._enabled = False
+            self._profiler = None
 
     # Note: get_line_time, get_gpu_line_time, has_gpu_timing inherited from base class
 


### PR DESCRIPTION
## Summary

- **Bound `cpu_samples_list` with reservoir sampling** (max 500 entries per line) using the same `sorted_reservoir` pattern already used for `memory_footprint_samples`. Previously this list grew without bound, causing memory issues especially on Windows where CPU profiling now works since v2.1.0.
- **Periodically restart `torch.profiler`** (~every 1s) to discard accumulated events from `with_stack=True`, preventing unbounded memory growth. Only every 5th window is processed (via `key_averages()`) to minimize throughput impact while still collecting representative profiling data.
- **Fix missing `cpu_samples_list` merge** in `merge_stats()` — previously data from child processes was silently lost.

Fixes #991

## Benchmark results

60-second torch workload (256×256 matmul + add + relu loop):

| Metric | master | fix | Change |
|---|---|---|---|
| Peak RSS (rusage) | 17,453 MiB | 1,765 MiB | **90% reduction** |
| Wall time | 280s | 67s | **4.2× faster** |
| Throughput | 22.6k ops/s | 13.1k ops/s | 42% overhead |

The throughput overhead is worst-case (tight torch-only loop). Real programs with mixed Python/torch code would see less impact.

### Approaches evaluated

| Approach | Throughput | Overhead | Peak RSS |
|---|---|---|---|
| Master (no fix) | 22.6k ops/s | — | 17,453 MiB |
| Every window (key_averages) | 6.1k ops/s | 73% | 2,095 MiB |
| **1-in-5 sampling (key_averages)** | **13.1k ops/s** | **42%** | **1,765 MiB** |
| Stack-keyed dict (raw events) | 7.1k ops/s | 68% | 2,112 MiB |
| Background thread | 1.5k ops/s | 93% | 21,190 MiB |

Benchmark scripts included in `benchmarks/` for reproducibility.

## Test plan

- [x] All 259 existing tests pass (`python3 -m pytest tests/ -v`)
- [x] Linters pass (`ruff check`, `mypy`)
- [x] Smoke test: `scalene run` on a simple program completes without excessive memory
- [x] Smoke test with `--profile-all`
- [x] Verify JSON output still contains `cpu_samples_list` arrays (now bounded to ~500 entries max)
- [x] If torch is installed, verify torch profiler memory stays bounded: `python benchmarks/measure_profiler_memory.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)