### PR TITLE
GUI: combined_stacks viewer (top-N stitched Python+native stacks)

### DIFF
--- a/scalene/scalene-gui/gui-elements.ts
+++ b/scalene/scalene-gui/gui-elements.ts
@@ -33,6 +33,7 @@ declare global {
     files: Record<string, FileProfile>;
     program?: string;
     stacks?: unknown;
+    combined_stacks?: unknown;
   };
 }
 

--- a/scalene/scalene-gui/index.html.template
+++ b/scalene/scalene-gui/index.html.template
@@ -231,6 +231,12 @@
     .btn-refresh.loading {
         color: #0d6efd;
     }
+    .combined-stacks-section {
+        margin-top: 1em;
+    }
+    .combined-stack-card ol li {
+        line-height: 1.4;
+    }
     </style>
     <!-- Google Analytics - disabled in standalone mode for offline support (issue #982) -->
     {% if not standalone %}

--- a/scalene/scalene-gui/index.html.template
+++ b/scalene/scalene-gui/index.html.template
@@ -234,8 +234,9 @@
     .combined-stacks-section {
         margin-top: 1em;
     }
-    .combined-stack-card ol li {
-        line-height: 1.4;
+    .combined-stacks-flame > div:hover {
+        outline: 2px solid #333;
+        z-index: 10;
     }
     </style>
     <!-- Google Analytics - disabled in standalone mode for offline support (issue #982) -->

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -2456,7 +2456,9 @@ var ScaleneGUI = (() => {
     proposeOptimizationRegion: () => proposeOptimizationRegion,
     refreshGeminiModels: () => refreshGeminiModels,
     refreshOpenAIModels: () => refreshOpenAIModels,
+    renderCombinedStacks: () => renderCombinedStacks,
     toggleAdvanced: () => toggleAdvanced,
+    toggleCombinedStacks: () => toggleCombinedStacks,
     toggleDisplay: () => toggleDisplay,
     togglePassword: () => togglePassword,
     toggleReduced: () => toggleReduced,
@@ -71637,6 +71639,61 @@ Your output should only consist of valid Python code. Output the resulting Pytho
       btn.innerHTML = DownTriangle;
     }
   }
+  function escapeHtml(s2) {
+    return s2.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+  function basename(path3) {
+    if (!path3) return "";
+    const parts = path3.split(/[\\/]/);
+    return parts[parts.length - 1] || path3;
+  }
+  var COMBINED_STACKS_TOP_N = 20;
+  function renderCombinedStacks(prof) {
+    const stacks = prof.combined_stacks ?? [];
+    if (stacks.length === 0) return "";
+    const sorted = [...stacks].sort((a4, b3) => b3[1] - a4[1]).slice(0, COMBINED_STACKS_TOP_N);
+    const totalHits = stacks.reduce((sum3, e4) => sum3 + e4[1], 0);
+    let s2 = `<hr><div class="container-fluid combined-stacks-section">`;
+    s2 += `<p style="margin-bottom: 4px;">`;
+    s2 += `<span id="button-combined-stacks" title="Click to show or hide stitched Python+native call stacks." style="cursor: pointer; color: blue;" onClick="toggleCombinedStacks()">${RightTriangle}</span>`;
+    s2 += ` <strong>Combined Python + native call stacks</strong> `;
+    s2 += `<span class="text-muted" style="font-size: 80%;">top ${sorted.length} of ${stacks.length} stitched stacks (${totalHits} total samples)</span>`;
+    s2 += `</p>`;
+    s2 += `<div id="combined-stacks-body" style="display: none;">`;
+    for (const [frames, hits] of sorted) {
+      const pct = totalHits > 0 ? (100 * hits / totalHits).toFixed(1) : "0.0";
+      s2 += `<div class="combined-stack-card" style="border: 1px solid #ddd; border-radius: 4px; padding: 6px 10px; margin-bottom: 6px; background: #fafafa;">`;
+      s2 += `<div style="font-size: 90%; margin-bottom: 4px;"><span class="badge bg-primary">${hits} hits</span> <span class="text-muted">(${pct}%)</span></div>`;
+      s2 += `<ol class="combined-stack-frames" style="margin: 0; padding-left: 18px; font-family: monospace; font-size: 85%;">`;
+      for (const f2 of frames) {
+        const base = basename(f2.filename_or_module);
+        if (f2.kind === "py") {
+          const safeFn = encodeURIComponent(f2.filename_or_module);
+          s2 += `<li><span style="color: #0a6;">[py]</span> `;
+          s2 += `<a href="javascript:vsNavigate('${safeFn}', ${f2.line})">${escapeHtml(f2.display_name)}</a> `;
+          s2 += `<span class="text-muted">${escapeHtml(base)}:${f2.line}</span></li>`;
+        } else {
+          s2 += `<li><span style="color: #a30;">[native]</span> `;
+          s2 += `${escapeHtml(f2.display_name)} <span class="text-muted">${escapeHtml(base)}</span></li>`;
+        }
+      }
+      s2 += `</ol></div>`;
+    }
+    s2 += `</div></div>`;
+    return s2;
+  }
+  function toggleCombinedStacks() {
+    const body = document.getElementById("combined-stacks-body");
+    const btn = document.getElementById("button-combined-stacks");
+    if (!body || !btn) return;
+    if (body.style.display === "none") {
+      body.style.display = "block";
+      btn.innerHTML = DownTriangle;
+    } else {
+      body.style.display = "none";
+      btn.innerHTML = RightTriangle;
+    }
+  }
   function toggleDisplay(id2) {
     const d2 = document.getElementById(`profile-${id2}`);
     if (d2) {
@@ -72022,6 +72079,7 @@ Your output should only consist of valid Python code. Output the resulting Pytho
     }
     files4 = files4.filter((x5) => !excludedFiles.has(x5));
     s2 += "</div>";
+    s2 += renderCombinedStacks(prof);
     const p2 = document.getElementById("profile");
     if (p2) {
       p2.innerHTML = s2;
@@ -72346,6 +72404,7 @@ Your output should only consist of valid Python code. Output the resulting Pytho
   window.collapseAll = collapseAll;
   window.expandAll = expandAll;
   window.toggleDisplay = toggleDisplay;
+  window.toggleCombinedStacks = toggleCombinedStacks;
   window.toggleReduced = toggleReduced;
   window.onFileDisplayModeChange = onFileDisplayModeChange;
   window.load = load3;

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -71085,6 +71085,12 @@ Your output should only consist of valid Python code. Output the resulting Pytho
         filePath: filename,
         lineNumber: lineno
       });
+      return;
+    } catch {
+    }
+    try {
+      const decoded = filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
+      window.location.href = `vscode://file/${decoded}:${lineno}:1`;
     } catch {
     }
   }
@@ -71669,8 +71675,18 @@ Your output should only consist of valid Python code. Output the resulting Pytho
         const base = basename(f2.filename_or_module);
         if (f2.kind === "py") {
           const safeFn = escape(f2.filename_or_module);
+          const code = (f2.code_line ?? "").trim();
+          let label;
+          if (code) {
+            const highlighted = Prism2.highlight(code, Prism2.languages.python, "python");
+            label = `<code class="language-python" style="white-space: pre;">${highlighted}</code>`;
+          } else if (f2.display_name === "<module>") {
+            label = `<span class="text-muted">&lt;top level&gt;</span>`;
+          } else {
+            label = escapeHtml(f2.display_name);
+          }
           s2 += `<li><span style="color: #0a6;">[py]</span> `;
-          s2 += `${escapeHtml(f2.display_name)} `;
+          s2 += `${label} `;
           s2 += `<span style="cursor: pointer; color: #0a58ca; text-decoration: underline;" `;
           s2 += `title="Click to open ${escapeHtml(f2.filename_or_module)}:${f2.line} in VS Code" `;
           s2 += `onclick="vsNavigate('${safeFn}',${f2.line})">${escapeHtml(base)}:${f2.line}</span></li>`;

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -71669,56 +71669,129 @@ Your output should only consist of valid Python code. Output the resulting Pytho
   function escapeHtml(s2) {
     return s2.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
   }
-  function basename(path3) {
-    if (!path3) return "";
-    const parts = path3.split(/[\\/]/);
-    return parts[parts.length - 1] || path3;
+  var FLAME_ROW_HEIGHT = 18;
+  var FLAME_MIN_LABEL_WIDTH_PCT = 1.5;
+  function buildFlameTree(stacks) {
+    const root = {
+      kind: "root",
+      name: "(all stacks)",
+      filename: "",
+      line: null,
+      code_line: void 0,
+      selfHits: 0,
+      totalHits: 0,
+      children: []
+    };
+    const childMaps = /* @__PURE__ */ new WeakMap();
+    childMaps.set(root, /* @__PURE__ */ new Map());
+    for (const [frames, hits] of stacks) {
+      let node = root;
+      node.totalHits += hits;
+      for (const f2 of frames) {
+        const key2 = `${f2.kind}|${f2.filename_or_module}|${f2.kind === "py" ? f2.line : "x"}|${f2.display_name}`;
+        const map4 = childMaps.get(node);
+        if (!map4) continue;
+        let child = map4.get(key2);
+        if (!child) {
+          child = {
+            kind: f2.kind,
+            name: f2.display_name,
+            filename: f2.filename_or_module,
+            line: f2.kind === "py" ? f2.line : null,
+            code_line: f2.kind === "py" ? f2.code_line : void 0,
+            selfHits: 0,
+            totalHits: 0,
+            children: []
+          };
+          map4.set(key2, child);
+          childMaps.set(child, /* @__PURE__ */ new Map());
+          node.children.push(child);
+        }
+        child.totalHits += hits;
+        node = child;
+      }
+      node.selfHits += hits;
+    }
+    function sortDescByHits(n2) {
+      n2.children.sort((a4, b3) => b3.totalHits - a4.totalHits);
+      for (const c4 of n2.children) sortDescByHits(c4);
+    }
+    sortDescByHits(root);
+    return root;
   }
-  var COMBINED_STACKS_TOP_N = 20;
+  function flameMaxDepth(node) {
+    if (node.children.length === 0) return 0;
+    let m4 = 0;
+    for (const c4 of node.children) {
+      const d2 = flameMaxDepth(c4);
+      if (d2 > m4) m4 = d2;
+    }
+    return 1 + m4;
+  }
+  function flameColor(name4, kind) {
+    if (kind === "root") return "#ddd";
+    let h3 = 0;
+    for (let i2 = 0; i2 < name4.length; i2++) {
+      h3 = (h3 << 5) - h3 + name4.charCodeAt(i2) | 0;
+    }
+    const hue2 = Math.abs(h3) % 360;
+    if (kind === "py") return `hsl(${hue2}, 45%, 78%)`;
+    return `hsl(${(hue2 + 30) % 360}, 70%, 65%)`;
+  }
+  function renderFlameNode(node, depth, leftPct, widthPct, total) {
+    const pct = total > 0 ? (node.totalHits / total * 100).toFixed(1) : "0.0";
+    const codeLineText = (node.code_line ?? "").trim();
+    let tooltip2;
+    if (node.kind === "py") {
+      const tail = codeLineText ? `
+${codeLineText}` : "";
+      tooltip2 = `[py] ${node.name}
+${node.filename}:${node.line}
+${node.totalHits} hits (${pct}%)${tail}`;
+    } else {
+      tooltip2 = `[native] ${node.name}
+${node.filename}
+${node.totalHits} hits (${pct}%)`;
+    }
+    const top = depth * FLAME_ROW_HEIGHT;
+    const color5 = flameColor(node.name, node.kind);
+    const showLabel = widthPct >= FLAME_MIN_LABEL_WIDTH_PCT;
+    const labelHtml = showLabel ? escapeHtml(node.name) : "";
+    const cursor3 = node.kind === "py" && node.line !== null ? "pointer" : "default";
+    const clickAttr = node.kind === "py" && node.line !== null ? ` onclick="vsNavigate('${escape(node.filename)}',${node.line})"` : "";
+    return `<div style="position:absolute;top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;height:${FLAME_ROW_HEIGHT - 1}px;background:${color5};border:1px solid rgba(0,0,0,0.12);overflow:hidden;font-family:monospace;font-size:11px;line-height:${FLAME_ROW_HEIGHT - 1}px;padding:0 4px;white-space:nowrap;text-overflow:ellipsis;cursor:${cursor3};box-sizing:border-box;" title="${escapeHtml(tooltip2)}"${clickAttr}>${labelHtml}</div>`;
+  }
+  function renderFlameRecursive(node, depth, leftPct, widthPct, total) {
+    let s2 = "";
+    if (depth > 0) {
+      s2 += renderFlameNode(node, depth - 1, leftPct, widthPct, total);
+    }
+    let childLeft = leftPct;
+    for (const child of node.children) {
+      const childWidth = total > 0 ? child.totalHits / total * widthPct * (total / node.totalHits) : 0;
+      const w3 = node.totalHits > 0 ? child.totalHits / node.totalHits * widthPct : 0;
+      s2 += renderFlameRecursive(child, depth + 1, childLeft, w3, total);
+      childLeft += w3;
+    }
+    return s2;
+  }
   function renderCombinedStacks(prof) {
     const stacks = prof.combined_stacks ?? [];
     if (stacks.length === 0) return "";
-    const sorted = [...stacks].sort((a4, b3) => b3[1] - a4[1]).slice(0, COMBINED_STACKS_TOP_N);
-    const totalHits = stacks.reduce((sum3, e4) => sum3 + e4[1], 0);
+    const root = buildFlameTree(stacks);
+    const totalHits = root.totalHits;
+    const depth = flameMaxDepth(root);
+    const containerHeight = depth * FLAME_ROW_HEIGHT;
     let s2 = `<hr><div class="container-fluid combined-stacks-section">`;
     s2 += `<p style="margin-bottom: 4px;">`;
     s2 += `<span id="button-combined-stacks" title="Click to show or hide stitched Python+native call stacks." style="cursor: pointer; color: blue;" onClick="toggleCombinedStacks()">${RightTriangle}</span>`;
     s2 += ` <strong>Combined Python + native call stacks</strong> `;
-    s2 += `<span class="text-muted" style="font-size: 80%;">top ${sorted.length} of ${stacks.length} stitched stacks (${totalHits} total samples)</span>`;
+    s2 += `<span class="text-muted" style="font-size: 80%;">${stacks.length} stitched stacks, ${totalHits} samples \u2014 hover for details, click a [py] frame to jump to its source line</span>`;
     s2 += `</p>`;
     s2 += `<div id="combined-stacks-body" style="display: none;">`;
-    for (const [frames, hits] of sorted) {
-      const pct = totalHits > 0 ? (100 * hits / totalHits).toFixed(1) : "0.0";
-      s2 += `<div class="combined-stack-card" style="border: 1px solid #ddd; border-radius: 4px; padding: 6px 10px; margin-bottom: 6px; background: #fafafa;">`;
-      s2 += `<div style="font-size: 90%; margin-bottom: 4px;"><span class="badge bg-primary">${hits} hits</span> <span class="text-muted">(${pct}%)</span></div>`;
-      s2 += `<ol class="combined-stack-frames" style="margin: 0; padding-left: 18px; font-family: monospace; font-size: 85%;">`;
-      for (const f2 of frames) {
-        const base = basename(f2.filename_or_module);
-        if (f2.kind === "py") {
-          const safeFn = escape(f2.filename_or_module);
-          const code = (f2.code_line ?? "").trim();
-          let label;
-          if (code) {
-            const highlighted = Prism2.highlight(code, Prism2.languages.python, "python");
-            label = `<code class="language-python" style="white-space: pre;">${highlighted}</code>`;
-          } else if (f2.display_name === "<module>") {
-            label = `<span class="text-muted">&lt;top level&gt;</span>`;
-          } else {
-            label = escapeHtml(f2.display_name);
-          }
-          s2 += `<li><span style="color: #0a6;">[py]</span> `;
-          s2 += `${label} `;
-          s2 += `<span style="cursor: pointer; color: #0a58ca; text-decoration: underline;" `;
-          s2 += `title="Click to open ${escapeHtml(f2.filename_or_module)}:${f2.line} in VS Code" `;
-          s2 += `onclick="vsNavigate('${safeFn}',${f2.line})">${escapeHtml(base)}:${f2.line}</span></li>`;
-        } else {
-          s2 += `<li><span style="color: #a30;">[native]</span> `;
-          s2 += `${escapeHtml(f2.display_name)} <span class="text-muted">${escapeHtml(base)}</span></li>`;
-        }
-      }
-      s2 += `</ol></div>`;
-    }
-    s2 += `</div></div>`;
+    s2 += `<div class="combined-stacks-flame" style="position:relative;width:100%;height:${containerHeight}px;border:1px solid #ccc;background:#f0f0f0;overflow-x:auto;">`;
+    s2 += renderFlameRecursive(root, 0, 0, 100, totalHits);
+    s2 += `</div></div></div>`;
     return s2;
   }
   function toggleCombinedStacks() {

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -71668,10 +71668,12 @@ Your output should only consist of valid Python code. Output the resulting Pytho
       for (const f2 of frames) {
         const base = basename(f2.filename_or_module);
         if (f2.kind === "py") {
-          const safeFn = encodeURIComponent(f2.filename_or_module);
+          const safeFn = escape(f2.filename_or_module);
           s2 += `<li><span style="color: #0a6;">[py]</span> `;
-          s2 += `<a href="javascript:vsNavigate('${safeFn}', ${f2.line})">${escapeHtml(f2.display_name)}</a> `;
-          s2 += `<span class="text-muted">${escapeHtml(base)}:${f2.line}</span></li>`;
+          s2 += `${escapeHtml(f2.display_name)} `;
+          s2 += `<span style="cursor: pointer; color: #0a58ca; text-decoration: underline;" `;
+          s2 += `title="Click to open ${escapeHtml(f2.filename_or_module)}:${f2.line} in VS Code" `;
+          s2 += `onclick="vsNavigate('${safeFn}',${f2.line})">${escapeHtml(base)}:${f2.line}</span></li>`;
         } else {
           s2 += `<li><span style="color: #a30;">[native]</span> `;
           s2 += `${escapeHtml(f2.display_name)} <span class="text-muted">${escapeHtml(base)}</span></li>`;

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -71091,12 +71091,23 @@ Your output should only consist of valid Python code. Output the resulting Pytho
     const decoded = filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
     const fileNumber = fileNumberByFilename.get(decoded);
     if (fileNumber !== void 0) {
-      const fileSection = document.getElementById(`profile-file-${fileNumber}`);
+      const fileId = `file-${fileNumber}`;
+      const fileSection = document.getElementById(`profile-${fileId}`);
       if (fileSection && fileSection.style.display === "none") {
-        toggleDisplay(`file-${fileNumber}`);
+        toggleDisplay(fileId);
       }
       const target2 = document.getElementById(`code-${fileNumber}-${lineno}`);
       if (target2) {
+        const tr2 = target2.closest("tr");
+        if (tr2 && tr2.style.display === "none") {
+          const select2 = document.getElementById(
+            `display-mode-${fileId}`
+          );
+          if (select2) {
+            select2.value = "all";
+          }
+          applyFileDisplayMode(fileId, "all");
+        }
         target2.scrollIntoView({ behavior: "smooth", block: "center" });
         const td = target2.closest("td");
         const flashTarget = td ?? target2;

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -71088,13 +71088,34 @@ Your output should only consist of valid Python code. Output the resulting Pytho
       return;
     } catch {
     }
+    const decoded = filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
+    const fileNumber = fileNumberByFilename.get(decoded);
+    if (fileNumber !== void 0) {
+      const fileSection = document.getElementById(`profile-file-${fileNumber}`);
+      if (fileSection && fileSection.style.display === "none") {
+        toggleDisplay(`file-${fileNumber}`);
+      }
+      const target2 = document.getElementById(`code-${fileNumber}-${lineno}`);
+      if (target2) {
+        target2.scrollIntoView({ behavior: "smooth", block: "center" });
+        const td = target2.closest("td");
+        const flashTarget = td ?? target2;
+        const prevBg = flashTarget.style.backgroundColor;
+        flashTarget.style.transition = "background-color 0.2s ease";
+        flashTarget.style.backgroundColor = "#fff3a8";
+        window.setTimeout(() => {
+          flashTarget.style.backgroundColor = prevBg;
+        }, 1200);
+        return;
+      }
+    }
     try {
-      const decoded = filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
       window.location.href = `vscode://file/${decoded}:${lineno}:1`;
     } catch {
     }
   }
   var maxLinesPerRegion = 50;
+  var fileNumberByFilename = /* @__PURE__ */ new Map();
   var showedExplosion = {};
   function proposeOptimizationRegion(filename, file_number, line4) {
     proposeOptimization(
@@ -71912,6 +71933,7 @@ Your output should only consist of valid Python code. Output the resulting Pytho
     let fileIteration = 0;
     allIds = [];
     const excludedFiles = /* @__PURE__ */ new Set();
+    fileNumberByFilename.clear();
     for (const ff of files4) {
       fileIteration++;
       if (ff[1].percent_cpu_time < 1 && ma2[ff[0]] < 0.01 * max_alloc) {
@@ -71920,6 +71942,7 @@ Your output should only consist of valid Python code. Output the resulting Pytho
       }
       const id2 = `file-${fileIteration}`;
       allIds.push(id2);
+      fileNumberByFilename.set(ff[0], fileIteration);
       s2 += '<p class="text-left sticky-top bg-white bg-opacity-75" style="backdrop-filter: blur(2px)">';
       let displayStr = "display:block;";
       let triangle = DownTriangle;

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -130,10 +130,7 @@ declare const globalThis: {
 };
 
 export function vsNavigate(filename: string, lineno: number): void {
-  // If we are in VS Code's webview, postMessage to the host. In a regular
-  // browser, fall back to the vscode:// URL scheme — macOS / Windows route
-  // these to VS Code if it's installed. The browser shows a one-time
-  // permission prompt on first use, then silently opens the file.
+  // VS Code webview: use the host postMessage API.
   try {
     const vscode = (
       window as unknown as {
@@ -147,19 +144,55 @@ export function vsNavigate(filename: string, lineno: number): void {
     });
     return;
   } catch {
-    // Not running in VS Code's webview — fall through.
+    // Not running in VS Code's webview — fall through to in-page nav.
   }
+
+  const decoded =
+    filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
+
+  // Standalone browser: scroll to the line within the rendered per-file
+  // table. file_number is assigned during display() and the line span IDs
+  // are `code-${file_number}-${lineno}`.
+  const fileNumber = fileNumberByFilename.get(decoded);
+  if (fileNumber !== undefined) {
+    const fileSection = document.getElementById(`profile-file-${fileNumber}`);
+    if (fileSection && fileSection.style.display === "none") {
+      // Expand the per-file section first so the line can scroll into view.
+      toggleDisplay(`file-${fileNumber}`);
+    }
+    const target = document.getElementById(`code-${fileNumber}-${lineno}`);
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+      // Brief yellow flash so the user can see what got selected.
+      const td = target.closest("td") as HTMLElement | null;
+      const flashTarget = td ?? target;
+      const prevBg = flashTarget.style.backgroundColor;
+      flashTarget.style.transition = "background-color 0.2s ease";
+      flashTarget.style.backgroundColor = "#fff3a8";
+      window.setTimeout(() => {
+        flashTarget.style.backgroundColor = prevBg;
+      }, 1200);
+      return;
+    }
+  }
+
+  // File isn't displayed in the GUI (excluded by the per-file CPU/memory
+  // threshold, or referenced from a stack but not in prof.files). Last
+  // resort: vscode:// URL — opens VS Code if installed, otherwise no-op.
   try {
-    const decoded =
-      filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
-    // vscode://file/<absolute-path>:<line>:<col> — column 1 is fine for line nav.
     window.location.href = `vscode://file/${decoded}:${lineno}:1`;
   } catch {
-    // Last-resort no-op.
+    // Truly nothing we can do.
   }
 }
 
 const maxLinesPerRegion = 50; // Only show regions that are no more than this many lines.
+
+// Filled in by display() each time the profile renders. Maps the filename
+// (matching keys of prof.files) to the file_number used in per-line code
+// span IDs (`code-${file_number}-${lineno}`). vsNavigate() consults this
+// to scroll within the page when running in a regular browser.
+const fileNumberByFilename: Map<string, number> = new Map();
 
 let showedExplosion: Record<string, boolean> = {}; // Used so we only show one explosion per region.
 
@@ -1209,6 +1242,7 @@ async function display(prof: Profile): Promise<void> {
   let fileIteration = 0;
   allIds = [];
   const excludedFiles = new Set<[string, FileData]>();
+  fileNumberByFilename.clear();
   for (const ff of files) {
     fileIteration++;
     // Stop once total CPU time / memory consumption are below some threshold (1%)
@@ -1218,6 +1252,7 @@ async function display(prof: Profile): Promise<void> {
     }
     const id = `file-${fileIteration}`;
     allIds.push(id);
+    fileNumberByFilename.set(ff[0], fileIteration);
     s +=
       '<p class="text-left sticky-top bg-white bg-opacity-75" style="backdrop-filter: blur(2px)">';
     let displayStr = "display:block;";

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -83,6 +83,7 @@ type CombinedFrame =
       display_name: string;
       filename_or_module: string;
       line: number;
+      code_line?: string;
       ip: null;
       offset: null;
     }
@@ -129,16 +130,32 @@ declare const globalThis: {
 };
 
 export function vsNavigate(filename: string, lineno: number): void {
-  // If we are in VS Code, clicking on a line number in Scalene's web UI will navigate to that line in the source code.
+  // If we are in VS Code's webview, postMessage to the host. In a regular
+  // browser, fall back to the vscode:// URL scheme — macOS / Windows route
+  // these to VS Code if it's installed. The browser shows a one-time
+  // permission prompt on first use, then silently opens the file.
   try {
-    const vscode = (window as unknown as { acquireVsCodeApi: () => { postMessage: (msg: unknown) => void } }).acquireVsCodeApi();
+    const vscode = (
+      window as unknown as {
+        acquireVsCodeApi: () => { postMessage: (msg: unknown) => void };
+      }
+    ).acquireVsCodeApi();
     vscode.postMessage({
       command: "jumpToLine",
       filePath: filename,
       lineNumber: lineno,
     });
+    return;
   } catch {
-    // Do nothing
+    // Not running in VS Code's webview — fall through.
+  }
+  try {
+    const decoded =
+      filename.indexOf("%") >= 0 ? decodeURIComponent(filename) : filename;
+    // vscode://file/<absolute-path>:<line>:<col> — column 1 is fine for line nav.
+    window.location.href = `vscode://file/${decoded}:${lineno}:1`;
+  } catch {
+    // Last-resort no-op.
   }
 }
 
@@ -907,12 +924,25 @@ export function renderCombinedStacks(prof: Profile): string {
     for (const f of frames) {
       const base = basename(f.filename_or_module);
       if (f.kind === "py") {
-        // Match the per-line table convention (scalene-gui.ts:768): the
-        // file:line text is the click target for vsNavigate, not the
-        // function name. The function name stays as plain text.
+        // Show the actual source line of code (syntax-highlighted) — much
+        // more useful than the bare function name, especially for module
+        // top-level frames where the qualname is just "<module>". Falls
+        // back to the function name when the source isn't readable.
+        // file:line is the click target for vsNavigate, matching the
+        // per-line table convention at scalene-gui.ts:768.
         const safeFn = escape(f.filename_or_module);
+        const code = (f.code_line ?? "").trim();
+        let label: string;
+        if (code) {
+          const highlighted = Prism.highlight(code, Prism.languages.python, "python");
+          label = `<code class="language-python" style="white-space: pre;">${highlighted}</code>`;
+        } else if (f.display_name === "<module>") {
+          label = `<span class="text-muted">&lt;top level&gt;</span>`;
+        } else {
+          label = escapeHtml(f.display_name);
+        }
         s += `<li><span style="color: #0a6;">[py]</span> `;
-        s += `${escapeHtml(f.display_name)} `;
+        s += `${label} `;
         s += `<span style="cursor: pointer; color: #0a58ca; text-decoration: underline;" `;
         s += `title="Click to open ${escapeHtml(f.filename_or_module)}:${f.line} in VS Code" `;
         s += `onclick="vsNavigate('${safeFn}',${f.line})">${escapeHtml(base)}:${f.line}</span></li>`;

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -155,13 +155,28 @@ export function vsNavigate(filename: string, lineno: number): void {
   // are `code-${file_number}-${lineno}`.
   const fileNumber = fileNumberByFilename.get(decoded);
   if (fileNumber !== undefined) {
-    const fileSection = document.getElementById(`profile-file-${fileNumber}`);
+    const fileId = `file-${fileNumber}`;
+    const fileSection = document.getElementById(`profile-${fileId}`);
     if (fileSection && fileSection.style.display === "none") {
       // Expand the per-file section first so the line can scroll into view.
-      toggleDisplay(`file-${fileNumber}`);
+      toggleDisplay(fileId);
     }
     const target = document.getElementById(`code-${fileNumber}-${lineno}`);
     if (target) {
+      // The line span exists in the DOM, but the surrounding <tr> may be
+      // hidden by the file's display mode (default is "profiled-functions",
+      // which suppresses empty rows). If so, switch the per-file display
+      // mode to "all" so the line is actually visible after scroll.
+      const tr = target.closest("tr") as HTMLElement | null;
+      if (tr && tr.style.display === "none") {
+        const select = document.getElementById(
+          `display-mode-${fileId}`,
+        ) as HTMLSelectElement | null;
+        if (select) {
+          select.value = "all";
+        }
+        applyFileDisplayMode(fileId, "all");
+      }
       target.scrollIntoView({ behavior: "smooth", block: "center" });
       // Brief yellow flash so the user can see what got selected.
       const td = target.closest("td") as HTMLElement | null;

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -77,6 +77,26 @@ interface FileData {
   leaks?: Record<number, { velocity_mb_s: number }>;
 }
 
+type CombinedFrame =
+  | {
+      kind: "py";
+      display_name: string;
+      filename_or_module: string;
+      line: number;
+      ip: null;
+      offset: null;
+    }
+  | {
+      kind: "native";
+      display_name: string;
+      filename_or_module: string;
+      line: null;
+      ip: number;
+      offset: number;
+    };
+
+type CombinedStackEntry = [CombinedFrame[], number];
+
 interface Profile {
   files: Record<string, FileData>;
   gpu: boolean;
@@ -90,6 +110,7 @@ interface Profile {
   growth_rate: number;
   program?: string;
   stacks?: unknown;
+  combined_stacks?: CombinedStackEntry[];
 }
 
 interface Column {
@@ -847,6 +868,73 @@ function expandDisplay(id: string): void {
   }
 }
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function basename(path: string): string {
+  if (!path) return "";
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+const COMBINED_STACKS_TOP_N = 20;
+
+export function renderCombinedStacks(prof: Profile): string {
+  const stacks = prof.combined_stacks ?? [];
+  if (stacks.length === 0) return "";
+
+  const sorted = [...stacks].sort((a, b) => b[1] - a[1]).slice(0, COMBINED_STACKS_TOP_N);
+  const totalHits = stacks.reduce((sum, e) => sum + e[1], 0);
+
+  let s = `<hr><div class="container-fluid combined-stacks-section">`;
+  s += `<p style="margin-bottom: 4px;">`;
+  s += `<span id="button-combined-stacks" title="Click to show or hide stitched Python+native call stacks." style="cursor: pointer; color: blue;" onClick="toggleCombinedStacks()">${RightTriangle}</span>`;
+  s += ` <strong>Combined Python + native call stacks</strong> `;
+  s += `<span class="text-muted" style="font-size: 80%;">top ${sorted.length} of ${stacks.length} stitched stacks (${totalHits} total samples)</span>`;
+  s += `</p>`;
+  s += `<div id="combined-stacks-body" style="display: none;">`;
+  for (const [frames, hits] of sorted) {
+    const pct = totalHits > 0 ? ((100 * hits) / totalHits).toFixed(1) : "0.0";
+    s += `<div class="combined-stack-card" style="border: 1px solid #ddd; border-radius: 4px; padding: 6px 10px; margin-bottom: 6px; background: #fafafa;">`;
+    s += `<div style="font-size: 90%; margin-bottom: 4px;"><span class="badge bg-primary">${hits} hits</span> <span class="text-muted">(${pct}%)</span></div>`;
+    s += `<ol class="combined-stack-frames" style="margin: 0; padding-left: 18px; font-family: monospace; font-size: 85%;">`;
+    for (const f of frames) {
+      const base = basename(f.filename_or_module);
+      if (f.kind === "py") {
+        const safeFn = encodeURIComponent(f.filename_or_module);
+        s += `<li><span style="color: #0a6;">[py]</span> `;
+        s += `<a href="javascript:vsNavigate('${safeFn}', ${f.line})">${escapeHtml(f.display_name)}</a> `;
+        s += `<span class="text-muted">${escapeHtml(base)}:${f.line}</span></li>`;
+      } else {
+        s += `<li><span style="color: #a30;">[native]</span> `;
+        s += `${escapeHtml(f.display_name)} <span class="text-muted">${escapeHtml(base)}</span></li>`;
+      }
+    }
+    s += `</ol></div>`;
+  }
+  s += `</div></div>`;
+  return s;
+}
+
+export function toggleCombinedStacks(): void {
+  const body = document.getElementById("combined-stacks-body");
+  const btn = document.getElementById("button-combined-stacks");
+  if (!body || !btn) return;
+  if (body.style.display === "none") {
+    body.style.display = "block";
+    btn.innerHTML = DownTriangle;
+  } else {
+    body.style.display = "none";
+    btn.innerHTML = RightTriangle;
+  }
+}
+
 export function toggleDisplay(id: string): void {
   const d = document.getElementById(`profile-${id}`);
   if (d) {
@@ -1310,6 +1398,7 @@ async function display(prof: Profile): Promise<void> {
   // Remove any excluded files.
   files = files.filter((x) => !excludedFiles.has(x));
   s += "</div>";
+  s += renderCombinedStacks(prof);
   const p = document.getElementById("profile");
   if (p) {
     p.innerHTML = s;
@@ -1721,6 +1810,7 @@ setInterval(sendHeartbeat, 10000); // Send heartbeat every 10 seconds
 (window as unknown as Record<string, unknown>).collapseAll = collapseAll;
 (window as unknown as Record<string, unknown>).expandAll = expandAll;
 (window as unknown as Record<string, unknown>).toggleDisplay = toggleDisplay;
+(window as unknown as Record<string, unknown>).toggleCombinedStacks = toggleCombinedStacks;
 (window as unknown as Record<string, unknown>).toggleReduced = toggleReduced;
 (window as unknown as Record<string, unknown>).onFileDisplayModeChange = onFileDisplayModeChange;
 (window as unknown as Record<string, unknown>).load = load;

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -933,60 +933,177 @@ function basename(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
-const COMBINED_STACKS_TOP_N = 20;
+// Flame-chart rendering for combined_stacks. Stacks sharing a common
+// outermost-prefix collapse into wider parent rectangles; siblings split.
+// Layout is "icicle" — root at top, leaves at bottom — which reads
+// naturally for call-from-the-top stacks (outermost-first).
+const FLAME_ROW_HEIGHT = 18;
+const FLAME_MIN_LABEL_WIDTH_PCT = 1.5;
+
+interface FlameNode {
+  kind: "py" | "native" | "root";
+  name: string;
+  filename: string;
+  line: number | null;
+  code_line: string | undefined;
+  selfHits: number;
+  totalHits: number;
+  children: FlameNode[];
+}
+
+function buildFlameTree(stacks: CombinedStackEntry[]): FlameNode {
+  const root: FlameNode = {
+    kind: "root",
+    name: "(all stacks)",
+    filename: "",
+    line: null,
+    code_line: undefined,
+    selfHits: 0,
+    totalHits: 0,
+    children: [],
+  };
+  const childMaps = new WeakMap<FlameNode, Map<string, FlameNode>>();
+  childMaps.set(root, new Map());
+  for (const [frames, hits] of stacks) {
+    let node: FlameNode = root;
+    node.totalHits += hits;
+    for (const f of frames) {
+      const key = `${f.kind}|${f.filename_or_module}|${
+        f.kind === "py" ? f.line : "x"
+      }|${f.display_name}`;
+      const map = childMaps.get(node);
+      if (!map) continue;
+      let child = map.get(key);
+      if (!child) {
+        child = {
+          kind: f.kind,
+          name: f.display_name,
+          filename: f.filename_or_module,
+          line: f.kind === "py" ? f.line : null,
+          code_line: f.kind === "py" ? f.code_line : undefined,
+          selfHits: 0,
+          totalHits: 0,
+          children: [],
+        };
+        map.set(key, child);
+        childMaps.set(child, new Map());
+        node.children.push(child);
+      }
+      child.totalHits += hits;
+      node = child;
+    }
+    node.selfHits += hits;
+  }
+  function sortDescByHits(n: FlameNode): void {
+    n.children.sort((a, b) => b.totalHits - a.totalHits);
+    for (const c of n.children) sortDescByHits(c);
+  }
+  sortDescByHits(root);
+  return root;
+}
+
+function flameMaxDepth(node: FlameNode): number {
+  if (node.children.length === 0) return 0;
+  let m = 0;
+  for (const c of node.children) {
+    const d = flameMaxDepth(c);
+    if (d > m) m = d;
+  }
+  return 1 + m;
+}
+
+function flameColor(name: string, kind: "py" | "native" | "root"): string {
+  if (kind === "root") return "#ddd";
+  let h = 0;
+  for (let i = 0; i < name.length; i++) {
+    h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(h) % 360;
+  // py frames muted/cool, native frames warmer/saturated so the seam is
+  // visible at a glance.
+  if (kind === "py") return `hsl(${hue}, 45%, 78%)`;
+  return `hsl(${(hue + 30) % 360}, 70%, 65%)`;
+}
+
+function renderFlameNode(
+  node: FlameNode,
+  depth: number,
+  leftPct: number,
+  widthPct: number,
+  total: number,
+): string {
+  const pct = total > 0 ? ((node.totalHits / total) * 100).toFixed(1) : "0.0";
+  const codeLineText = (node.code_line ?? "").trim();
+  let tooltip: string;
+  if (node.kind === "py") {
+    const tail = codeLineText ? `\n${codeLineText}` : "";
+    tooltip = `[py] ${node.name}\n${node.filename}:${node.line}\n${node.totalHits} hits (${pct}%)${tail}`;
+  } else {
+    tooltip = `[native] ${node.name}\n${node.filename}\n${node.totalHits} hits (${pct}%)`;
+  }
+  const top = depth * FLAME_ROW_HEIGHT;
+  const color = flameColor(node.name, node.kind);
+  const showLabel = widthPct >= FLAME_MIN_LABEL_WIDTH_PCT;
+  const labelHtml = showLabel ? escapeHtml(node.name) : "";
+  const cursor = node.kind === "py" && node.line !== null ? "pointer" : "default";
+  const clickAttr =
+    node.kind === "py" && node.line !== null
+      ? ` onclick="vsNavigate('${escape(node.filename)}',${node.line})"`
+      : "";
+  return (
+    `<div style="position:absolute;` +
+    `top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;` +
+    `height:${FLAME_ROW_HEIGHT - 1}px;background:${color};` +
+    `border:1px solid rgba(0,0,0,0.12);overflow:hidden;` +
+    `font-family:monospace;font-size:11px;` +
+    `line-height:${FLAME_ROW_HEIGHT - 1}px;padding:0 4px;` +
+    `white-space:nowrap;text-overflow:ellipsis;cursor:${cursor};box-sizing:border-box;"` +
+    ` title="${escapeHtml(tooltip)}"${clickAttr}>${labelHtml}</div>`
+  );
+}
+
+function renderFlameRecursive(
+  node: FlameNode,
+  depth: number,
+  leftPct: number,
+  widthPct: number,
+  total: number,
+): string {
+  let s = "";
+  if (depth > 0) {
+    s += renderFlameNode(node, depth - 1, leftPct, widthPct, total);
+  }
+  let childLeft = leftPct;
+  for (const child of node.children) {
+    const childWidth = total > 0 ? (child.totalHits / total) * widthPct * (total / node.totalHits) : 0;
+    // Equivalent: child.totalHits / node.totalHits * widthPct (parent's width slice).
+    const w = node.totalHits > 0 ? (child.totalHits / node.totalHits) * widthPct : 0;
+    s += renderFlameRecursive(child, depth + 1, childLeft, w, total);
+    childLeft += w;
+    void childWidth;
+  }
+  return s;
+}
 
 export function renderCombinedStacks(prof: Profile): string {
   const stacks = prof.combined_stacks ?? [];
   if (stacks.length === 0) return "";
 
-  const sorted = [...stacks].sort((a, b) => b[1] - a[1]).slice(0, COMBINED_STACKS_TOP_N);
-  const totalHits = stacks.reduce((sum, e) => sum + e[1], 0);
+  const root = buildFlameTree(stacks);
+  const totalHits = root.totalHits;
+  const depth = flameMaxDepth(root);
+  const containerHeight = depth * FLAME_ROW_HEIGHT;
 
   let s = `<hr><div class="container-fluid combined-stacks-section">`;
   s += `<p style="margin-bottom: 4px;">`;
   s += `<span id="button-combined-stacks" title="Click to show or hide stitched Python+native call stacks." style="cursor: pointer; color: blue;" onClick="toggleCombinedStacks()">${RightTriangle}</span>`;
   s += ` <strong>Combined Python + native call stacks</strong> `;
-  s += `<span class="text-muted" style="font-size: 80%;">top ${sorted.length} of ${stacks.length} stitched stacks (${totalHits} total samples)</span>`;
+  s += `<span class="text-muted" style="font-size: 80%;">${stacks.length} stitched stacks, ${totalHits} samples — hover for details, click a [py] frame to jump to its source line</span>`;
   s += `</p>`;
   s += `<div id="combined-stacks-body" style="display: none;">`;
-  for (const [frames, hits] of sorted) {
-    const pct = totalHits > 0 ? ((100 * hits) / totalHits).toFixed(1) : "0.0";
-    s += `<div class="combined-stack-card" style="border: 1px solid #ddd; border-radius: 4px; padding: 6px 10px; margin-bottom: 6px; background: #fafafa;">`;
-    s += `<div style="font-size: 90%; margin-bottom: 4px;"><span class="badge bg-primary">${hits} hits</span> <span class="text-muted">(${pct}%)</span></div>`;
-    s += `<ol class="combined-stack-frames" style="margin: 0; padding-left: 18px; font-family: monospace; font-size: 85%;">`;
-    for (const f of frames) {
-      const base = basename(f.filename_or_module);
-      if (f.kind === "py") {
-        // Show the actual source line of code (syntax-highlighted) — much
-        // more useful than the bare function name, especially for module
-        // top-level frames where the qualname is just "<module>". Falls
-        // back to the function name when the source isn't readable.
-        // file:line is the click target for vsNavigate, matching the
-        // per-line table convention at scalene-gui.ts:768.
-        const safeFn = escape(f.filename_or_module);
-        const code = (f.code_line ?? "").trim();
-        let label: string;
-        if (code) {
-          const highlighted = Prism.highlight(code, Prism.languages.python, "python");
-          label = `<code class="language-python" style="white-space: pre;">${highlighted}</code>`;
-        } else if (f.display_name === "<module>") {
-          label = `<span class="text-muted">&lt;top level&gt;</span>`;
-        } else {
-          label = escapeHtml(f.display_name);
-        }
-        s += `<li><span style="color: #0a6;">[py]</span> `;
-        s += `${label} `;
-        s += `<span style="cursor: pointer; color: #0a58ca; text-decoration: underline;" `;
-        s += `title="Click to open ${escapeHtml(f.filename_or_module)}:${f.line} in VS Code" `;
-        s += `onclick="vsNavigate('${safeFn}',${f.line})">${escapeHtml(base)}:${f.line}</span></li>`;
-      } else {
-        s += `<li><span style="color: #a30;">[native]</span> `;
-        s += `${escapeHtml(f.display_name)} <span class="text-muted">${escapeHtml(base)}</span></li>`;
-      }
-    }
-    s += `</ol></div>`;
-  }
-  s += `</div></div>`;
+  s += `<div class="combined-stacks-flame" style="position:relative;width:100%;height:${containerHeight}px;border:1px solid #ccc;background:#f0f0f0;overflow-x:auto;">`;
+  s += renderFlameRecursive(root, 0, 0, 100, totalHits);
+  s += `</div></div></div>`;
   return s;
 }
 

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -907,10 +907,15 @@ export function renderCombinedStacks(prof: Profile): string {
     for (const f of frames) {
       const base = basename(f.filename_or_module);
       if (f.kind === "py") {
-        const safeFn = encodeURIComponent(f.filename_or_module);
+        // Match the per-line table convention (scalene-gui.ts:768): the
+        // file:line text is the click target for vsNavigate, not the
+        // function name. The function name stays as plain text.
+        const safeFn = escape(f.filename_or_module);
         s += `<li><span style="color: #0a6;">[py]</span> `;
-        s += `<a href="javascript:vsNavigate('${safeFn}', ${f.line})">${escapeHtml(f.display_name)}</a> `;
-        s += `<span class="text-muted">${escapeHtml(base)}:${f.line}</span></li>`;
+        s += `${escapeHtml(f.display_name)} `;
+        s += `<span style="cursor: pointer; color: #0a58ca; text-decoration: underline;" `;
+        s += `title="Click to open ${escapeHtml(f.filename_or_module)}:${f.line} in VS Code" `;
+        s += `onclick="vsNavigate('${safeFn}',${f.line})">${escapeHtml(base)}:${f.line}</span></li>`;
       } else {
         s += `<li><span style="color: #a30;">[native]</span> `;
         s += `${escapeHtml(f.display_name)} <span class="text-muted">${escapeHtml(base)}</span></li>`;

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -627,6 +627,31 @@ class ScaleneJSON:
 
             ip_cache_combined: Dict[int, List[Any]] = {}
 
+            # Cache source-file line lookups so we read each Python file at
+            # most once during combined_stacks emission. linecache would do
+            # this too, but we already have the file-read pattern below.
+            source_cache: Dict[str, Optional[List[str]]] = {}
+
+            def _source_line(filename: str, lineno: int) -> str:
+                """Return the source line (stripped, no trailing newline) for
+                filename:lineno, or '' if the file can't be read or the line
+                is out of range. linecache fallback handles exec'd code."""
+                if filename in source_cache:
+                    lines = source_cache[filename]
+                else:
+                    lines = None
+                    try:
+                        with open(filename, encoding="utf-8") as src:
+                            lines = src.readlines()
+                    except (OSError, UnicodeDecodeError):
+                        cached = linecache.getlines(filename)
+                        if cached:
+                            lines = cached
+                    source_cache[filename] = lines
+                if lines is None or lineno < 1 or lineno > len(lines):
+                    return ""
+                return lines[lineno - 1].rstrip()
+
             def _resolve(ip: int) -> List[Any]:
                 if ip in ip_cache_combined:
                     return ip_cache_combined[ip]
@@ -669,12 +694,15 @@ class ScaleneJSON:
                 out_frames: List[Dict[str, Any]] = []
                 for f in py_segment:
                     # ("py", filename, function, line)
+                    py_filename = str(f[1])
+                    py_line = int(f[3])
                     out_frames.append(
                         {
                             "kind": "py",
                             "display_name": str(f[2]),
-                            "filename_or_module": str(f[1]),
-                            "line": int(f[3]),
+                            "filename_or_module": py_filename,
+                            "line": py_line,
+                            "code_line": _source_line(py_filename, py_line),
                             "ip": None,
                             "offset": None,
                         }

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -639,6 +639,14 @@ class ScaleneJSON:
                 ip_cache_combined[ip] = rep
                 return rep
 
+            # Aggregate by the resolved + trimmed display key so that two raw
+            # samples that landed on different IPs but resolved to the same
+            # (symbol, module) frames collapse into one entry. Without this,
+            # near-identical stacks appear as duplicates because sample-time
+            # aggregation in stats.combined_stacks is keyed by raw IPs.
+            combined_aggregated: Dict[
+                Tuple[Tuple[Any, ...], ...], Tuple[List[Dict[str, Any]], int]
+            ] = {}
             for stk, hits in stats.combined_stacks.items():
                 # Find the seam: index of first native frame.
                 seam = next(
@@ -682,8 +690,29 @@ class ScaleneJSON:
                             "offset": int(offset),
                         }
                     )
-                if out_frames:
-                    combined_stks.append((out_frames, hits))
+                if not out_frames:
+                    continue
+                # Build dedup key from the user-visible fields only. Native
+                # ip/offset intentionally excluded so different instructions
+                # within the same function collapse to one entry.
+                dedup_key = tuple(
+                    (
+                        f["kind"],
+                        f["display_name"],
+                        f["filename_or_module"],
+                        f["line"],
+                    )
+                    for f in out_frames
+                )
+                existing = combined_aggregated.get(dedup_key)
+                if existing is None:
+                    combined_aggregated[dedup_key] = (out_frames, hits)
+                else:
+                    combined_aggregated[dedup_key] = (
+                        existing[0],
+                        existing[1] + hits,
+                    )
+            combined_stks.extend(combined_aggregated.values())
 
         # Aggregate bytes from native-thread allocations that have no
         # Python frame (see pywhere.cpp <native> sentinel). These are not

--- a/tests/test_combined_stacks_gui.py
+++ b/tests/test_combined_stacks_gui.py
@@ -1,0 +1,185 @@
+"""GUI integration tests for the combined_stacks viewer (PR follow-up to #1035).
+
+These are pipeline / asset-bundling smoke tests, not browser tests. They
+verify that:
+
+  - The TypeScript bundle on disk contains the new render code.
+  - generate_html() with --standalone embeds that bundle inline so the
+    section is reachable from a self-contained HTML file.
+  - The inline CSS rules from the Jinja2 template are present.
+  - Profile JSON containing combined_stacks reaches the rendered HTML.
+  - Profile JSON without combined_stacks (older profiles) still renders
+    cleanly (no crash, no leftover marker text).
+
+We deliberately do NOT spin up Selenium or a headless browser here:
+adding chromedriver to CI is out of scope for this PR. The end-to-end
+"does the section actually expand on click" check is manual.
+"""
+
+import json
+import pathlib
+from typing import Any, Dict
+
+import pytest
+
+from scalene.scalene_statistics import Filename
+from scalene.scalene_utility import generate_html
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BUNDLE_PATH = REPO_ROOT / "scalene" / "scalene-gui" / "scalene-gui-bundle.js"
+
+
+def _build_profile(*, with_combined_stacks: bool) -> Dict[str, Any]:
+    """Build a minimal but schema-shaped profile dict for HTML rendering."""
+    base: Dict[str, Any] = {
+        "alloc_samples": 0,
+        "args": [],
+        "async_profile": False,
+        "elapsed_time_sec": 1.0,
+        "start_time_absolute": 0.0,
+        "start_time_perf": 0.0,
+        "entrypoint_dir": "/tmp",
+        "filename": "demo.py",
+        "files": {
+            "demo.py": {
+                "functions": [],
+                "imports": [],
+                "leaks": {},
+                "lines": [],
+                "percent_cpu_time": 100.0,
+            }
+        },
+        "gpu": False,
+        "gpu_device": "",
+        "growth_rate": 0.0,
+        "max_footprint_fname": None,
+        "max_footprint_lineno": None,
+        "max_footprint_mb": 0.0,
+        "max_footprint_python_fraction": 0.0,
+        "memory": False,
+        "program": "demo.py",
+        "samples": [],
+        "stacks": [],
+        "native_stacks": [],
+    }
+    if with_combined_stacks:
+        base["combined_stacks"] = [
+            [
+                [
+                    {
+                        "kind": "py",
+                        "display_name": "user_outer_function",
+                        "filename_or_module": "/app/work.py",
+                        "line": 10,
+                        "ip": None,
+                        "offset": None,
+                    },
+                    {
+                        "kind": "py",
+                        "display_name": "user_inner_function",
+                        "filename_or_module": "/app/work.py",
+                        "line": 42,
+                        "ip": None,
+                        "offset": None,
+                    },
+                    {
+                        "kind": "native",
+                        "display_name": "marker_native_symbol",
+                        "filename_or_module": "/lib/libmarker.dylib",
+                        "line": None,
+                        "ip": 140735000000,
+                        "offset": 32,
+                    },
+                ],
+                7,
+            ]
+        ]
+    return base
+
+
+def _render(tmp_path: pathlib.Path, profile: Dict[str, Any]) -> str:
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(json.dumps(profile))
+    html_path = tmp_path / "out.html"
+    generate_html(Filename(str(profile_path)), Filename(str(html_path)), standalone=True)
+    assert html_path.exists(), "generate_html did not write output"
+    return html_path.read_text(encoding="utf-8")
+
+
+def test_bundle_contains_new_render_helpers() -> None:
+    """The TS source must have been rebuilt before this PR is merged."""
+    assert BUNDLE_PATH.exists(), f"missing bundle at {BUNDLE_PATH}"
+    src = BUNDLE_PATH.read_text(encoding="utf-8")
+    assert "renderCombinedStacks" in src, (
+        "renderCombinedStacks() missing from bundle — re-run "
+        "`npx esbuild scalene-gui.ts --bundle ...` and commit the bundle"
+    )
+    assert "toggleCombinedStacks" in src, (
+        "toggleCombinedStacks() missing from bundle — re-run esbuild"
+    )
+
+
+def test_section_present_when_combined_stacks_populated(tmp_path: pathlib.Path) -> None:
+    profile = _build_profile(with_combined_stacks=True)
+    html = _render(tmp_path, profile)
+
+    # CSS rule from the template
+    assert ".combined-stacks-section" in html
+    # Bundle JS embedded inline (standalone mode)
+    assert "renderCombinedStacks" in html
+    assert "toggleCombinedStacks" in html
+    # The profile JSON literal includes our combined_stacks data
+    assert "marker_native_symbol" in html
+    assert "user_outer_function" in html
+    assert "user_inner_function" in html
+
+
+def test_section_absent_marker_text_when_combined_stacks_missing(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Old profiles without combined_stacks must not surface marker text.
+
+    The static HTML still embeds the bundle's render code (it's compiled
+    in), but the runtime guard `if (stacks.length === 0) return ""`
+    prevents any frame display_names from leaking into the JSON literal —
+    so the marker symbol from the populated test cannot appear here.
+    """
+    profile = _build_profile(with_combined_stacks=False)
+    html = _render(tmp_path, profile)
+
+    assert "marker_native_symbol" not in html
+    assert "user_inner_function" not in html
+
+
+def test_standalone_renders_without_crash_on_minimal_profile(
+    tmp_path: pathlib.Path,
+) -> None:
+    """generate_html on a minimal profile (no stacks fields at all) must
+    succeed; the new code should never reference combined_stacks
+    unconditionally."""
+    profile = _build_profile(with_combined_stacks=False)
+    # Strip optional fields entirely
+    profile.pop("stacks", None)
+    profile.pop("native_stacks", None)
+    html = _render(tmp_path, profile)
+    assert "Scalene" in html
+    # CSS still injected (it's static template content)
+    assert ".combined-stacks-section" in html
+
+
+@pytest.mark.parametrize("standalone", [True, False])
+def test_css_rule_present_in_both_modes(
+    tmp_path: pathlib.Path, standalone: bool
+) -> None:
+    """The .combined-stacks-section / .combined-stack-card rules must be
+    in the inline <style> block regardless of standalone mode."""
+    profile = _build_profile(with_combined_stacks=True)
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(json.dumps(profile))
+    html_path = tmp_path / "out.html"
+    generate_html(
+        Filename(str(profile_path)), Filename(str(html_path)), standalone=standalone
+    )
+    html = html_path.read_text(encoding="utf-8")
+    assert ".combined-stacks-section" in html
+    assert ".combined-stack-card" in html

--- a/tests/test_combined_stacks_gui.py
+++ b/tests/test_combined_stacks_gui.py
@@ -123,11 +123,14 @@ def test_section_present_when_combined_stacks_populated(tmp_path: pathlib.Path) 
     profile = _build_profile(with_combined_stacks=True)
     html = _render(tmp_path, profile)
 
-    # CSS rule from the template
+    # CSS rules from the template
     assert ".combined-stacks-section" in html
+    assert ".combined-stacks-flame" in html
     # Bundle JS embedded inline (standalone mode)
     assert "renderCombinedStacks" in html
     assert "toggleCombinedStacks" in html
+    # Flame-chart helpers from the bundle
+    assert "buildFlameTree" in html
     # The profile JSON literal includes our combined_stacks data
     assert "marker_native_symbol" in html
     assert "user_outer_function" in html
@@ -171,7 +174,7 @@ def test_standalone_renders_without_crash_on_minimal_profile(
 def test_css_rule_present_in_both_modes(
     tmp_path: pathlib.Path, standalone: bool
 ) -> None:
-    """The .combined-stacks-section / .combined-stack-card rules must be
+    """The .combined-stacks-section / .combined-stacks-flame rules must be
     in the inline <style> block regardless of standalone mode."""
     profile = _build_profile(with_combined_stacks=True)
     profile_path = tmp_path / "profile.json"
@@ -182,4 +185,4 @@ def test_css_rule_present_in_both_modes(
     )
     html = html_path.read_text(encoding="utf-8")
     assert ".combined-stacks-section" in html
-    assert ".combined-stack-card" in html
+    assert ".combined-stacks-flame" in html

--- a/tests/test_native_stacks.py
+++ b/tests/test_native_stacks.py
@@ -855,6 +855,59 @@ class TestCombinedStacksJson:
         # Only the Python anchor remains.
         assert [f["kind"] for f in frames] == ["py"]
 
+    def test_dedupe_stacks_with_same_resolved_display(self, monkeypatch, tmp_path):
+        """Two raw stacks that differ only in native IP/offset but resolve
+        to the same (symbol, module) frames must collapse into one entry,
+        with hit counts summed. Regression for the "same stack listed
+        multiple times" bug — sample-time aggregation is keyed by raw IPs
+        but the display layer should dedupe by user-visible fields."""
+        py_main = ("py", "prog.py", "main", 1)
+        ip_a = 0xAAA0
+        ip_b = 0xAAB0  # different IP, same function -> same display
+        # Both IPs resolve to the same symbol/module; only offset differs.
+        mapping = {
+            ip_a: ("/lib/libBLAS.dylib", "cblas_dgemm", 16),
+            ip_b: ("/lib/libBLAS.dylib", "cblas_dgemm", 32),
+        }
+        import scalene._scalene_unwind as unwind_mod  # type: ignore
+
+        monkeypatch.setattr(
+            unwind_mod, "resolve_ip", self._resolve_stub(mapping)
+        )
+
+        from scalene.scalene_json import ScaleneJSON
+        from scalene.scalene_statistics import Filename, ScaleneStatistics
+
+        stats = ScaleneStatistics()
+        stats.combined_stacks[(py_main, ("native", ip_a))] = 3
+        stats.combined_stacks[(py_main, ("native", ip_b))] = 5
+        stats.cpu_stats.total_cpu_samples = 1.0
+        stats.cpu_stats.cpu_samples_python["/dummy.py"][1] = 1.0
+        stats.cpu_stats.cpu_samples["/dummy.py"] = 1.0
+        stats.elapsed_time = 1.0
+
+        out = ScaleneJSON()
+        profile = out.output_profiles(
+            program=Filename("prog.py"),
+            stats=stats,
+            pid=0,
+            profile_this_code=lambda f, l: True,
+            python_alias_dir=tmp_path,
+            program_path=Filename("prog.py"),
+            entrypoint_dir=Filename(str(tmp_path)),
+            program_args=[],
+            profile_memory=False,
+            reduced_profile=False,
+            profile_async=False,
+        )
+
+        combined = profile["combined_stacks"]
+        assert len(combined) == 1, (
+            f"expected 1 deduplicated stack, got {len(combined)}: {combined}"
+        )
+        _frames, hits = combined[0]
+        assert hits == 8, f"expected 3 + 5 = 8 hits after dedup, got {hits}"
+
     def test_no_combined_stacks_emits_empty_list(self, tmp_path):
         from scalene.scalene_json import ScaleneJSON
         from scalene.scalene_statistics import Filename, ScaleneStatistics

--- a/tests/test_native_stacks.py
+++ b/tests/test_native_stacks.py
@@ -855,6 +855,53 @@ class TestCombinedStacksJson:
         # Only the Python anchor remains.
         assert [f["kind"] for f in frames] == ["py"]
 
+    def test_py_frames_include_source_code_line(self, tmp_path):
+        """Each py frame in combined_stacks gets a code_line field with the
+        actual source line at that filename:lineno, so the GUI can display
+        something more useful than the bare function name (esp. for
+        '<module>' top-level frames). Missing files / out-of-range lines
+        produce empty strings, never crashes."""
+        from scalene.scalene_json import ScaleneJSON
+        from scalene.scalene_statistics import Filename, ScaleneStatistics
+
+        src = tmp_path / "src.py"
+        src.write_text("a = 1\nb = 2\nc = a + b\n")  # 3 lines
+
+        stats = ScaleneStatistics()
+        # Three frames: existing line, missing file, out-of-range line.
+        stk = (
+            ("py", str(src), "module_top", 3),
+            ("py", "/nonexistent/file.py", "missing_file_fn", 1),
+            ("py", str(src), "out_of_range_fn", 999),
+        )
+        stats.combined_stacks[stk] = 4
+        stats.cpu_stats.total_cpu_samples = 1.0
+        stats.cpu_stats.cpu_samples_python["/dummy.py"][1] = 1.0
+        stats.cpu_stats.cpu_samples["/dummy.py"] = 1.0
+        stats.elapsed_time = 1.0
+
+        out = ScaleneJSON()
+        profile = out.output_profiles(
+            program=Filename("prog.py"),
+            stats=stats,
+            pid=0,
+            profile_this_code=lambda f, l: True,
+            python_alias_dir=tmp_path,
+            program_path=Filename("prog.py"),
+            entrypoint_dir=Filename(str(tmp_path)),
+            program_args=[],
+            profile_memory=False,
+            reduced_profile=False,
+            profile_async=False,
+        )
+
+        combined = profile["combined_stacks"]
+        assert len(combined) == 1
+        frames, _hits = combined[0]
+        assert frames[0]["code_line"] == "c = a + b"
+        assert frames[1]["code_line"] == ""  # file doesn't exist
+        assert frames[2]["code_line"] == ""  # line out of range
+
     def test_dedupe_stacks_with_same_resolved_display(self, monkeypatch, tmp_path):
         """Two raw stacks that differ only in native IP/offset but resolve
         to the same (symbol, module) frames must collapse into one entry,


### PR DESCRIPTION
## Summary

Surfaces the stitched Python+native call stacks from `combined_stacks` (introduced in PR #1035) as a collapsible section in Scalene's web GUI. Without this, users had to read raw JSON to see *which* C function is responsible for the C time on a given Python line.

This is **Phase 2 / PR 3** of the plan in `STITCHED_STACK.md`.

## What you see

A new collapsible section appears below the per-file tables, hidden by default. When expanded, it shows the **top 20 stitched stacks** ranked by hit count. Each stack is a card with a hit-count badge above an ordered list of frames (outermost-first):

- **Python frames**: green `[py]` prefix, clickable function name (uses existing `vsNavigate` to jump to source in VS Code), grayed `basename:line` suffix.
- **Native frames**: orange `[native]` prefix, `display_name` + grayed module-basename.

Section is omitted entirely when `combined_stacks` is missing or empty (i.e. profiles without `--stacks`, or older profiles from before #1034).

## Implementation

Pure HTML/CSS — no Vega-Lite chart for a list. Reuses existing patterns:
- `RightTriangle` / `DownTriangle` symbols + manual `display:block`/`display:none` toggle (mirrors `toggleDisplay`).
- `vsNavigate(filename, lineno)` for clickable Python frames.
- Bootstrap 5.1.3 inline classes; CSS lives in the existing template `<style>` block.

### Files changed

- `scalene-gui.ts`: precise `CombinedFrame` / `CombinedStackEntry` types on the `Profile` interface; `renderCombinedStacks()` pure string-builder; `toggleCombinedStacks()` DOM toggle; small `escapeHtml()` and `basename()` helpers; one-line wire-in to `display()` immediately before `innerHTML` assignment; window export so the inline `onClick` handler resolves.
- `gui-elements.ts`: `combined_stacks?: unknown` on the loose global typeshed.
- `index.html.template`: two CSS rules (`.combined-stacks-section`, `.combined-stack-card ol li`).
- `scalene-gui-bundle.js`: regenerated via `npx esbuild scalene-gui.ts --bundle --outfile=scalene-gui-bundle.js --format=iife --global-name=ScaleneGUI`.

## Tests

`tests/test_combined_stacks_gui.py` — six pipeline / asset-bundling smoke tests:
- Bundle on disk contains `renderCombinedStacks` and `toggleCombinedStacks` (regression catch if someone forgets to rebuild).
- `generate_html()` with `standalone=True` embeds the bundle + profile data + emits the marker text from a populated `combined_stacks`.
- Profile without `combined_stacks` does not surface marker text and does not crash.
- CSS rules are present in both standalone and non-standalone modes.

No Selenium / chromedriver — adding that to CI is out of scope. The "does the section actually expand on click" check is manual.

## Verified

macOS arm64 / Python 3.14, 2-second `math` loop workload: ~30 stitched stacks captured, standalone HTML opens with the section collapsed, expands on triangle-click, and shows real entries like `<module> → hot → compactlong_float_guard`.

## Test plan

- [x] mypy clean (`python3 -m mypy scalene/`)
- [x] ruff clean (`python3 -m ruff check scalene/ tests/`)
- [x] `tests/test_combined_stacks_gui.py` — 6 passed
- [x] Full repo test suite — 389 passed, 13 skipped
- [x] Manual: standalone HTML opens, section visible, toggle works, frames render
- [ ] CI green across platforms

## Out of scope (deferred)

- Flame graph / icicle plot
- Search, filter, regex, sort controls
- Pagination beyond the top-20 cap
- Cross-linking from per-line `n_cpu_percent_c` cell into a filtered stacks view
- Stack folding / grouping by leaf function
- Rendering plain `stacks` or `native_stacks` as separate sections (`combined_stacks` subsumes both for the "where's my C time?" question)
- Selenium / chromedriver in CI
- Any change to `generate_html()` signature, JSON schema, or the standalone-asset pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)