### PR TITLE
Stitched Python+native stacks (combined_stacks)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/scalene/scalene_cpu_profiler.py
+++ b/scalene/scalene_cpu_profiler.py
@@ -13,7 +13,12 @@ from scalene.scalene_statistics import (
     LineNumber,
     ScaleneStatistics,
 )
-from scalene.scalene_utility import _main_thread_id, add_stack, enter_function_meta
+from scalene.scalene_utility import (
+    _main_thread_id,
+    add_combined_stack,
+    add_stack,
+    enter_function_meta,
+)
 from scalene.time_info import TimeInfo
 
 if TYPE_CHECKING:
@@ -49,6 +54,7 @@ class ScaleneCPUProfiler:
         should_trace: Callable[[Filename, str], bool],
         last_cpu_interval: float,
         stacks_enabled: bool,
+        native_drains: list[tuple[int, ...]] | None = None,
     ) -> None:
         """Handle interrupts for CPU profiling.
 
@@ -62,6 +68,9 @@ class ScaleneCPUProfiler:
             should_trace: Function to check if a file/function should be traced.
             last_cpu_interval: The last CPU sampling interval.
             stacks_enabled: Whether stack collection is enabled.
+            native_drains: Native (C/C++) stacks captured by the C-level
+                signal-handler unwinder during this sampling pass; used to
+                build stitched Python+native stacks (combined_stacks).
         """
         if not new_frames:
             return
@@ -131,6 +140,13 @@ class ScaleneCPUProfiler:
                 average_c_time,
                 average_cpu_time,
             )
+            if native_drains:
+                add_combined_stack(
+                    main_thread_frame,
+                    should_trace,
+                    native_drains,
+                    self._stats.combined_stacks,
+                )
 
         enter_function_meta(main_thread_frame, should_trace, self._stats)
         fname = Filename(main_thread_frame.f_code.co_filename)

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -608,6 +608,83 @@ class ScaleneJSON:
                 if resolved_frames:
                     native_stks.append((resolved_frames, hits))
 
+        # Stitched Python+native stacks. Frames in stats.combined_stacks are
+        # tagged tuples (outermost-first):
+        #   ("py", filename, function, line)  or  ("native", ip)
+        # Resolve native IPs and trim contiguous CPython runtime frames at
+        # the seam (i.e. between Python and native segments) so the visible
+        # stack ends with real C/C++ user code rather than _PyEval_*.
+        combined_stks: List[Tuple[List[Dict[str, Any]], int]] = []
+        if stats.combined_stacks:
+            try:
+                from scalene import _scalene_unwind  # type: ignore
+
+                resolve = _scalene_unwind.resolve_ip
+            except ImportError:
+                resolve = None
+
+            ip_cache_combined: Dict[int, List[Any]] = {}
+
+            def _resolve(ip: int) -> List[Any]:
+                if ip in ip_cache_combined:
+                    return ip_cache_combined[ip]
+                info = resolve(ip) if resolve is not None else None
+                if info is None:
+                    rep: List[Any] = ["", "", ip, 0]
+                else:
+                    module, symbol, offset = info
+                    rep = [module, symbol, ip, offset]
+                ip_cache_combined[ip] = rep
+                return rep
+
+            for stk, hits in stats.combined_stacks.items():
+                # Find the seam: index of first native frame.
+                seam = next(
+                    (i for i, f in enumerate(stk) if f and f[0] == "native"),
+                    len(stk),
+                )
+                py_segment = stk[:seam]
+                native_segment_raw = stk[seam:]
+
+                # Resolve native IPs, then trim handler/runtime frames using
+                # the existing helpers. The native segment as stored is
+                # outermost-first (entry -> leaf), but _trim_native_stack
+                # expects leaf-first (it pops handlers from the front, runtime
+                # from the back), so reverse before trimming and reverse back.
+                resolved_leaf_first = [
+                    _resolve(int(f[1])) for f in native_segment_raw
+                ]
+                resolved_leaf_first.reverse()
+                trimmed_leaf_first = _trim_native_stack(resolved_leaf_first)
+                trimmed = list(reversed(trimmed_leaf_first))
+
+                out_frames: List[Dict[str, Any]] = []
+                for f in py_segment:
+                    # ("py", filename, function, line)
+                    out_frames.append(
+                        {
+                            "kind": "py",
+                            "display_name": str(f[2]),
+                            "filename_or_module": str(f[1]),
+                            "line": int(f[3]),
+                            "ip": None,
+                            "offset": None,
+                        }
+                    )
+                for module, symbol, ip, offset in trimmed:
+                    out_frames.append(
+                        {
+                            "kind": "native",
+                            "display_name": str(symbol),
+                            "filename_or_module": str(module),
+                            "line": None,
+                            "ip": int(ip),
+                            "offset": int(offset),
+                        }
+                    )
+                if out_frames:
+                    combined_stks.append((out_frames, hits))
+
         # Aggregate bytes from native-thread allocations that have no
         # Python frame (see pywhere.cpp <native> sentinel). These are not
         # attributable to any source line, so surface them at the top level.
@@ -650,6 +727,7 @@ class ScaleneJSON:
             "samples": compressed_footprint_samples if profile_memory else [],
             "stacks": stks,
             "native_stacks": native_stks,
+            "combined_stacks": combined_stks,
         }
 
         # Build a list of files we will actually report on.

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -36,6 +36,76 @@ class GPUDevice(str, Enum):
     no_gpu = ""
 
 
+# Native-frame trimming helpers used when serializing native_stacks.
+#
+# Each frame is a 4-element list: [module, symbol, ip, offset].
+# We strip two kinds of noise:
+#   1. Scalene's own signal-handler / kernel-trampoline frames at the
+#      innermost (leaf) end of the stack.
+#   2. CPython interpreter / runtime / process-entry frames at the
+#      outermost (root) end of the stack.
+#
+# Stacks come back from the unwinder leaf-first, i.e. index 0 is the
+# innermost frame and index -1 is the outermost.
+
+_CPYTHON_RUNTIME_SYMBOLS = frozenset({
+    # interpreter eval loop
+    "Py_RunMain",
+    "Py_BytesMain",
+    "Py_Main",
+    "PyEval_EvalCode",
+    "_PyEval_EvalFrameDefault",
+    "_PyEval_Vector",
+    # generic call dispatch
+    "call_method",
+    "slot_tp_init",
+    "type_call",
+    "builtin_exec",
+    "run_mod",
+    # process entry points beneath Py_RunMain
+    "_start",
+    "__libc_start_main",
+    "__libc_start_call_main",
+})
+
+_CPYTHON_RUNTIME_SYMBOL_PREFIXES = (
+    "PyObject_Vectorcall",
+    "_PyObject_Vectorcall",
+    "pymain_",
+)
+
+
+def _is_scalene_handler_frame(frame: List[Any]) -> bool:
+    module, symbol, _ip, _off = frame
+    if symbol and "scalene_signal_unwinder" in symbol:
+        return True
+    if symbol in ("_sigtramp", "__restore_rt"):
+        return True
+    return bool(module and "_scalene_unwind" in module)
+
+
+def _is_cpython_runtime_frame(frame: List[Any]) -> bool:
+    _module, symbol, _ip, _off = frame
+    if not symbol:
+        return False
+    if symbol in _CPYTHON_RUNTIME_SYMBOLS:
+        return True
+    return bool(symbol.startswith(_CPYTHON_RUNTIME_SYMBOL_PREFIXES))
+
+
+def _trim_native_stack(frames: List[List[Any]]) -> List[List[Any]]:
+    """Drop the signal-handler entry frames at the leaf end and the
+    CPython runtime / process-entry frames at the root end. Operates on
+    a copy and returns a new list so callers can keep the originals.
+    """
+    out = list(frames)
+    while out and _is_scalene_handler_frame(out[0]):
+        out.pop(0)
+    while out and _is_cpython_runtime_frame(out[-1]):
+        out.pop()
+    return out
+
+
 class FunctionDetail(BaseModel):
     line: str
     lineno: LineNumber
@@ -506,11 +576,10 @@ class ScaleneJSON:
         # time). Cache by IP because the same address typically appears
         # across many stacks.
         #
-        # Strip the signal-handler entry frames at the top of each stack —
-        # the innermost frames will always be our own scalene_signal_unwinder
-        # and the kernel signal trampoline. They're not useful information
-        # to the user. We do this by symbol/module match rather than a fixed
-        # skip count so it stays correct across platforms and inlining.
+        # Trim is done by _trim_native_stack: it drops Scalene's own
+        # signal-handler/trampoline frames at the leaf end and contiguous
+        # CPython interpreter/process-entry frames at the root end, so what
+        # the user sees starts and ends with real C/C++ user code.
         native_stks: List[Tuple[List[List[Any]], int]] = []
         if stats.native_stacks:
             try:
@@ -519,14 +588,6 @@ class ScaleneJSON:
                 resolve = _scalene_unwind.resolve_ip
             except ImportError:
                 resolve = None
-
-            def is_scalene_handler_frame(frame: List[Any]) -> bool:
-                module, symbol, _ip, _off = frame
-                if symbol and "scalene_signal_unwinder" in symbol:
-                    return True
-                if symbol in ("_sigtramp", "__restore_rt"):
-                    return True
-                return bool(module and "_scalene_unwind" in module)
 
             ip_cache: Dict[int, List[Any]] = {}
             for stk, hits in stats.native_stacks.items():
@@ -543,9 +604,7 @@ class ScaleneJSON:
                         frame_repr = [module, symbol, ip, offset]
                     ip_cache[ip] = frame_repr
                     resolved_frames.append(frame_repr)
-                # Drop the leading handler/trampoline frames.
-                while resolved_frames and is_scalene_handler_frame(resolved_frames[0]):
-                    resolved_frames.pop(0)
+                resolved_frames = _trim_native_stack(resolved_frames)
                 if resolved_frames:
                     native_stks.append((resolved_frames, hits))
 

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -823,13 +823,9 @@ class Scalene:
             # numpy mid-call), unlike anything we could unwind from here —
             # by the time this Python handler runs, the interrupted C call
             # has already returned to the bytecode interpreter.
-            # Drain native (C/C++) stacks captured by our C-level sigaction
-            # handler. Those stacks reflect the *interrupted* user code (e.g.
-            # numpy mid-call), unlike anything we could unwind from here —
-            # by the time this Python handler runs, the interrupted C call
-            # has already returned to the bytecode interpreter.
+            native_drains: list[tuple[int, ...]] = []
             if Scalene.__args.stacks:
-                drain_native_stacks(Scalene.__stats.native_stacks)
+                native_drains = drain_native_stacks(Scalene.__stats.native_stacks)
 
             # Process this CPU sample.
             frames = compute_frames_to_record(Scalene._should_trace)
@@ -841,6 +837,7 @@ class Scalene:
                 gpu_mem_used,
                 Scalene.__last_signal_time,
                 Scalene.__is_thread_sleeping,
+                native_drains,
             )
             # Advance library profiler schedules (e.g., torch profiler
             # periodic flush) to keep memory bounded.
@@ -1036,6 +1033,7 @@ class Scalene:
         gpu_mem_used: float,
         prev: TimeInfo,
         is_thread_sleeping: dict[int, bool],
+        native_drains: list[tuple[int, ...]] | None = None,
     ) -> None:
         """Handle interrupts for CPU profiling.
 
@@ -1062,6 +1060,7 @@ class Scalene:
             Scalene._should_trace,
             Scalene.__last_cpu_interval,
             Scalene.__args.stacks,
+            native_drains or [],
         )
 
     @staticmethod

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -462,6 +462,7 @@ class ScaleneStatistics:
             "memory_stats.alloc_samples",
             "stacks",
             "native_stacks",
+            "combined_stacks",
             "cpu_stats.total_cpu_samples",
             "cpu_stats.cpu_samples_c",
             "cpu_stats.cpu_samples_python",
@@ -524,6 +525,17 @@ class ScaleneStatistics:
         # happens at report time, not in the signal handler.
         self.native_stacks: dict[tuple[int, ...], int] = defaultdict(int)
 
+        # Stitched Python+native stacks captured during CPU samples, together
+        # with hit count. Each stack is a tuple of tagged frame tuples
+        # (outermost-first) where each entry is one of:
+        #   ("py", filename: str, function_name: str, line_number: int)
+        #   ("native", ip: int)
+        # Native IPs are resolved (and CPython runtime tail trimmed) at
+        # report time, mirroring how native_stacks is handled.
+        self.combined_stacks: dict[tuple[tuple[Any, ...], ...], int] = defaultdict(
+            int
+        )
+
         # Initialize statistics classes
         self.cpu_stats = CPUStatistics()
         self.memory_stats = MemoryStatistics()
@@ -549,6 +561,7 @@ class ScaleneStatistics:
         self.elapsed_time = 0
         self.stacks.clear()
         self.native_stacks.clear()
+        self.combined_stacks.clear()
         self.cpu_stats.clear()
         self.memory_stats.clear()
         self.gpu_stats.clear()
@@ -763,6 +776,8 @@ class ScaleneStatistics:
                 self.stacks.update(x.stacks)
                 for stk, hits in x.native_stacks.items():
                     self.native_stacks[stk] += hits
+                for cstk, chits in x.combined_stacks.items():
+                    self.combined_stacks[cstk] += chits
                 self.cpu_stats.total_cpu_samples += x.cpu_stats.total_cpu_samples
                 self.gpu_stats.total_gpu_samples += x.gpu_stats.total_gpu_samples
 

--- a/scalene/scalene_utility.py
+++ b/scalene/scalene_utility.py
@@ -228,21 +228,80 @@ def install_native_stack_unwinder(sig: int) -> bool:
 
 def drain_native_stacks(
     native_stacks: Dict[Tuple[int, ...], int],
-) -> None:
+) -> List[Tuple[int, ...]]:
     """Drain stacks captured by the C signal handler since the last call,
     aggregating each into the supplied dict by hit count. Cheap and safe to
     call from the Python-level CPU signal handler — it only does an atomic
     load, a list build, and dict accounting.
+
+    Returns the non-empty drained tuples so the caller can use them for
+    stitched-stack assembly. The aggregation into ``native_stacks`` still
+    happens as a side effect to preserve backward compatibility.
     """
     if not _native_unwind_available:
-        return
+        return []
     try:
         captured = _scalene_unwind.drain_native_stack_buffer()
     except Exception:
-        return
+        return []
+    nonempty: List[Tuple[int, ...]] = []
     for stk in captured:
         if stk:
             native_stacks[stk] += 1
+            nonempty.append(stk)
+    return nonempty
+
+
+def add_combined_stack(
+    frame: Optional[FrameType],
+    should_trace: Callable[[Filename, str], bool],
+    native_drains: List[Tuple[int, ...]],
+    combined_stacks: Dict[Tuple[Tuple[Any, ...], ...], int],
+) -> None:
+    """Build stitched Python+native stacks for the current CPU sample.
+
+    Walks ``frame`` back through ``f_back`` to build the Python chain
+    (outermost-first), filtering with ``should_trace`` so Scalene's own
+    profiler frames and other non-user code are excluded. Each native drain
+    is then appended as its own native segment, producing one stitched
+    stack per drain. Native IPs are stored unresolved; symbol resolution
+    and CPython-runtime trimming happen at JSON serialization time.
+
+    If multiple native stacks were drained for one Python handler
+    invocation, each one is attached to the same Python chain (best-effort
+    v1 policy — see STITCHED_STACK.md).
+    """
+    if not native_drains:
+        return
+
+    py_chain: List[Tuple[Any, ...]] = []
+    f: Optional[FrameType] = frame
+    while f is not None:
+        if should_trace(Filename(f.f_code.co_filename), f.f_code.co_name):
+            line = (
+                int(f.f_lineno)
+                if f.f_lineno is not None
+                else int(f.f_code.co_firstlineno)
+            )
+            py_chain.insert(
+                0,
+                (
+                    "py",
+                    str(f.f_code.co_filename),
+                    str(get_fully_qualified_name(f)),
+                    line,
+                ),
+            )
+        f = f.f_back
+
+    py_chain_tuple = tuple(py_chain)
+    for native_stk in native_drains:
+        # native_stk is leaf-first; the stitched layout we want is
+        # outermost-to-innermost, so the native segment appends in order
+        # native-entry -> native-leaf, which means reversing the
+        # leaf-first tuple from the unwinder.
+        native_segment = tuple(("native", ip) for ip in reversed(native_stk))
+        combined_stacks[py_chain_tuple + native_segment] += 1
 
 
 def on_stack(

--- a/test/smoketest_pool_spawn.py
+++ b/test/smoketest_pool_spawn.py
@@ -13,13 +13,19 @@ cmd = [sys.executable, "-m", "scalene", "run", "--cpu-only", "test/pool_spawn_te
 print("COMMAND", " ".join(cmd))
 
 try:
-    proc = subprocess.run(cmd, timeout=120)
+    proc = subprocess.run(cmd, timeout=120, capture_output=True, text=True)
     rc = proc.returncode
-except subprocess.TimeoutExpired:
+    out, err = proc.stdout, proc.stderr
+except subprocess.TimeoutExpired as e:
     # Timeout during cleanup is acceptable — the profiled program completed
     # but Python's multiprocessing resource tracker can hang on shutdown.
     print("Process timed out (likely cleanup hang), treating as success")
     rc = 0
+    out = (e.stdout or b"").decode(errors="replace") if e.stdout else ""
+    err = (e.stderr or b"").decode(errors="replace") if e.stderr else ""
+
+print(out, end="")
+print(err, end="", file=sys.stderr)
 
 # Allow exit codes 0 (success) and 1 (memoryview cleanup warning on Windows)
 if rc > 1:

--- a/tests/test_native_stacks.py
+++ b/tests/test_native_stacks.py
@@ -531,3 +531,389 @@ class TestTrimNativeStack:
 
     def test_empty_input_returns_empty(self):
         assert _trim_native_stack([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Stitched (combined) Python+native stack assembly
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(filename: str, function: str, line: int, parent=None):
+    """Build a duck-typed FrameType for add_combined_stack tests.
+
+    add_combined_stack only reads f_lineno, f_code.co_filename,
+    f_code.co_firstlineno, f_code.co_name, and f_back. A simple namespace is
+    enough — no need to compile real Python.
+    """
+    import types as _types
+
+    code = _types.SimpleNamespace(
+        co_filename=filename,
+        co_name=function,
+        co_firstlineno=line,
+        co_qualname=function,
+    )
+    return _types.SimpleNamespace(
+        f_code=code,
+        f_lineno=line,
+        f_back=parent,
+        f_locals={},
+    )
+
+
+class TestAddCombinedStack:
+    def test_no_drains_is_a_noop(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        combined: dict = defaultdict(int)
+        frame = _make_frame("/p.py", "main", 5)
+        add_combined_stack(frame, lambda *_: True, [], combined)
+        assert dict(combined) == {}
+
+    def test_outermost_to_innermost_python_chain(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        # Build a chain: main (line 1) -> middle (line 7) -> leaf (line 12).
+        # Walking f_back from leaf gives leaf -> middle -> main, but
+        # add_combined_stack must produce outermost-first: main, middle, leaf.
+        main = _make_frame("/p.py", "main", 1)
+        middle = _make_frame("/p.py", "middle", 7, parent=main)
+        leaf = _make_frame("/p.py", "leaf", 12, parent=middle)
+
+        combined: dict = defaultdict(int)
+        add_combined_stack(leaf, lambda *_: True, [(0xAAAA,)], combined)
+
+        assert len(combined) == 1
+        stk = next(iter(combined.keys()))
+        py_frames = [f for f in stk if f[0] == "py"]
+        assert [(f[2], f[3]) for f in py_frames] == [
+            ("main", 1),
+            ("middle", 7),
+            ("leaf", 12),
+        ]
+
+    def test_native_segment_appended_in_outermost_first_order(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        frame = _make_frame("/p.py", "f", 3)
+        # The unwinder gives leaf-first: (leaf_ip, ..., entry_ip).
+        native_drain = (0x1111, 0x2222, 0x3333)
+        combined: dict = defaultdict(int)
+        add_combined_stack(frame, lambda *_: True, [native_drain], combined)
+
+        stk = next(iter(combined.keys()))
+        native_ips = [f[1] for f in stk if f[0] == "native"]
+        # Outermost-first => entry first, leaf last => reversed.
+        assert native_ips == [0x3333, 0x2222, 0x1111]
+
+    def test_multiple_drains_each_attached_to_python_chain(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        frame = _make_frame("/p.py", "f", 3)
+        drain_a = (0xAAAA,)
+        drain_b = (0xBBBB,)
+        drain_c = (0xCCCC,)
+        combined: dict = defaultdict(int)
+        add_combined_stack(
+            frame, lambda *_: True, [drain_a, drain_b, drain_c], combined
+        )
+
+        # Three distinct stitched stacks, each anchored on the same Python
+        # chain — best-effort v1 policy.
+        assert len(combined) == 3
+        py_anchor = ("py", "/p.py", "f", 3)
+        for stk, hits in combined.items():
+            assert hits == 1
+            assert stk[0] == py_anchor
+
+    def test_repeat_drain_increments_hit_count(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        frame = _make_frame("/p.py", "f", 3)
+        drain = (0xAAAA, 0xBBBB)
+
+        combined: dict = defaultdict(int)
+        add_combined_stack(frame, lambda *_: True, [drain], combined)
+        add_combined_stack(frame, lambda *_: True, [drain], combined)
+        add_combined_stack(frame, lambda *_: True, [drain], combined)
+
+        assert len(combined) == 1
+        assert next(iter(combined.values())) == 3
+
+    def test_should_trace_filters_python_frames(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        scalene_internal = _make_frame(
+            "/scalene/scalene_profiler.py", "cpu_signal_handler", 800
+        )
+        user_outer = _make_frame(
+            "/usercode.py", "main", 1, parent=scalene_internal
+        )
+        user_inner = _make_frame(
+            "/usercode.py", "hot", 5, parent=user_outer
+        )
+
+        def trace(filename, _name):
+            return "scalene" not in filename
+
+        combined: dict = defaultdict(int)
+        add_combined_stack(user_inner, trace, [(0xAAAA,)], combined)
+
+        stk = next(iter(combined.keys()))
+        py_frames = [f for f in stk if f[0] == "py"]
+        # Scalene's profiler frame must be filtered out — only user frames
+        # remain in the stitched Python segment.
+        assert [(f[1], f[2]) for f in py_frames] == [
+            ("/usercode.py", "main"),
+            ("/usercode.py", "hot"),
+        ]
+
+    def test_handles_frame_with_none_lineno(self):
+        from collections import defaultdict
+
+        from scalene.scalene_utility import add_combined_stack
+
+        # Python 3.11+ may report f_lineno=None during cleanup; fall back to
+        # co_firstlineno.
+        frame = _make_frame("/p.py", "f", 42)
+        frame.f_lineno = None
+        combined: dict = defaultdict(int)
+        add_combined_stack(frame, lambda *_: True, [(0xAAAA,)], combined)
+
+        stk = next(iter(combined.keys()))
+        py_frames = [f for f in stk if f[0] == "py"]
+        assert py_frames[0][3] == 42  # used co_firstlineno
+
+
+# ---------------------------------------------------------------------------
+# combined_stacks JSON serialization (resolution + seam trim + frame schema)
+# ---------------------------------------------------------------------------
+
+
+def _build_stats_with_combined(raw_stack: tuple, hits: int = 1):
+    """Build a ScaleneStatistics with one combined_stacks entry, plus stub
+    everything else needed for output_profiles to run.
+
+    The dummy file needs both per-line samples (so it's an instrumented file)
+    and a non-zero per-file cpu_samples count above cpu_percent_threshold (1%
+    of elapsed_time), or it gets pruned from report_files and the whole
+    output is dropped.
+    """
+    from scalene.scalene_statistics import ScaleneStatistics
+
+    stats = ScaleneStatistics()
+    stats.combined_stacks[raw_stack] = hits
+    stats.cpu_stats.total_cpu_samples = 1.0
+    stats.cpu_stats.cpu_samples_python["/dummy.py"][1] = 1.0
+    stats.cpu_stats.cpu_samples["/dummy.py"] = 1.0  # >1% of elapsed_time
+    stats.elapsed_time = 1.0
+    return stats
+
+
+class TestCombinedStacksJson:
+    def _resolve_stub(self, mapping):
+        """Return a fake _scalene_unwind.resolve_ip that uses `mapping`."""
+
+        def _resolve(ip):
+            return mapping.get(ip)
+
+        return _resolve
+
+    def _emit(self, stats, tmp_path):
+        """Run output_profiles and return the resulting JSON dict."""
+        from scalene.scalene_json import ScaleneJSON
+        from scalene.scalene_statistics import Filename
+
+        out = ScaleneJSON()
+        return out.output_profiles(
+            program=Filename("prog.py"),
+            stats=stats,
+            pid=0,
+            profile_this_code=lambda f, l: True,
+            python_alias_dir=tmp_path,
+            program_path=Filename("prog.py"),
+            entrypoint_dir=Filename(str(tmp_path)),
+            program_args=[],
+            profile_memory=False,
+            reduced_profile=False,
+            profile_async=False,
+        )
+
+    def test_native_segment_resolved_and_trimmed(self, monkeypatch, tmp_path):
+        # Stack as stored: outermost-first.
+        # Python: main / hot
+        # Native (entry -> leaf): _PyEval_EvalFrameDefault, _multiarray_umath::do_work, libBLAS::cblas_dgemm
+        # After seam trim, _PyEval_EvalFrameDefault should be dropped because
+        # it sits between Python and the real native leaf segment.
+        py_main = ("py", "prog.py", "main", 10)
+        py_hot = ("py", "prog.py", "hot", 22)
+        ip_eval = 0xE000
+        ip_callsite = 0xC000
+        ip_leaf = 0x1000
+
+        mapping = {
+            ip_eval: ("/lib/libpython.so", "_PyEval_EvalFrameDefault", 0),
+            ip_callsite: ("/x/_multiarray_umath.so", "do_work", 12),
+            ip_leaf: ("/lib/libBLAS.dylib", "cblas_dgemm", 32),
+        }
+
+        # Patch the _scalene_unwind.resolve_ip used by scalene_json.
+        import scalene._scalene_unwind as unwind_mod  # type: ignore
+
+        monkeypatch.setattr(
+            unwind_mod, "resolve_ip", self._resolve_stub(mapping)
+        )
+
+        stack = (
+            py_main,
+            py_hot,
+            ("native", ip_eval),
+            ("native", ip_callsite),
+            ("native", ip_leaf),
+        )
+        stats = _build_stats_with_combined(stack, hits=4)
+        profile = self._emit(stats, tmp_path)
+
+        combined = profile["combined_stacks"]
+        assert isinstance(combined, list) and len(combined) == 1
+        frames, hits = combined[0]
+        assert hits == 4
+
+        # Python segment unchanged; native segment should now be just the
+        # two real native frames, in outermost-first order.
+        kinds = [f["kind"] for f in frames]
+        assert kinds == ["py", "py", "native", "native"]
+
+        py_segment = [f for f in frames if f["kind"] == "py"]
+        assert [f["display_name"] for f in py_segment] == ["main", "hot"]
+        assert [f["line"] for f in py_segment] == [10, 22]
+        for f in py_segment:
+            assert f["ip"] is None and f["offset"] is None
+
+        native_segment = [f for f in frames if f["kind"] == "native"]
+        assert [f["display_name"] for f in native_segment] == [
+            "do_work",
+            "cblas_dgemm",
+        ]
+        assert [f["filename_or_module"] for f in native_segment] == [
+            "/x/_multiarray_umath.so",
+            "/lib/libBLAS.dylib",
+        ]
+        for f in native_segment:
+            assert f["line"] is None
+            assert isinstance(f["ip"], int) and f["ip"] != 0
+
+    def test_pure_python_stack_emits_unchanged(self, tmp_path):
+        py_main = ("py", "prog.py", "main", 1)
+        py_hot = ("py", "prog.py", "hot", 5)
+        stack = (py_main, py_hot)
+        stats = _build_stats_with_combined(stack, hits=2)
+        profile = self._emit(stats, tmp_path)
+
+        combined = profile["combined_stacks"]
+        assert len(combined) == 1
+        frames, hits = combined[0]
+        assert hits == 2
+        assert [f["kind"] for f in frames] == ["py", "py"]
+        assert [f["display_name"] for f in frames] == ["main", "hot"]
+
+    def test_pure_runtime_native_segment_drops(self, monkeypatch, tmp_path):
+        # If the native segment is entirely interpreter / process-entry
+        # frames, trimming leaves nothing — only the Python part remains.
+        py_main = ("py", "prog.py", "main", 1)
+        ip_eval = 0xE000
+        ip_runmain = 0xF000
+        mapping = {
+            ip_eval: ("/lib/libpython.so", "_PyEval_EvalFrameDefault", 0),
+            ip_runmain: ("/lib/libpython.so", "Py_RunMain", 0),
+        }
+        import scalene._scalene_unwind as unwind_mod  # type: ignore
+
+        monkeypatch.setattr(
+            unwind_mod, "resolve_ip", self._resolve_stub(mapping)
+        )
+
+        stack = (py_main, ("native", ip_eval), ("native", ip_runmain))
+        stats = _build_stats_with_combined(stack, hits=1)
+        profile = self._emit(stats, tmp_path)
+
+        combined = profile["combined_stacks"]
+        assert len(combined) == 1
+        frames, _hits = combined[0]
+        # Only the Python anchor remains.
+        assert [f["kind"] for f in frames] == ["py"]
+
+    def test_no_combined_stacks_emits_empty_list(self, tmp_path):
+        from scalene.scalene_json import ScaleneJSON
+        from scalene.scalene_statistics import Filename, ScaleneStatistics
+
+        stats = ScaleneStatistics()
+        stats.cpu_stats.total_cpu_samples = 1.0
+        stats.cpu_stats.cpu_samples_python["/dummy.py"][1] = 1.0
+        stats.cpu_stats.cpu_samples["/dummy.py"] = 1.0
+        stats.elapsed_time = 1.0
+
+        out = ScaleneJSON()
+        profile = out.output_profiles(
+            program=Filename("prog.py"),
+            stats=stats,
+            pid=0,
+            profile_this_code=lambda f, l: True,
+            python_alias_dir=tmp_path,
+            program_path=Filename("prog.py"),
+            entrypoint_dir=Filename(str(tmp_path)),
+            program_args=[],
+            profile_memory=False,
+            reduced_profile=False,
+            profile_async=False,
+        )
+        assert profile["combined_stacks"] == []
+
+
+# ---------------------------------------------------------------------------
+# drain_native_stacks return-value contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(WINDOWS, reason="unwinder is a stub on Windows")
+def test_drain_native_stacks_returns_list_and_aggregates(monkeypatch):
+    """drain_native_stacks must aggregate AND return the raw drains."""
+    from collections import defaultdict
+
+    import scalene.scalene_utility as util
+
+    # Stub the C extension's drain to return a known-good capture set so
+    # the test doesn't depend on the signal-handler path having fired.
+    fake_capture = [(0x1, 0x2, 0x3), (0x4, 0x5), ()]
+    monkeypatch.setattr(
+        util._scalene_unwind, "drain_native_stack_buffer", lambda: fake_capture
+    )
+
+    native_stacks: dict = defaultdict(int)
+    drained = util.drain_native_stacks(native_stacks)
+
+    # Empty drain entries must be filtered out of both the return value
+    # and the aggregation dict.
+    assert drained == [(0x1, 0x2, 0x3), (0x4, 0x5)]
+    assert dict(native_stacks) == {(0x1, 0x2, 0x3): 1, (0x4, 0x5): 1}
+
+
+def test_drain_native_stacks_empty_on_unsupported(monkeypatch):
+    """When the C extension is unavailable, drain returns []."""
+    import scalene.scalene_utility as util
+
+    monkeypatch.setattr(util, "_native_unwind_available", False)
+    drained = util.drain_native_stacks({})
+    assert drained == []

--- a/tests/test_native_stacks.py
+++ b/tests/test_native_stacks.py
@@ -44,6 +44,11 @@ from pathlib import Path
 import pytest
 
 from scalene import _scalene_unwind
+from scalene.scalene_json import (
+    _is_cpython_runtime_frame,
+    _is_scalene_handler_frame,
+    _trim_native_stack,
+)
 
 WINDOWS = sys.platform == "win32"
 SA_SIGINFO = getattr(signal, "SA_SIGINFO", None)
@@ -355,3 +360,174 @@ def test_scalene_subprocess_no_stacks_smoke(tmp_path):
         "Expected empty native_stacks without --stacks; got "
         f"{len(profile.get('native_stacks', []))} entries"
     )
+
+
+# ---------------------------------------------------------------------------
+# Native-stack frame classification + trimming (pure-Python helpers)
+# ---------------------------------------------------------------------------
+
+
+def _f(module: str = "", symbol: str = "", ip: int = 0x1000, offset: int = 0):
+    """Build a resolved-frame list as scalene_json.py constructs them."""
+    return [module, symbol, ip, offset]
+
+
+class TestIsScaleneHandlerFrame:
+    def test_matches_unwinder_symbol(self):
+        assert _is_scalene_handler_frame(
+            _f(symbol="scalene_signal_unwinder")
+        )
+
+    def test_matches_macos_sigtramp(self):
+        assert _is_scalene_handler_frame(_f(symbol="_sigtramp"))
+
+    def test_matches_linux_restore_rt(self):
+        assert _is_scalene_handler_frame(_f(symbol="__restore_rt"))
+
+    def test_matches_module_path(self):
+        assert _is_scalene_handler_frame(
+            _f(module="/site-packages/scalene/_scalene_unwind.so", symbol="")
+        )
+
+    def test_user_frame_is_not_handler(self):
+        assert not _is_scalene_handler_frame(
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm")
+        )
+
+    def test_unresolved_frame_is_not_handler(self):
+        assert not _is_scalene_handler_frame(_f())
+
+
+class TestIsCPythonRuntimeFrame:
+    def test_matches_exact_eval_frame(self):
+        assert _is_cpython_runtime_frame(_f(symbol="_PyEval_EvalFrameDefault"))
+
+    def test_matches_py_runmain(self):
+        assert _is_cpython_runtime_frame(_f(symbol="Py_RunMain"))
+
+    def test_matches_vectorcall_prefix(self):
+        assert _is_cpython_runtime_frame(_f(symbol="PyObject_Vectorcall"))
+        assert _is_cpython_runtime_frame(
+            _f(symbol="_PyObject_VectorcallTstate")
+        )
+
+    def test_matches_pymain_prefix(self):
+        assert _is_cpython_runtime_frame(_f(symbol="pymain_run_python"))
+
+    def test_matches_libc_entrypoints(self):
+        assert _is_cpython_runtime_frame(_f(symbol="_start"))
+        assert _is_cpython_runtime_frame(_f(symbol="__libc_start_main"))
+
+    def test_unresolved_frame_is_not_runtime(self):
+        # Empty symbol must not be treated as runtime (would over-trim
+        # otherwise resolvable user frames whose symbol lookup failed).
+        assert not _is_cpython_runtime_frame(_f(symbol=""))
+
+    def test_user_symbol_is_not_runtime(self):
+        assert not _is_cpython_runtime_frame(_f(symbol="cblas_dgemm"))
+        # A user function whose name happens to share a prefix with
+        # something we don't trim must still pass through.
+        assert not _is_cpython_runtime_frame(_f(symbol="my_call_method"))
+
+
+class TestTrimNativeStack:
+    def test_strips_leading_handler_frames(self):
+        frames = [
+            _f(symbol="scalene_signal_unwinder"),
+            _f(symbol="_sigtramp"),
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm"),
+        ]
+        trimmed = _trim_native_stack(frames)
+        assert [f[1] for f in trimmed] == ["cblas_dgemm"]
+
+    def test_strips_trailing_cpython_runtime_frames(self):
+        frames = [
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm"),
+            _f(
+                module="/.../_multiarray_umath.so",
+                symbol="array_function_simple_impl",
+            ),
+            _f(symbol="_PyEval_EvalFrameDefault"),
+            _f(symbol="_PyEval_EvalFrameDefault"),
+            _f(symbol="_PyEval_Vector"),
+            _f(symbol="Py_RunMain"),
+            _f(symbol="__libc_start_main"),
+            _f(symbol="_start"),
+        ]
+        trimmed = _trim_native_stack(frames)
+        assert [f[1] for f in trimmed] == [
+            "cblas_dgemm",
+            "array_function_simple_impl",
+        ]
+
+    def test_strips_both_ends(self):
+        frames = [
+            _f(symbol="scalene_signal_unwinder"),
+            _f(symbol="_sigtramp"),
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm"),
+            _f(symbol="_PyEval_EvalFrameDefault"),
+            _f(symbol="Py_RunMain"),
+        ]
+        trimmed = _trim_native_stack(frames)
+        assert [f[1] for f in trimmed] == ["cblas_dgemm"]
+
+    def test_only_runtime_returns_empty(self):
+        # A sample that landed entirely in the interpreter trims to
+        # nothing, and the caller drops empty stacks.
+        frames = [
+            _f(symbol="_PyEval_EvalFrameDefault"),
+            _f(symbol="Py_RunMain"),
+            _f(symbol="_start"),
+        ]
+        assert _trim_native_stack(frames) == []
+
+    def test_only_handler_returns_empty(self):
+        frames = [
+            _f(symbol="scalene_signal_unwinder"),
+            _f(symbol="_sigtramp"),
+        ]
+        assert _trim_native_stack(frames) == []
+
+    def test_does_not_trim_runtime_in_middle(self):
+        # An interpreter frame sandwiched between native frames stays:
+        # we only trim CONTIGUOUS runtime frames from the root end.
+        frames = [
+            _f(symbol="numpy_callback"),
+            _f(symbol="_PyEval_EvalFrameDefault"),
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm"),
+            _f(symbol="_PyEval_EvalFrameDefault"),
+            _f(symbol="Py_RunMain"),
+        ]
+        trimmed = _trim_native_stack(frames)
+        assert [f[1] for f in trimmed] == [
+            "numpy_callback",
+            "_PyEval_EvalFrameDefault",
+            "cblas_dgemm",
+        ]
+
+    def test_keeps_unresolved_frames(self):
+        # Unresolved IPs (empty symbol) must not be trimmed — they may
+        # be real user code that just failed to symbolize.
+        frames = [
+            _f(symbol="scalene_signal_unwinder"),
+            _f(ip=0xDEADBEEF),
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm"),
+            _f(symbol="Py_RunMain"),
+        ]
+        trimmed = _trim_native_stack(frames)
+        assert len(trimmed) == 2
+        assert trimmed[0][2] == 0xDEADBEEF
+        assert trimmed[1][1] == "cblas_dgemm"
+
+    def test_does_not_mutate_input(self):
+        frames = [
+            _f(symbol="scalene_signal_unwinder"),
+            _f(module="/lib/libBLAS.dylib", symbol="cblas_dgemm"),
+            _f(symbol="Py_RunMain"),
+        ]
+        original = [list(f) for f in frames]
+        _trim_native_stack(frames)
+        assert frames == original
+
+    def test_empty_input_returns_empty(self):
+        assert _trim_native_stack([]) == []


### PR DESCRIPTION
## Summary

Builds on #1034 (just merged). Introduces a third top-level stack representation, `combined_stacks`, alongside the existing `stacks` (Python-only) and `native_stacks` (native-only) outputs.

Each stitched sample combines the user-traceable Python chain with the native leaf segment captured by the C-level signal-handler unwinder, so profiles can show e.g. `<module> -> hot -> cblas_dgemm` as a single stack rather than two disconnected views.

This is **PR 2** of the plan from `STITCHED_STACK.md`. PR 1 (CPython runtime frame trimming) shipped as part of #1034 plus a small follow-up commit (`c3085d51`) on this branch.

## What changed

**Data model** — `scalene/scalene_statistics.py`
- `combined_stacks: dict[tuple[tuple, ...], int]` keyed by tagged frame tuples (outermost-first):
  - `("py", filename, function, line)`
  - `("native", ip)`
- Native IPs stored unresolved; resolution + CPython-runtime seam trim happen at JSON time, mirroring how `native_stacks` is handled.
- Wired into `clear()` and `merge_stats()` so per-process stats compose.

**Sampling** — `scalene/scalene_utility.py`, `scalene/scalene_profiler.py`, `scalene/scalene_cpu_profiler.py`
- `drain_native_stacks` now returns the raw drained tuples to the caller while still aggregating into `native_stacks` as a side effect (backward compatible).
- `cpu_signal_handler` captures the drain return value and threads it through `_process_cpu_sample` to `ScaleneCPUProfiler.process_cpu_sample`.
- New `add_combined_stack()` helper walks the main-thread Python chain through `f_back` applying `should_trace` (so Scalene's own profiler frames are excluded), then appends each native drain as its own native segment. If multiple native stacks were drained for one Python handler invocation, each one gets its own stitched stack — best-effort v1 policy from the plan.

**Serialization** — `scalene/scalene_json.py`
- New `combined_stacks` top-level field. Each frame is emitted as a structured dict `{kind, display_name, filename_or_module, line, ip, offset}` so the seam between Python and native stays explicit.
- Reuses `_trim_native_stack` to drop CPython interpreter / runtime frames at the seam.
- `stacks` and `native_stacks` output is unchanged.

**Tests** — `tests/test_native_stacks.py`
- `add_combined_stack`: outermost-first ordering, native segment reversed correctly (entry -> leaf), `should_trace` filtering excludes Scalene-internal frames, multiple drains attach to the same Python chain, hit-count aggregation, `f_lineno=None` fallback.
- JSON: native segment resolved + seam-trimmed, pure-Python stack survives, all-runtime native segment trims to nothing, empty case emits `[]`.
- `drain_native_stacks`: returns the drained list AND aggregates; returns `[]` when extension is unavailable.

All 43 tests in `tests/test_native_stacks.py` pass; mypy and ruff clean on changed files.

## Verified end-to-end

macOS arm64 / Python 3.14, `math` loop workload, ~30 stitched stacks per 2-second run. Sample stack:
```
py     <module>                  /tmp/stitched_smoke.py
py     hot                       /tmp/stitched_smoke.py
native compactlong_float_guard   .../Python.framework/Versions/3.14/Python
```
That CPython `compactlong_float_guard` is the JIT fast-path for math on floats — exactly the kind of native leaf that was previously invisible in `stacks` and disconnected in `native_stacks`.

## Test plan

- [ ] CI green on Python 3.9–3.14 across Ubuntu and macOS
- [x] Existing `stacks` output unchanged (verified by 33 pre-existing tests still passing)
- [x] Existing `native_stacks` output unchanged (verified by smoke + unit tests)
- [x] `combined_stacks` populates with real native frames when `--stacks` is set (smoke-tested)
- [x] No `combined_stacks` data when `--stacks` is not set (no native drains -> nothing aggregated)
- [x] mypy + ruff clean

## Out of scope (future work)

- **PR 3** — viewer/GUI rendering of stitched stacks (collapsed flame view, top-N frames per Python line).
- **PR 4** — Linux-only experimental CPython-perf backend behind a feature gate.
- Bridge-frame visibility refinement (currently we apply the same `should_trace` filter as `stacks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)