### PR TITLE
Fix CLI line number truncation for lines > 999

### DIFF
--- a/scalene/scalene_output.py
+++ b/scalene/scalene_output.py
@@ -428,7 +428,7 @@ class ScaleneOutput:
                 style="dim",
                 justify="right",
                 no_wrap=True,
-                width=4,
+                width=6,
             )
             tbl.add_column(
                 Markdown("Time  " + "\n" + "_Python_", style="blue"),

--- a/scalene/scalene_parseargs.py
+++ b/scalene/scalene_parseargs.py
@@ -671,7 +671,7 @@ class ScaleneParseArgs:
                 style="dim",
                 justify="right",
                 no_wrap=True,
-                width=4,
+                width=6,
             )
             tbl.add_column(
                 Markdown("Time  \n_Python_", style="blue"),


### PR DESCRIPTION
## Summary
- Fixes #1021: Line numbers larger than 999 were truncated (e.g., `1699` → `16…`) in CLI output
- Widens the Line column from 4 to 6 characters in both CLI renderers (`scalene_output.py` and `scalene_parseargs.py`)

## Test plan
- [ ] Profile a file with >1000 lines and verify line numbers display fully in `scalene view --cli`
- [ ] Verify no column alignment issues in normal (short line number) profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)