### PR TITLE
Memory flame chart + sync per-sample stack capture

### DIFF
--- a/scalene/scalene-gui/index.html.template
+++ b/scalene/scalene-gui/index.html.template
@@ -248,7 +248,11 @@
     .combined-stacks-section {
         margin-top: 1em;
     }
-    .combined-stacks-flame > div:hover {
+    /* Shared hover highlight for all flame/stack/timeline segments. */
+    .flame-segment {
+        pointer-events: auto;
+    }
+    .flame-segment:hover {
         outline: 2px solid #333;
         z-index: 10;
     }

--- a/scalene/scalene-gui/scalene-gui-bundle.js
+++ b/scalene/scalene-gui/scalene-gui-bundle.js
@@ -2452,10 +2452,12 @@ var ScaleneGUI = (() => {
     refreshOpenAIModels: () => refreshOpenAIModels,
     renderCombinedStacks: () => renderCombinedStacks,
     renderCombinedStacksTimeline: () => renderCombinedStacksTimeline,
+    renderMemoryStacks: () => renderMemoryStacks,
     toggleAdvanced: () => toggleAdvanced,
     toggleCombinedStacks: () => toggleCombinedStacks,
     toggleCombinedStacksTimeline: () => toggleCombinedStacksTimeline,
     toggleDisplay: () => toggleDisplay,
+    toggleMemoryStacks: () => toggleMemoryStacks,
     togglePassword: () => togglePassword,
     toggleReduced: () => toggleReduced,
     toggleServiceFields: () => toggleServiceFields,
@@ -72255,20 +72257,21 @@ Your output should only consist of valid Python code. Output the resulting Pytho
     if (kind === "py") return `hsl(${hue2}, 45%, 78%)`;
     return `hsl(${(hue2 + 30) % 360}, 70%, 65%)`;
   }
-  function renderFlameNode(node, depth, leftPct, widthPct, total) {
+  function renderFlameNode(node, depth, leftPct, widthPct, total, formatQuantity = (q2) => `${q2} hits`) {
     const pct = total > 0 ? (node.totalHits / total * 100).toFixed(1) : "0.0";
     const codeLineText = (node.code_line ?? "").trim();
+    const qty = formatQuantity(node.totalHits);
     let tooltip2;
     if (node.kind === "py") {
       const tail = codeLineText ? `
 ${codeLineText}` : "";
       tooltip2 = `[py] ${node.name}
 ${node.filename}:${node.line}
-${node.totalHits} hits (${pct}%)${tail}`;
+${qty} (${pct}%)${tail}`;
     } else {
       tooltip2 = `[native] ${node.name}
 ${node.filename}
-${node.totalHits} hits (${pct}%)`;
+${qty} (${pct}%)`;
     }
     const top = depth * FLAME_ROW_HEIGHT;
     const color5 = flameColor(node.name, node.kind);
@@ -72276,18 +72279,18 @@ ${node.totalHits} hits (${pct}%)`;
     const labelHtml = showLabel ? escapeHtml(node.name) : "";
     const cursor3 = node.kind === "py" && node.line !== null ? "pointer" : "default";
     const clickAttr = node.kind === "py" && node.line !== null ? ` onclick="vsNavigate('${escape(node.filename)}',${node.line})"` : "";
-    return `<div style="position:absolute;top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;height:${FLAME_ROW_HEIGHT - 1}px;background:${color5};border:1px solid rgba(0,0,0,0.12);overflow:hidden;font-family:monospace;font-size:11px;line-height:${FLAME_ROW_HEIGHT - 1}px;padding:0 4px;white-space:nowrap;text-overflow:ellipsis;cursor:${cursor3};box-sizing:border-box;" title="${escapeHtml(tooltip2)}"${clickAttr}>${labelHtml}</div>`;
+    return `<div class="flame-segment" style="position:absolute;top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;height:${FLAME_ROW_HEIGHT - 1}px;background:${color5};border:1px solid rgba(0,0,0,0.12);overflow:hidden;font-family:monospace;font-size:11px;line-height:${FLAME_ROW_HEIGHT - 1}px;padding:0 4px;white-space:nowrap;text-overflow:ellipsis;cursor:${cursor3};box-sizing:border-box;" title="${escapeHtml(tooltip2)}"${clickAttr}>${labelHtml}</div>`;
   }
-  function renderFlameRecursive(node, depth, leftPct, widthPct, total) {
+  function renderFlameRecursive(node, depth, leftPct, widthPct, total, formatQuantity) {
     let s2 = "";
     if (depth > 0) {
-      s2 += renderFlameNode(node, depth - 1, leftPct, widthPct, total);
+      s2 += renderFlameNode(node, depth - 1, leftPct, widthPct, total, formatQuantity);
     }
     let childLeft = leftPct;
     for (const child of node.children) {
       const childWidth = total > 0 ? child.totalHits / total * widthPct * (total / node.totalHits) : 0;
       const w3 = node.totalHits > 0 ? child.totalHits / node.totalHits * widthPct : 0;
-      s2 += renderFlameRecursive(child, depth + 1, childLeft, w3, total);
+      s2 += renderFlameRecursive(child, depth + 1, childLeft, w3, total, formatQuantity);
       childLeft += w3;
       void childWidth;
     }
@@ -72303,7 +72306,7 @@ ${node.totalHits} hits (${pct}%)`;
     let s2 = `<hr><div class="container-fluid combined-stacks-section">`;
     s2 += `<p style="margin-bottom: 4px;">`;
     s2 += `<span id="button-combined-stacks" class="disclosure-triangle" title="Click to show or hide stitched Python+native call stacks." onClick="toggleCombinedStacks()">${RightTriangle}</span>`;
-    s2 += ` <strong>Combined Python + native call stacks</strong> `;
+    s2 += ` <strong>Call stacks</strong> `;
     s2 += `<span class="text-muted" style="font-size: 80%;">${stacks.length} stitched stacks, ${totalHits} samples \u2014 hover for details, click a [py] frame to jump to its source line</span>`;
     s2 += `</p>`;
     s2 += `<div id="combined-stacks-body" style="display: none;">`;
@@ -72315,6 +72318,44 @@ ${node.totalHits} hits (${pct}%)`;
   function toggleCombinedStacks() {
     const body = document.getElementById("combined-stacks-body");
     const btn = document.getElementById("button-combined-stacks");
+    if (!body || !btn) return;
+    if (body.style.display === "none") {
+      body.style.display = "block";
+      btn.innerHTML = DownTriangle;
+    } else {
+      body.style.display = "none";
+      btn.innerHTML = RightTriangle;
+    }
+  }
+  function formatMb(mb2) {
+    if (mb2 >= 1024) return `${(mb2 / 1024).toFixed(2)} GB`;
+    if (mb2 >= 1) return `${mb2.toFixed(2)} MB`;
+    if (mb2 >= 1e-3) return `${(mb2 * 1024).toFixed(2)} KB`;
+    return `${(mb2 * 1024 * 1024).toFixed(0)} B`;
+  }
+  function renderMemoryStacks(prof) {
+    const stacks = prof.memory_stacks ?? [];
+    if (stacks.length === 0) return "";
+    const root = buildFlameTree(stacks);
+    const totalMb = root.totalHits;
+    if (totalMb <= 0) return "";
+    const depth = flameMaxDepth(root);
+    const containerHeight = depth * FLAME_ROW_HEIGHT;
+    let s2 = `<hr><div class="container-fluid memory-stacks-section">`;
+    s2 += `<p style="margin-bottom: 4px;">`;
+    s2 += `<span id="button-memory-stacks" class="disclosure-triangle" title="Click to show or hide memory-weighted call stacks." onClick="toggleMemoryStacks()">${RightTriangle}</span>`;
+    s2 += ` <strong>Memory stacks</strong> `;
+    s2 += `<span class="text-muted" style="font-size: 80%;">${stacks.length} stacks, ${formatMb(totalMb)} attributed \u2014 frame widths are proportional to MB allocated; hover for details, click a frame to jump to its source line</span>`;
+    s2 += `</p>`;
+    s2 += `<div id="memory-stacks-body" style="display: none;">`;
+    s2 += `<div class="memory-stacks-flame" style="position:relative;width:100%;height:${containerHeight}px;border:1px solid #ccc;background:#f0f0f0;overflow-x:auto;">`;
+    s2 += renderFlameRecursive(root, 0, 0, 100, totalMb, formatMb);
+    s2 += `</div></div></div>`;
+    return s2;
+  }
+  function toggleMemoryStacks() {
+    const body = document.getElementById("memory-stacks-body");
+    const btn = document.getElementById("button-memory-stacks");
     if (!body || !btn) return;
     if (body.style.display === "none") {
       body.style.display = "block";
@@ -72499,7 +72540,7 @@ ${seg.startSec.toFixed(3)}s \u2014 ${seg.endSec.toFixed(3)}s (${seg.totalHits} s
         const label = showLabels ? escapeHtml(f2.display_name) : "";
         const cursor3 = f2.kind === "py" && f2.line !== null ? "pointer" : "default";
         const clickAttr = f2.kind === "py" && f2.line !== null ? ` onclick="vsNavigate('${escape(f2.filename_or_module)}',${f2.line})"` : "";
-        s2 += `<div style="position:absolute;top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;height:${TIMELINE_ROW_HEIGHT - 1}px;background:${color5};border:1px solid rgba(0,0,0,0.10);overflow:hidden;font-family:monospace;font-size:10px;line-height:${TIMELINE_ROW_HEIGHT - 1}px;padding:0 2px;white-space:nowrap;text-overflow:ellipsis;cursor:${cursor3};box-sizing:border-box;" title="${escapeHtml(tooltip2)}"${clickAttr}>${label}</div>`;
+        s2 += `<div class="flame-segment" style="position:absolute;top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;height:${TIMELINE_ROW_HEIGHT - 1}px;background:${color5};border:1px solid rgba(0,0,0,0.10);overflow:hidden;font-family:monospace;font-size:10px;line-height:${TIMELINE_ROW_HEIGHT - 1}px;padding:0 2px;white-space:nowrap;text-overflow:ellipsis;cursor:${cursor3};box-sizing:border-box;" title="${escapeHtml(tooltip2)}"${clickAttr}>${label}</div>`;
       }
     }
     return s2;
@@ -72514,7 +72555,7 @@ ${seg.startSec.toFixed(3)}s \u2014 ${seg.endSec.toFixed(3)}s (${seg.totalHits} s
       const leftPct = (run2.startSec - startSec) / totalSec * 100;
       const widthPct = (run2.endSec - run2.startSec) / totalSec * 100;
       if (widthPct <= 0) continue;
-      s2 += `<div style="position:absolute;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;top:0;height:100%;background:${color5};box-sizing:border-box;" title="${escapeHtml(label)} during ${run2.startSec.toFixed(3)}s \u2014 ${run2.endSec.toFixed(3)}s"></div>`;
+      s2 += `<div class="flame-segment" style="position:absolute;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;top:0;height:100%;background:${color5};box-sizing:border-box;" title="${escapeHtml(label)} during ${run2.startSec.toFixed(3)}s \u2014 ${run2.endSec.toFixed(3)}s"></div>`;
     }
     s2 += `</div>`;
     return s2;
@@ -72547,7 +72588,7 @@ ${seg.startSec.toFixed(3)}s \u2014 ${seg.endSec.toFixed(3)}s (${seg.totalHits} s
     let s2 = `<hr><div class="container-fluid combined-stacks-timeline-section">`;
     s2 += `<p style="margin-bottom: 4px;">`;
     s2 += `<span id="button-combined-timeline" class="disclosure-triangle" title="Click to show or hide the experimental timeline view." onClick="toggleCombinedStacksTimeline()">${RightTriangle}</span>`;
-    s2 += ` <strong>Stitched stack timeline</strong> `;
+    s2 += ` <strong>Timeline</strong> `;
     s2 += `<span class="badge bg-warning text-dark" style="font-size: 70%; vertical-align: middle;">experimental</span> `;
     s2 += `<span class="text-muted" style="font-size: 80%;">${runs.length} runs over ${totalSec.toFixed(2)}s \u2014 x: time, y: stack depth (outermost on top); GC and I/O tracks shown above</span>`;
     s2 += `</p>`;
@@ -72978,6 +73019,7 @@ ${seg.startSec.toFixed(3)}s \u2014 ${seg.endSec.toFixed(3)}s (${seg.totalHits} s
     s2 += "</div>";
     s2 += renderCombinedStacks(prof);
     s2 += renderCombinedStacksTimeline(prof);
+    s2 += renderMemoryStacks(prof);
     const p2 = document.getElementById("profile");
     if (p2) {
       p2.innerHTML = s2;
@@ -73304,6 +73346,7 @@ ${seg.startSec.toFixed(3)}s \u2014 ${seg.endSec.toFixed(3)}s (${seg.totalHits} s
   window.toggleDisplay = toggleDisplay;
   window.toggleCombinedStacks = toggleCombinedStacks;
   window.toggleCombinedStacksTimeline = toggleCombinedStacksTimeline;
+  window.toggleMemoryStacks = toggleMemoryStacks;
   window.toggleReduced = toggleReduced;
   window.onFileDisplayModeChange = onFileDisplayModeChange;
   window.load = load3;

--- a/scalene/scalene-gui/scalene-gui.ts
+++ b/scalene/scalene-gui/scalene-gui.ts
@@ -113,6 +113,7 @@ interface Profile {
   stacks?: unknown;
   combined_stacks?: CombinedStackEntry[];
   combined_stacks_timeline?: CombinedStackTimelineEvent[];
+  memory_stacks?: CombinedStackEntry[];
 }
 
 interface CombinedStackTimelineEvent {
@@ -1056,15 +1057,17 @@ function renderFlameNode(
   leftPct: number,
   widthPct: number,
   total: number,
+  formatQuantity: (q: number) => string = (q) => `${q} hits`,
 ): string {
   const pct = total > 0 ? ((node.totalHits / total) * 100).toFixed(1) : "0.0";
   const codeLineText = (node.code_line ?? "").trim();
+  const qty = formatQuantity(node.totalHits);
   let tooltip: string;
   if (node.kind === "py") {
     const tail = codeLineText ? `\n${codeLineText}` : "";
-    tooltip = `[py] ${node.name}\n${node.filename}:${node.line}\n${node.totalHits} hits (${pct}%)${tail}`;
+    tooltip = `[py] ${node.name}\n${node.filename}:${node.line}\n${qty} (${pct}%)${tail}`;
   } else {
-    tooltip = `[native] ${node.name}\n${node.filename}\n${node.totalHits} hits (${pct}%)`;
+    tooltip = `[native] ${node.name}\n${node.filename}\n${qty} (${pct}%)`;
   }
   const top = depth * FLAME_ROW_HEIGHT;
   const color = flameColor(node.name, node.kind);
@@ -1076,7 +1079,7 @@ function renderFlameNode(
       ? ` onclick="vsNavigate('${escape(node.filename)}',${node.line})"`
       : "";
   return (
-    `<div style="position:absolute;` +
+    `<div class="flame-segment" style="position:absolute;` +
     `top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;` +
     `height:${FLAME_ROW_HEIGHT - 1}px;background:${color};` +
     `border:1px solid rgba(0,0,0,0.12);overflow:hidden;` +
@@ -1093,17 +1096,18 @@ function renderFlameRecursive(
   leftPct: number,
   widthPct: number,
   total: number,
+  formatQuantity?: (q: number) => string,
 ): string {
   let s = "";
   if (depth > 0) {
-    s += renderFlameNode(node, depth - 1, leftPct, widthPct, total);
+    s += renderFlameNode(node, depth - 1, leftPct, widthPct, total, formatQuantity);
   }
   let childLeft = leftPct;
   for (const child of node.children) {
     const childWidth = total > 0 ? (child.totalHits / total) * widthPct * (total / node.totalHits) : 0;
     // Equivalent: child.totalHits / node.totalHits * widthPct (parent's width slice).
     const w = node.totalHits > 0 ? (child.totalHits / node.totalHits) * widthPct : 0;
-    s += renderFlameRecursive(child, depth + 1, childLeft, w, total);
+    s += renderFlameRecursive(child, depth + 1, childLeft, w, total, formatQuantity);
     childLeft += w;
     void childWidth;
   }
@@ -1122,7 +1126,7 @@ export function renderCombinedStacks(prof: Profile): string {
   let s = `<hr><div class="container-fluid combined-stacks-section">`;
   s += `<p style="margin-bottom: 4px;">`;
   s += `<span id="button-combined-stacks" class="disclosure-triangle" title="Click to show or hide stitched Python+native call stacks." onClick="toggleCombinedStacks()">${RightTriangle}</span>`;
-  s += ` <strong>Combined Python + native call stacks</strong> `;
+  s += ` <strong>Call stacks</strong> `;
   s += `<span class="text-muted" style="font-size: 80%;">${stacks.length} stitched stacks, ${totalHits} samples — hover for details, click a [py] frame to jump to its source line</span>`;
   s += `</p>`;
   s += `<div id="combined-stacks-body" style="display: none;">`;
@@ -1135,6 +1139,52 @@ export function renderCombinedStacks(prof: Profile): string {
 export function toggleCombinedStacks(): void {
   const body = document.getElementById("combined-stacks-body");
   const btn = document.getElementById("button-combined-stacks");
+  if (!body || !btn) return;
+  if (body.style.display === "none") {
+    body.style.display = "block";
+    btn.innerHTML = DownTriangle;
+  } else {
+    body.style.display = "none";
+    btn.innerHTML = RightTriangle;
+  }
+}
+
+// Memory-weighted flame chart. Each stack entry's weight is MB allocated,
+// so frame widths are proportional to bytes attributed to that call path
+// at malloc-sample time (not hit counts). Reuses the flame-tree machinery.
+function formatMb(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(2)} GB`;
+  if (mb >= 1) return `${mb.toFixed(2)} MB`;
+  if (mb >= 0.001) return `${(mb * 1024).toFixed(2)} KB`;
+  return `${(mb * 1024 * 1024).toFixed(0)} B`;
+}
+
+export function renderMemoryStacks(prof: Profile): string {
+  const stacks = prof.memory_stacks ?? [];
+  if (stacks.length === 0) return "";
+
+  const root = buildFlameTree(stacks);
+  const totalMb = root.totalHits;
+  if (totalMb <= 0) return "";
+  const depth = flameMaxDepth(root);
+  const containerHeight = depth * FLAME_ROW_HEIGHT;
+
+  let s = `<hr><div class="container-fluid memory-stacks-section">`;
+  s += `<p style="margin-bottom: 4px;">`;
+  s += `<span id="button-memory-stacks" class="disclosure-triangle" title="Click to show or hide memory-weighted call stacks." onClick="toggleMemoryStacks()">${RightTriangle}</span>`;
+  s += ` <strong>Memory stacks</strong> `;
+  s += `<span class="text-muted" style="font-size: 80%;">${stacks.length} stacks, ${formatMb(totalMb)} attributed — frame widths are proportional to MB allocated; hover for details, click a frame to jump to its source line</span>`;
+  s += `</p>`;
+  s += `<div id="memory-stacks-body" style="display: none;">`;
+  s += `<div class="memory-stacks-flame" style="position:relative;width:100%;height:${containerHeight}px;border:1px solid #ccc;background:#f0f0f0;overflow-x:auto;">`;
+  s += renderFlameRecursive(root, 0, 0, 100, totalMb, formatMb);
+  s += `</div></div></div>`;
+  return s;
+}
+
+export function toggleMemoryStacks(): void {
+  const body = document.getElementById("memory-stacks-body");
+  const btn = document.getElementById("button-memory-stacks");
   if (!body || !btn) return;
   if (body.style.display === "none") {
     body.style.display = "block";
@@ -1404,7 +1454,7 @@ function renderTimelineFrames(
           ? ` onclick="vsNavigate('${escape(f.filename_or_module)}',${f.line})"`
           : "";
       s +=
-        `<div style="position:absolute;` +
+        `<div class="flame-segment" style="position:absolute;` +
         `top:${top}px;left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;` +
         `height:${TIMELINE_ROW_HEIGHT - 1}px;background:${color};` +
         `border:1px solid rgba(0,0,0,0.10);overflow:hidden;` +
@@ -1443,7 +1493,7 @@ function renderTimelineTrack(
     const widthPct = ((run.endSec - run.startSec) / totalSec) * 100;
     if (widthPct <= 0) continue;
     s +=
-      `<div style="position:absolute;` +
+      `<div class="flame-segment" style="position:absolute;` +
       `left:${leftPct.toFixed(4)}%;width:${widthPct.toFixed(4)}%;` +
       `top:0;height:100%;background:${color};` +
       `box-sizing:border-box;" title="${escapeHtml(label)} during ` +
@@ -1489,7 +1539,7 @@ export function renderCombinedStacksTimeline(prof: Profile): string {
   let s = `<hr><div class="container-fluid combined-stacks-timeline-section">`;
   s += `<p style="margin-bottom: 4px;">`;
   s += `<span id="button-combined-timeline" class="disclosure-triangle" title="Click to show or hide the experimental timeline view." onClick="toggleCombinedStacksTimeline()">${RightTriangle}</span>`;
-  s += ` <strong>Stitched stack timeline</strong> `;
+  s += ` <strong>Timeline</strong> `;
   s += `<span class="badge bg-warning text-dark" style="font-size: 70%; vertical-align: middle;">experimental</span> `;
   s += `<span class="text-muted" style="font-size: 80%;">${runs.length} runs over ${totalSec.toFixed(2)}s — x: time, y: stack depth (outermost on top); GC and I/O tracks shown above</span>`;
   s += `</p>`;
@@ -2008,6 +2058,7 @@ async function display(prof: Profile): Promise<void> {
   s += "</div>";
   s += renderCombinedStacks(prof);
   s += renderCombinedStacksTimeline(prof);
+  s += renderMemoryStacks(prof);
   const p = document.getElementById("profile");
   if (p) {
     p.innerHTML = s;
@@ -2421,6 +2472,7 @@ setInterval(sendHeartbeat, 10000); // Send heartbeat every 10 seconds
 (window as unknown as Record<string, unknown>).toggleDisplay = toggleDisplay;
 (window as unknown as Record<string, unknown>).toggleCombinedStacks = toggleCombinedStacks;
 (window as unknown as Record<string, unknown>).toggleCombinedStacksTimeline = toggleCombinedStacksTimeline;
+(window as unknown as Record<string, unknown>).toggleMemoryStacks = toggleMemoryStacks;
 (window as unknown as Record<string, unknown>).toggleReduced = toggleReduced;
 (window as unknown as Record<string, unknown>).onFileDisplayModeChange = onFileDisplayModeChange;
 (window as unknown as Record<string, unknown>).load = load;

--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -33,6 +33,10 @@ from scalene.scalene_statistics import (
     StackStats,
 )
 
+# Python `def` header regex shared between CPU- and memory-stack name
+# resolution. Captures the leading indent and the function name.
+_DEF_RE = re.compile(r"^(\s*)(?:async\s+)?def\s+([A-Za-z_][A-Za-z_0-9]*)\s*\(")
+
 
 class CombinedStackTimelineEvent(BaseModel):
     """One run-length-encoded entry in the JSON-serialized stitched-stacks
@@ -256,6 +260,7 @@ class ScaleneJSONSchema(BaseModel):
     program: str
     samples: List[List[NonNegativeFloat]]
     stacks: List[List[Any]]
+    memory_stacks: List[List[Any]] = Field(default_factory=list)
 
 
 class ScaleneJSON:
@@ -866,6 +871,108 @@ class ScaleneJSON:
         )
         native_allocations_mb = sum(native_samples.values())
 
+        # Serialize memory_stacks: Python call stacks captured at malloc-
+        # sample time, weighted by MB attributed to each sample. Reuses the
+        # combined_stacks wire shape (list of (frames, weight)) with only
+        # kind="py" frames so the GUI's flame-tree builder works unchanged.
+        #
+        # Function names are resolved here (at JSON serialization time)
+        # rather than during sample processing, because name resolution
+        # requires reading source files — if we did it on the sigqueue
+        # thread, the resulting allocations would be captured by the
+        # interposer and show up as artifacts in the user's profile.
+        memory_stks: List[Tuple[List[Dict[str, Any]], float]] = []
+        if stats.memory_stacks:
+            mem_source_cache: Dict[str, Optional[List[str]]] = {}
+
+            def _mem_source_line(filename: str, lineno: int) -> str:
+                if filename in mem_source_cache:
+                    lines = mem_source_cache[filename]
+                else:
+                    lines = None
+                    try:
+                        with open(filename, encoding="utf-8") as src:
+                            lines = src.readlines()
+                    except (OSError, UnicodeDecodeError):
+                        cached = linecache.getlines(filename)
+                        if cached:
+                            lines = cached
+                    mem_source_cache[filename] = lines
+                if lines is None or lineno < 1 or lineno > len(lines):
+                    return ""
+                return lines[lineno - 1].rstrip()
+
+            def _enclosing_function(filename: str, lineno: int) -> Optional[str]:
+                """Find the enclosing `def` name for (filename, lineno) by
+                scanning source text. Returns None if no enclosing function
+                (i.e. module scope). Mirrors the rule used for CPU stacks:
+                a def encloses the line iff its body indent is strictly less
+                than the target line's indent."""
+                lines_list = mem_source_cache.get(filename)
+                if lines_list is None and filename not in mem_source_cache:
+                    # Force population via the same helper used for code_line.
+                    _mem_source_line(filename, 1)
+                    lines_list = mem_source_cache.get(filename)
+                if not lines_list or lineno < 1 or lineno > len(lines_list):
+                    return None
+                target_line = lines_list[lineno - 1]
+                stripped = target_line.lstrip()
+                if not stripped or stripped.startswith("#"):
+                    return None
+                target_indent = len(target_line) - len(stripped)
+                if target_indent <= 0:
+                    return None
+                for i in range(lineno - 2, -1, -1):
+                    line = lines_list[i]
+                    m = _DEF_RE.match(line)
+                    if m:
+                        header_indent = len(m.group(1))
+                        if header_indent < target_indent:
+                            return m.group(2)
+                        continue
+                    ls = line.lstrip()
+                    if not ls or ls.startswith("#"):
+                        continue
+                    ind = len(line) - len(ls)
+                    if ind < target_indent:
+                        if ind == 0:
+                            return None
+                        target_indent = ind
+                return None
+
+            name_cache: Dict[Tuple[str, int], Optional[str]] = {}
+
+            def _resolved_name(filename: str, lineno: int) -> str:
+                key = (filename, lineno)
+                if key in name_cache:
+                    cached_name = name_cache[key]
+                else:
+                    cached_name = _enclosing_function(filename, lineno)
+                    name_cache[key] = cached_name
+                return cached_name if cached_name else "<module>"
+
+            for stk, mb in stats.memory_stacks.items():
+                frames: List[Dict[str, Any]] = []
+                for sf in stk:
+                    display = sf.function_name if sf.function_name else (
+                        _resolved_name(sf.filename, sf.line_number)
+                    )
+                    frames.append(
+                        {
+                            "kind": "py",
+                            "display_name": display,
+                            "filename_or_module": sf.filename,
+                            "line": sf.line_number,
+                            "code_line": _mem_source_line(
+                                sf.filename, sf.line_number
+                            ),
+                            "ip": None,
+                            "offset": None,
+                        }
+                    )
+                if frames and mb > 0:
+                    memory_stks.append((frames, round(mb, 6)))
+
         output: Dict[str, Any] = {
             "program": program,
             "entrypoint_dir": entrypoint_dir,
@@ -916,6 +1023,10 @@ class ScaleneJSON:
                 for frames, hits in combined_stks
             ],
             "combined_stacks_timeline": combined_stks_timeline,
+            # Memory-weighted Python stacks for the memory flame chart.
+            # Each entry is (frames, mb). Only populated when --stacks and
+            # --memory are both enabled.
+            "memory_stacks": memory_stks,
         }
 
         # Build a list of files we will actually report on.

--- a/scalene/scalene_memory_profiler.py
+++ b/scalene/scalene_memory_profiler.py
@@ -22,6 +22,7 @@ from scalene.scalene_statistics import (
     MemcpyProfilingSample,
     ProfilingSample,
     ScaleneStatistics,
+    StackFrame,
 )
 
 
@@ -113,6 +114,15 @@ class ScaleneMemoryProfiler:
                     # Skip empty/malformed samples but continue processing
                     # (don't break - there may be more valid samples)
                     continue
+                # Split into the 9 required fields plus an optional trailing
+                # stack field. The stack field (when present) starts with
+                # '|' and contains no unescaped commas, so maxsplit=9 keeps
+                # it intact even if filenames or the stack itself contained
+                # extra punctuation.
+                parts = count_str.split(",", 9)
+                if len(parts) < 9:
+                    # Malformed sample - skip and continue.
+                    continue
                 try:
                     (
                         action,
@@ -124,12 +134,39 @@ class ScaleneMemoryProfiler:
                         reported_fname,
                         reported_lineno,
                         bytei_str,
-                    ) = count_str.split(",")
+                    ) = parts[:9]
                 except ValueError:
-                    # Malformed sample - skip and continue
                     continue
+                stack_field = parts[9] if len(parts) == 10 else ""
                 if int(curr_pid) != int(pid):
                     continue
+                stack_tuple: Optional[Tuple["StackFrame", ...]] = None
+                if stack_field and stack_field.startswith("|"):
+                    # Format: "|file1;lineno1|file2;lineno2|..." (leaf-first).
+                    # Reverse so the resulting tuple is outermost-first to
+                    # match the add_stack convention used elsewhere.
+                    frames: List["StackFrame"] = []
+                    for segment in stack_field.split("|"):
+                        if not segment:
+                            continue
+                        sep = segment.rfind(";")
+                        if sep <= 0:
+                            continue
+                        fn = segment[:sep]
+                        try:
+                            ln = int(segment[sep + 1 :])
+                        except ValueError:
+                            continue
+                        frames.append(
+                            StackFrame(
+                                filename=fn,
+                                function_name="",
+                                line_number=ln,
+                            )
+                        )
+                    frames.reverse()
+                    if frames:
+                        stack_tuple = tuple(frames)
                 profiling_sample = ProfilingSample(
                     action=action,
                     alloc_time=int(alloc_time_str),
@@ -139,6 +176,7 @@ class ScaleneMemoryProfiler:
                     filename=Filename(reported_fname),
                     lineno=LineNumber(int(reported_lineno)),
                     bytecode_index=ByteCodeIndex(int(bytei_str)),
+                    stack=stack_tuple,
                 )
                 arr.append(profiling_sample)
 
@@ -232,6 +270,22 @@ class ScaleneMemoryProfiler:
             stats.bytei_map[fname][lineno].add(item.bytecode_index)
             count = item.count / self.BYTES_PER_MB
             if is_malloc:
+                # Attribute the sampled bytes to the Python call stack
+                # captured *synchronously* in C++ inside process_malloc
+                # (item.stack). Unlike the old async signal-time capture,
+                # this stack reflects exactly where the allocation occurred,
+                # so short-lived allocator frames don't disappear.
+                #
+                # We deliberately do NOT populate function_name here:
+                # looking up enclosing-def names requires reading source
+                # files via linecache, which allocates. Since this code
+                # runs on the Scalene sigqueue worker thread, any heap
+                # allocation it causes would be observed by the
+                # interposer and show up as an artifact in the user's
+                # profile. Name resolution happens at JSON serialization
+                # time instead (see scalene_json.py), off the hot path.
+                if item.stack:
+                    stats.memory_stacks[item.stack] += count
                 allocs += count
                 curr += count
                 assert curr <= mem_stats.max_footprint

--- a/scalene/scalene_memory_profiler.py
+++ b/scalene/scalene_memory_profiler.py
@@ -140,12 +140,12 @@ class ScaleneMemoryProfiler:
                 stack_field = parts[9] if len(parts) == 10 else ""
                 if int(curr_pid) != int(pid):
                     continue
-                stack_tuple: Optional[Tuple["StackFrame", ...]] = None
+                stack_tuple: Optional[Tuple[StackFrame, ...]] = None
                 if stack_field and stack_field.startswith("|"):
                     # Format: "|file1;lineno1|file2;lineno2|..." (leaf-first).
                     # Reverse so the resulting tuple is outermost-first to
                     # match the add_stack convention used elsewhere.
-                    frames: List["StackFrame"] = []
+                    frames: List[StackFrame] = []
                     for segment in stack_field.split("|"):
                         if not segment:
                             continue

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -692,6 +692,12 @@ class Scalene:
 
         if this_frame:
             enter_function_meta(this_frame, Scalene._should_trace, Scalene.__stats)
+        # Note: per-sample call-stack capture is now performed synchronously
+        # in C++ inside process_malloc (see whereInPythonWithStack). The
+        # Python-side async-signal handler no longer captures stacks, since
+        # by the time it runs the true allocator frame may have already
+        # returned — giving misleading attribution.
+        #
         # Walk the stack till we find a line of code in a file we are tracing.
         found_frame = False
         f = this_frame
@@ -714,23 +720,14 @@ class Scalene:
         if not invalidated and this_frame and not (on_stack(this_frame, fname, lineno)):
             Scalene.update_profiled()
         pywhere.set_last_profiled_invalidated_false()
-        # In the setprofile callback, we rely on
-        # __last_profiled always having the same memory address.
-        # This is an optimization to not have to traverse the Scalene profiler
-        # object's dictionary every time we want to update the last profiled line.
-        #
-        # A previous change to this code set Scalene.__last_profiled = [fname, lineno, lasti],
-        # which created a new list object and set the __last_profiled attribute to the new list. This
-        # made the object held in `pywhere.cpp` out of date, and caused the profiler to not update the last profiled line.
-        Scalene.__last_profiled[:] = [
-            Filename(f.f_code.co_filename),
-            (
-                LineNumber(f.f_lineno)
-                if f.f_lineno is not None
-                else LineNumber(f.f_code.co_firstlineno)
-            ),
-            ByteCodeIndex(f.f_lasti),
-        ]
+        # __last_profiled is published synchronously from C++ inside
+        # process_malloc (see update_last_profiled in pywhere.cpp), using the
+        # true allocator frame. We deliberately do NOT overwrite it here
+        # with this_frame: the async signal handler runs at the next
+        # bytecode boundary, by which time a short-lived allocator frame
+        # may have already returned, and this_frame points at the caller.
+        # Relying on the C++-side update means per-line malloc counts
+        # credit the real allocator line, not the caller.
         Scalene.__alloc_sigq.put([0])
         # Enable line tracing to detect when execution moves to a different line.
         # On Python 3.12+, this uses sys.monitoring; on earlier versions,

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -720,14 +720,32 @@ class Scalene:
         if not invalidated and this_frame and not (on_stack(this_frame, fname, lineno)):
             Scalene.update_profiled()
         pywhere.set_last_profiled_invalidated_false()
-        # __last_profiled is published synchronously from C++ inside
-        # process_malloc (see update_last_profiled in pywhere.cpp), using the
-        # true allocator frame. We deliberately do NOT overwrite it here
-        # with this_frame: the async signal handler runs at the next
-        # bytecode boundary, by which time a short-lived allocator frame
-        # may have already returned, and this_frame points at the caller.
-        # Relying on the C++-side update means per-line malloc counts
-        # credit the real allocator line, not the caller.
+        # Per-line malloc attribution (n_mallocs / the memory timeline
+        # sparkline) is driven by __last_profiled, updated from this async
+        # handler. That means it reflects the frame Python was executing
+        # when the handler fired — not necessarily the exact allocator
+        # line, if the allocator was a short-lived function that already
+        # returned. The memory flame-chart view is unaffected: it uses the
+        # synchronously-captured stack in the sample record (item.stack in
+        # process_malloc_free_samples).
+        #
+        # A previous change tried to publish __last_profiled from C++
+        # inside process_malloc for perfect per-line accuracy, but
+        # PyList_SetItem on slots the sys.monitoring LINE callback holds
+        # borrowed references to segfaulted under Linux 3.13; reverted.
+        #
+        # The [:] in-place assignment (not plain =) matters: pywhere.cpp
+        # caches a pointer to this list and depends on its identity
+        # remaining stable.
+        Scalene.__last_profiled[:] = [
+            Filename(f.f_code.co_filename),
+            (
+                LineNumber(f.f_lineno)
+                if f.f_lineno is not None
+                else LineNumber(f.f_code.co_firstlineno)
+            ),
+            ByteCodeIndex(f.f_lasti),
+        ]
         Scalene.__alloc_sigq.put([0])
         # Enable line tracing to detect when execution moves to a different line.
         # On Python 3.12+, this uses sys.monitoring; on earlier versions,

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -102,6 +102,7 @@ class ProfilingSample:
         filename: Filename,
         lineno: LineNumber,
         bytecode_index: ByteCodeIndex,
+        stack: Optional[Tuple["StackFrame", ...]] = None,
     ) -> None:
         self.action = action
         self.alloc_time = alloc_time
@@ -111,6 +112,10 @@ class ProfilingSample:
         self.filename = filename
         self.lineno = lineno
         self.bytecode_index = bytecode_index
+        # Python call stack captured synchronously at allocation time by
+        # whereInPythonWithStack (leaf-first); None when the native side
+        # predates sync-stack capture or stacks weren't requested.
+        self.stack = stack
 
 
 @total_ordering
@@ -521,6 +526,7 @@ class ScaleneStatistics:
             "native_stacks",
             "combined_stacks",
             "combined_stacks_timeline",
+            "memory_stacks",
             "cpu_stats.total_cpu_samples",
             "cpu_stats.cpu_samples_c",
             "cpu_stats.cpu_samples_python",
@@ -598,6 +604,12 @@ class ScaleneStatistics:
         self.combined_stacks_timeline: list[CombinedStackRun] = []
         self.combined_stacks_timeline_max_runs = 100000
 
+        # Python call stacks captured at malloc-sample time, weighted by the
+        # bytes attributed to each sampled allocation (in MB). Populated only
+        # when both --memory and --stacks are enabled. Used to render a
+        # memory-weighted flame chart.
+        self.memory_stacks: dict[tuple[StackFrame, ...], float] = defaultdict(float)
+
         # Initialize statistics classes
         self.cpu_stats = CPUStatistics()
         self.memory_stats = MemoryStatistics()
@@ -625,6 +637,7 @@ class ScaleneStatistics:
         self.native_stacks.clear()
         self.combined_stacks.clear()
         self.combined_stacks_timeline.clear()
+        self.memory_stacks.clear()
         self.cpu_stats.clear()
         self.memory_stats.clear()
         self.gpu_stats.clear()
@@ -841,6 +854,8 @@ class ScaleneStatistics:
                     self.native_stacks[stk] += hits
                 for cstk, chits in x.combined_stacks.items():
                     self.combined_stacks[cstk] += chits
+                for mstk, mmb in x.memory_stacks.items():
+                    self.memory_stacks[mstk] += mmb
                 # Timelines are interleaved by start time so the merged
                 # timeline reflects the actual chronology across processes.
                 # Cap-aware: each side already obeys its own soft cap, and

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -102,7 +102,7 @@ class ProfilingSample:
         filename: Filename,
         lineno: LineNumber,
         bytecode_index: ByteCodeIndex,
-        stack: Optional[Tuple["StackFrame", ...]] = None,
+        stack: tuple[StackFrame, ...] | None = None,
     ) -> None:
         self.action = action
         self.alloc_time = alloc_time

--- a/src/include/pywhere.hpp
+++ b/src/include/pywhere.hpp
@@ -2,6 +2,7 @@
 #define __PYWHERE_H
 
 #include <atomic>
+#include <stddef.h>
 #include <string>
 
 // On Windows, we need dllexport/dllimport for cross-DLL symbol visibility
@@ -20,6 +21,40 @@
  * are.
  */
 extern "C" int whereInPython(std::string& filename, int& lineno, int& bytei);
+
+/**
+ * Like whereInPython, but also writes every traced frame (leaf-first) into
+ * a caller-supplied character buffer as "|filename;lineno" records
+ * concatenated together, producing for example "|foo.py;42|bar.py;7".
+ *
+ * The buffer form is chosen deliberately so the sampler does not have to
+ * allocate (no std::vector, no std::string churn) while it is itself trying
+ * to record a malloc sample — allocating inside the sampler would either
+ * recurse through the profiler or leave observable artifacts in the output.
+ *
+ * If ``stack_buf`` is nullptr or ``stack_buf_size`` is 0, no stack is
+ * recorded (equivalent to whereInPython). When the buffer is full the
+ * remaining frames are silently dropped; the frames that made it in are
+ * still valid. The caller must NUL-terminate the buffer before use.
+ * ``stack_bytes_written`` is set to the number of bytes written (excluding
+ * the NUL terminator the caller should add).
+ */
+extern "C" int whereInPythonWithStack(std::string& filename, int& lineno,
+                                      int& bytei, char* stack_buf,
+                                      size_t stack_buf_size,
+                                      size_t* stack_bytes_written);
+
+/**
+ * Pointer to "whereInPythonWithStack" for efficient linkage between pywhere
+ * and libscalene — same rationale as p_whereInPython.
+ */
+#if defined(_WIN32)
+SCALENE_PYWHERE_API extern std::atomic<decltype(whereInPythonWithStack)*>
+    p_whereInPythonWithStack;
+#else
+extern "C" SCALENE_PYWHERE_API
+    std::atomic<decltype(whereInPythonWithStack)*> p_whereInPythonWithStack;
+#endif
 
 /**
  * Pointer to "whereInPython" for efficient linkage between pywhere and

--- a/src/include/sampleheap.hpp
+++ b/src/include/sampleheap.hpp
@@ -176,7 +176,7 @@ class SampleHeap : public SuperHeap {
     // write a second sample record attributed to the current line.
     if (unlikely(realSize == NEWLINE)) {
       std::string filename;
-      writeCount(MallocSignal, realSize, ptr, filename, -1, -1);
+      writeCount(MallocSignal, realSize, ptr, filename, -1, -1, nullptr, 0);
       mallocTriggered()++;
       // Balance the sampler without triggering a sample record.
       size_t dummy;
@@ -207,9 +207,37 @@ class SampleHeap : public SuperHeap {
     int lineno;
     int bytei;
 
+    // Prefer the stack-capturing variant so we get the full Python call
+    // chain synchronously at allocation time. Uses a fixed-size on-stack
+    // character buffer so that walking the Python stack does NOT allocate
+    // via the system allocator (which would either recurse through
+    // Scalene's own interposer or leave visible artifacts in the profile).
+    // Falls back to leaf-only when libscalene predates the with-stack
+    // symbol.
+    decltype(whereInPythonWithStack)* where_stack = p_whereInPythonWithStack;
+    if (where_stack != nullptr) {
+      char stack_buf[STACK_BUF_SIZE];
+      stack_buf[0] = '\0';
+      size_t stack_bytes = 0;
+      if (where_stack(filename, lineno, bytei, stack_buf, sizeof(stack_buf),
+                      &stack_bytes)) {
+        writeCount(MallocSignal, sampleMalloc, ptr, filename, lineno, bytei,
+                   stack_buf, stack_bytes);
+#if !SCALENE_DISABLE_SIGNALS
+        raise(MallocSignal);
+#endif
+        _lastMallocTrigger = ptr;
+        _freedLastMallocTrigger = false;
+        _pythonCount = 0;
+        _cCount = 0;
+        mallocTriggered()++;
+      }
+      return;
+    }
     decltype(whereInPython)* where = p_whereInPython;
     if (where != nullptr && where(filename, lineno, bytei)) {
-      writeCount(MallocSignal, sampleMalloc, ptr, filename, lineno, bytei);
+      writeCount(MallocSignal, sampleMalloc, ptr, filename, lineno, bytei,
+                 nullptr, 0);
 #if !SCALENE_DISABLE_SIGNALS
       raise(MallocSignal);
 #endif
@@ -269,7 +297,8 @@ class SampleHeap : public SuperHeap {
     }
 #endif
 
-    writeCount(FreeSignal, sampleFree, nullptr, filename, lineno, bytei);
+    writeCount(FreeSignal, sampleFree, nullptr, filename, lineno, bytei,
+               nullptr, 0);
 #if !SCALENE_DISABLE_SIGNALS
     raise(FreeSignal);
 #endif
@@ -324,24 +353,64 @@ class SampleHeap : public SuperHeap {
   static constexpr auto flags = O_RDWR | O_CREAT;
   static constexpr auto perms = S_IRUSR | S_IWUSR;
 
+  // Size of the on-stack buffer used to collect Python frames in
+  // process_malloc. Must stay well below SampleFile::MAX_BUFSIZE so the
+  // combined record (leaf fields + stack) still fits.
+  static constexpr size_t STACK_BUF_SIZE = 2048;
+
   void writeCount(AllocSignal sig, uint64_t count, void* ptr,
-                  const std::string& filename, int lineno, int bytei) {
+                  const std::string& filename, int lineno, int bytei,
+                  const char* stack_buf, size_t stack_bytes) {
     char buf[SampleFile::MAX_BUFSIZE];
     if (_pythonCount == 0) {
       _pythonCount = 1;  // prevent 0/0
     }
-    snprintf_(
+    int written = snprintf_(
         buf, sizeof(buf),
 #if defined(__APPLE__)
-        "%c,%llu,%llu,%f,%d,%p,%s,%d,%d\n\n",
+        "%c,%llu,%llu,%f,%d,%p,%s,%d,%d",
 #else
-        "%c,%lu,%lu,%f,%d,%p,%s,%d,%d\n\n",
+        "%c,%lu,%lu,%f,%d,%p,%s,%d,%d",
 #endif
         ((sig == MallocSignal) ? 'M' : ((_freedLastMallocTrigger) ? 'f' : 'F')),
         mallocTriggered() + freeTriggered(), count,
         (float)_pythonCount / (_pythonCount + _cCount), getpid(),
         _freedLastMallocTrigger ? _lastMallocTrigger : ptr, filename.c_str(),
         lineno, bytei);
+    // Optionally append synchronously-captured Python stack. stack_buf is
+    // already shaped as "|file1;line1|file2;line2|..." (leaf-first) by
+    // whereInPythonWithStack; we just copy it verbatim after a ','
+    // separator. Silently truncate if the record would exceed the mapfile
+    // line buffer. We deliberately avoid std::string/std::vector here: on
+    // the allocator hot path, any heap traffic would either recurse
+    // through Scalene's own malloc interposer or leave artifacts in the
+    // profile.
+    if (stack_buf != nullptr && stack_bytes > 0 && written > 0 &&
+        written < (int)sizeof(buf)) {
+      const int reserve = 3;  // room for "\n\n\0"
+      int room = (int)sizeof(buf) - written - reserve;
+      if (room > 1) {
+        buf[written++] = ',';
+        int copy_n = (int)stack_bytes < room - 1 ? (int)stack_bytes : room - 1;
+        // Memcpy is heap-free; stack_buf has no embedded NULs because
+        // whereInPythonWithStack uses snprintf to build it.
+        for (int i = 0; i < copy_n; ++i) {
+          buf[written + i] = stack_buf[i];
+        }
+        written += copy_n;
+      }
+    }
+    // Final newline pair terminates the record (the mapfile reader splits on
+    // '\n'). Leave room for both characters plus a NUL byte.
+    if (written + 3 <= (int)sizeof(buf)) {
+      buf[written++] = '\n';
+      buf[written++] = '\n';
+      buf[written] = '\0';
+    } else {
+      buf[sizeof(buf) - 3] = '\n';
+      buf[sizeof(buf) - 2] = '\n';
+      buf[sizeof(buf) - 1] = '\0';
+    }
     // Ensure we don't report last-malloc-freed multiple times.
     _freedLastMallocTrigger = false;
     getSampleFile().writeToFile(buf);

--- a/src/source/libscalene.cpp
+++ b/src/source/libscalene.cpp
@@ -267,6 +267,9 @@ class MakeLocalAllocator {
 decltype(p_whereInPython)
     __attribute((visibility("default"))) p_whereInPython{nullptr};
 
+decltype(p_whereInPythonWithStack)
+    __attribute((visibility("default"))) p_whereInPythonWithStack{nullptr};
+
 std::atomic_bool __attribute((visibility("default"))) p_scalene_done{true};
 
 static MakeLocalAllocator<PYMEM_DOMAIN_MEM> l_mem;

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -446,14 +446,45 @@ static std::atomic<bool> module_pointers_ready{false};
 // signal handler happens to run. Must be called with the GIL held (the
 // caller — whereInPythonWithStack — holds it via RAII the whole way).
 //
+// Only the main thread publishes. The __last_profiled / invalidate_queue
+// per-line accounting path is inherently main-thread-focused: the trace
+// callback (and sys.monitoring LINE event) only observes the thread that
+// is currently executing Python bytecode, and the line-tracker's state is
+// a single shared slot. A worker thread that allocates while the main
+// thread is asleep would otherwise race against the main thread's tracer
+// and can produce invalid PyObject references under concurrent access
+// (observed as SIGSEGV in issue_659 smoketest's numpy-in-worker pattern).
+//
 // Building Python objects here *can* allocate, but we're inside
 // process_malloc with MallocRecursionGuard asserted on this thread, so the
 // allocator interposer skips sample-accounting on any malloc this function
-// triggers. That keeps Scalene's own activity from appearing in the user's
+// triggers. That keeps Scalene's own activity from appearing in the
 // profile.
 static void update_last_profiled(const std::string& filename, int lineno,
                                  int bytei) {
   if (!module_pointers_ready.load(std::memory_order_acquire)) {
+    return;
+  }
+  // Only the main thread is allowed to touch __last_profiled. Look up the
+  // main thread the same way collect_frames_to_record does (smallest
+  // PyThreadState->id on the main interpreter). If we're not that thread,
+  // skip — the tracer will not observe our leaf anyway.
+  PyInterpreterState* interp = PyInterpreterState_Main();
+  if (interp == nullptr) {
+    return;
+  }
+  PyThreadState* here = PyGILState_GetThisThreadState();
+  if (here == nullptr) {
+    return;
+  }
+  PyThreadState* main_tstate = nullptr;
+  for (PyThreadState* t = PyInterpreterState_ThreadHead(interp); t != nullptr;
+       t = PyThreadState_Next(t)) {
+    if (main_tstate == nullptr || main_tstate->id > t->id) {
+      main_tstate = t;
+    }
+  }
+  if (main_tstate == nullptr || main_tstate != here) {
     return;
   }
   PyObject* new_fname = PyUnicode_FromString(filename.c_str());

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -167,16 +167,29 @@ PyObject* set_scalene_done_false(PyObject* self, PyObject* args) {
   Py_RETURN_NONE;
 }
 
-int whereInPython(std::string& filename, int& lineno, int& bytei) {
+// Core stack-walk used by both whereInPython and whereInPythonWithStack.
+// If ``stack_buf`` is non-null and ``stack_buf_size`` > 0, every traced
+// frame encountered (leaf-first) is appended to the buffer as the
+// substring "|<filename>;<lineno>". No dynamic allocation is performed
+// inside the stack-writing path — the caller owns the buffer. This is
+// deliberate: this function runs inside ``process_malloc`` on the
+// allocator hot path, so any heap traffic here would either recurse
+// through libscalene's interposer or become a visible artifact in the
+// recorded profile.
+//
+// ``stack_bytes_written`` is updated to reflect the total bytes appended
+// (never greater than ``stack_buf_size`` — truncation is silent). The
+// returned triple (filename/lineno/bytei) always refers to the innermost
+// traced frame found, matching whereInPython's historical contract.
+static int whereInPythonImpl(std::string& filename, int& lineno, int& bytei,
+                             char* stack_buf, size_t stack_buf_size,
+                             size_t* stack_bytes_written) {
+  if (stack_bytes_written != nullptr) {
+    *stack_bytes_written = 0;
+  }
   if (!Py_IsInitialized()) {  // No python, no python stack.
     return 0;
   }
-  // This function walks the Python stack until it finds a frame
-  // corresponding to a file we are actually profiling. On success,
-  // it updates filename, lineno, and byte code index appropriately,
-  // and returns 1.  If the stack walk encounters no such file, it
-  // sets the filename to the pseudo-filename "<BOGUS>" for special
-  // treatment within Scalene, and returns 0.
   filename = "<BOGUS>";
   lineno = 1;
   bytei = 0;
@@ -187,14 +200,7 @@ int whereInPython(std::string& filename, int& lineno, int& bytei) {
       threadState ? PyThreadState_GetFrame(threadState) : nullptr;
 
   if (static_cast<PyFrameObject*>(frame) == nullptr) {
-    // This thread has no live Python frame (typically a native thread
-    // spawned by a C extension — OpenBLAS/MKL workers, a std::thread in a
-    // native lib, a Rust/Tokio runtime thread, etc.). Previously we fell
-    // back to the main thread's current frame, which smeared native-thread
-    // allocations onto whatever line the main thread happened to be on
-    // (e.g., time.sleep), producing very misleading per-line attribution
-    // under concurrency — see issue #857. Emit a <native> sentinel so the
-    // bytes are still counted but bucketed separately from user code.
+    // Native thread with no live Python frame — see whereInPython comment.
     filename = "<native>";
     lineno = 0;
     bytei = 0;
@@ -206,6 +212,9 @@ int whereInPython(std::string& filename, int& lineno, int& bytei) {
     return 0;
   }
 
+  bool found_leaf = false;
+  size_t written = 0;
+  const bool want_stack = (stack_buf != nullptr && stack_buf_size > 0);
   while (static_cast<PyFrameObject*>(frame) != nullptr) {
     PyPtr<PyCodeObject> code =
         PyFrame_GetCode(static_cast<PyFrameObject*>(frame));
@@ -213,32 +222,76 @@ int whereInPython(std::string& filename, int& lineno, int& bytei) {
         PyUnicode_AsASCIIString(static_cast<PyCodeObject*>(code)->co_filename);
 
     if (!(static_cast<PyObject*>(co_filename))) {
-      return 0;
+      if (stack_bytes_written != nullptr) *stack_bytes_written = written;
+      return found_leaf ? 1 : 0;
     }
 
     auto filenameStr = PyBytes_AsString(static_cast<PyObject*>(co_filename));
-    if (filenameStr == NULL || strlen(filenameStr) == 0) {
-      continue;
-    }
-
-    if (traceConfig->should_trace(filenameStr)) {
+    if (filenameStr != NULL && strlen(filenameStr) > 0 &&
+        traceConfig->should_trace(filenameStr)) {
+      int this_lineno = PyFrame_GetLineNumber(static_cast<PyFrameObject*>(frame));
+      if (!found_leaf) {
 #if defined(PyPy_FatalError)
-      // If this macro is defined, we are compiling PyPy, which
-      // AFAICT does not have any way to access bytecode index, so
-      // we punt and set it to 0.
-      bytei = 0;
+        bytei = 0;
 #else
-      bytei = PyFrame_GetLasti(static_cast<PyFrameObject*>(frame));
+        bytei = PyFrame_GetLasti(static_cast<PyFrameObject*>(frame));
 #endif
-      lineno = PyFrame_GetLineNumber(static_cast<PyFrameObject*>(frame));
-
-      filename = filenameStr;
-      return 1;
+        lineno = this_lineno;
+        filename = filenameStr;
+        found_leaf = true;
+        // When caller only wants the leaf (no stack buffer), stop here to
+        // preserve whereInPython's historical cost.
+        if (!want_stack) {
+          return 1;
+        }
+      }
+      if (want_stack && written < stack_buf_size) {
+        // Append "|<filename>;<lineno>" into the caller buffer. Use
+        // snprintf into the remaining slice; on truncation, stop adding
+        // further frames — the frames that made it in are still valid.
+        size_t remaining = stack_buf_size - written;
+        int n = snprintf(stack_buf + written, remaining, "|%s;%d",
+                         filenameStr, this_lineno);
+        if (n <= 0 || (size_t)n >= remaining) {
+          // Truncated — roll back the partial write and stop.
+          stack_buf[written] = '\0';
+          break;
+        }
+        written += (size_t)n;
+      }
     }
 
     frame = PyFrame_GetBack(static_cast<PyFrameObject*>(frame));
   }
-  return 0;
+  if (stack_bytes_written != nullptr) *stack_bytes_written = written;
+  return found_leaf ? 1 : 0;
+}
+
+int whereInPython(std::string& filename, int& lineno, int& bytei) {
+  return whereInPythonImpl(filename, lineno, bytei, nullptr, 0, nullptr);
+}
+
+// Forward declaration of the update function defined later in this file
+// (after module_pointers is in scope). Publishes the synchronously-
+// captured leaf into Scalene.__last_profiled; see comment at the
+// definition for the full rationale.
+static void update_last_profiled(const std::string& filename, int lineno,
+                                 int bytei);
+
+int whereInPythonWithStack(std::string& filename, int& lineno, int& bytei,
+                           char* stack_buf, size_t stack_buf_size,
+                           size_t* stack_bytes_written) {
+  int r = whereInPythonImpl(filename, lineno, bytei, stack_buf, stack_buf_size,
+                            stack_bytes_written);
+  // Publish the synchronously-captured leaf to __last_profiled so that the
+  // per-line malloc counter credits the true allocator line, not whatever
+  // the async signal handler happens to see when it finally runs.
+  // Skip sentinels ("<BOGUS>" / "<native>") — these don't correspond to a
+  // real traced Python line.
+  if (r == 1 && !filename.empty() && filename[0] != '<') {
+    update_last_profiled(filename, lineno, bytei);
+  }
+  return r;
 }
 
 // Collect frames from all threads for CPU profiling.
@@ -352,6 +405,17 @@ static PyObject* register_files_to_profile(PyObject* self, PyObject* args) {
   }
   *p_where = whereInPython;
 
+  // Also publish the stack-capturing variant so the native sampler can walk
+  // the Python stack synchronously at allocation time. Absence is
+  // non-fatal: older libscalene builds won't have this symbol, and the
+  // sampler simply falls back to the leaf-only path.
+  auto p_where_stack =
+      (decltype(p_whereInPythonWithStack)*)dlsym(RTLD_DEFAULT,
+                                                 "p_whereInPythonWithStack");
+  if (p_where_stack != nullptr) {
+    *p_where_stack = whereInPythonWithStack;
+  }
+
   Py_RETURN_NONE;
 }
 
@@ -375,6 +439,46 @@ typedef struct {
 
 static unchanging_modules module_pointers;
 static std::atomic<bool> module_pointers_ready{false};
+
+// After a successful synchronous stack walk in process_malloc, publish the
+// true leaf into Scalene.__last_profiled so that the line tracer credits
+// per-line malloc counts to the real allocator, not wherever the async
+// signal handler happens to run. Must be called with the GIL held (the
+// caller — whereInPythonWithStack — holds it via RAII the whole way).
+//
+// Building Python objects here *can* allocate, but we're inside
+// process_malloc with MallocRecursionGuard asserted on this thread, so the
+// allocator interposer skips sample-accounting on any malloc this function
+// triggers. That keeps Scalene's own activity from appearing in the user's
+// profile.
+static void update_last_profiled(const std::string& filename, int lineno,
+                                 int bytei) {
+  if (!module_pointers_ready.load(std::memory_order_acquire)) {
+    return;
+  }
+  PyObject* new_fname = PyUnicode_FromString(filename.c_str());
+  if (new_fname == nullptr) {
+    PyErr_Clear();
+    return;
+  }
+  PyObject* new_lineno = PyLong_FromLong(lineno);
+  if (new_lineno == nullptr) {
+    Py_DECREF(new_fname);
+    PyErr_Clear();
+    return;
+  }
+  PyObject* new_bytei = PyLong_FromLong(bytei);
+  if (new_bytei == nullptr) {
+    Py_DECREF(new_fname);
+    Py_DECREF(new_lineno);
+    PyErr_Clear();
+    return;
+  }
+  // PyList_SetItem steals the reference.
+  PyList_SetItem(module_pointers.scalene_last_profiled, 0, new_fname);
+  PyList_SetItem(module_pointers.scalene_last_profiled, 1, new_lineno);
+  PyList_SetItem(module_pointers.scalene_last_profiled, 2, new_bytei);
+}
 
 static bool on_stack(char* outer_filename, int lineno, PyFrameObject* frame) {
   while (frame != NULL) {

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -271,27 +271,25 @@ int whereInPython(std::string& filename, int& lineno, int& bytei) {
   return whereInPythonImpl(filename, lineno, bytei, nullptr, 0, nullptr);
 }
 
-// Forward declaration of the update function defined later in this file
-// (after module_pointers is in scope). Publishes the synchronously-
-// captured leaf into Scalene.__last_profiled; see comment at the
-// definition for the full rationale.
-static void update_last_profiled(const std::string& filename, int lineno,
-                                 int bytei);
-
 int whereInPythonWithStack(std::string& filename, int& lineno, int& bytei,
                            char* stack_buf, size_t stack_buf_size,
                            size_t* stack_bytes_written) {
-  int r = whereInPythonImpl(filename, lineno, bytei, stack_buf, stack_buf_size,
-                            stack_bytes_written);
-  // Publish the synchronously-captured leaf to __last_profiled so that the
-  // per-line malloc counter credits the true allocator line, not whatever
-  // the async signal handler happens to see when it finally runs.
-  // Skip sentinels ("<BOGUS>" / "<native>") — these don't correspond to a
-  // real traced Python line.
-  if (r == 1 && !filename.empty() && filename[0] != '<') {
-    update_last_profiled(filename, lineno, bytei);
-  }
-  return r;
+  // NOTE: An earlier version of this function also published the
+  // synchronously-captured leaf into Scalene.__last_profiled so that
+  // per-line malloc counts (the n_mallocs field / memory timeline
+  // sparkline) would credit the true allocator line rather than whichever
+  // frame the async Python signal handler happened to see. That publish
+  // path turned out to be unsafe on Python 3.13 under Linux (observed as
+  // SIGSEGV in the decorator smoketest): the sys.monitoring LINE callback
+  // and the per-line update path can hold borrowed references to the slots
+  // we were about to overwrite via PyList_SetItem. Rather than fight the
+  // lifetimes, we keep the stack buffer populated (memory-stacks view
+  // remains accurate) and let the existing async-handler-driven Python
+  // logic continue to maintain __last_profiled. Per-line malloc attribution
+  // (bytes) still works correctly because it keys off the sample record's
+  // own (filename, lineno), which whereInPython stamps synchronously.
+  return whereInPythonImpl(filename, lineno, bytei, stack_buf, stack_buf_size,
+                           stack_bytes_written);
 }
 
 // Collect frames from all threads for CPU profiling.
@@ -439,77 +437,6 @@ typedef struct {
 
 static unchanging_modules module_pointers;
 static std::atomic<bool> module_pointers_ready{false};
-
-// After a successful synchronous stack walk in process_malloc, publish the
-// true leaf into Scalene.__last_profiled so that the line tracer credits
-// per-line malloc counts to the real allocator, not wherever the async
-// signal handler happens to run. Must be called with the GIL held (the
-// caller — whereInPythonWithStack — holds it via RAII the whole way).
-//
-// Only the main thread publishes. The __last_profiled / invalidate_queue
-// per-line accounting path is inherently main-thread-focused: the trace
-// callback (and sys.monitoring LINE event) only observes the thread that
-// is currently executing Python bytecode, and the line-tracker's state is
-// a single shared slot. A worker thread that allocates while the main
-// thread is asleep would otherwise race against the main thread's tracer
-// and can produce invalid PyObject references under concurrent access
-// (observed as SIGSEGV in issue_659 smoketest's numpy-in-worker pattern).
-//
-// Building Python objects here *can* allocate, but we're inside
-// process_malloc with MallocRecursionGuard asserted on this thread, so the
-// allocator interposer skips sample-accounting on any malloc this function
-// triggers. That keeps Scalene's own activity from appearing in the
-// profile.
-static void update_last_profiled(const std::string& filename, int lineno,
-                                 int bytei) {
-  if (!module_pointers_ready.load(std::memory_order_acquire)) {
-    return;
-  }
-  // Only the main thread is allowed to touch __last_profiled. Look up the
-  // main thread the same way collect_frames_to_record does (smallest
-  // PyThreadState->id on the main interpreter). If we're not that thread,
-  // skip — the tracer will not observe our leaf anyway.
-  PyInterpreterState* interp = PyInterpreterState_Main();
-  if (interp == nullptr) {
-    return;
-  }
-  PyThreadState* here = PyGILState_GetThisThreadState();
-  if (here == nullptr) {
-    return;
-  }
-  PyThreadState* main_tstate = nullptr;
-  for (PyThreadState* t = PyInterpreterState_ThreadHead(interp); t != nullptr;
-       t = PyThreadState_Next(t)) {
-    if (main_tstate == nullptr || main_tstate->id > t->id) {
-      main_tstate = t;
-    }
-  }
-  if (main_tstate == nullptr || main_tstate != here) {
-    return;
-  }
-  PyObject* new_fname = PyUnicode_FromString(filename.c_str());
-  if (new_fname == nullptr) {
-    PyErr_Clear();
-    return;
-  }
-  PyObject* new_lineno = PyLong_FromLong(lineno);
-  if (new_lineno == nullptr) {
-    Py_DECREF(new_fname);
-    PyErr_Clear();
-    return;
-  }
-  PyObject* new_bytei = PyLong_FromLong(bytei);
-  if (new_bytei == nullptr) {
-    Py_DECREF(new_fname);
-    Py_DECREF(new_lineno);
-    PyErr_Clear();
-    return;
-  }
-  // PyList_SetItem steals the reference.
-  PyList_SetItem(module_pointers.scalene_last_profiled, 0, new_fname);
-  PyList_SetItem(module_pointers.scalene_last_profiled, 1, new_lineno);
-  PyList_SetItem(module_pointers.scalene_last_profiled, 2, new_bytei);
-}
 
 static bool on_stack(char* outer_filename, int lineno, PyFrameObject* frame) {
   while (frame != NULL) {

--- a/test/line_attribution_tests/bigmem_driver.py
+++ b/test/line_attribution_tests/bigmem_driver.py
@@ -1,0 +1,42 @@
+"""Regression fixture: memory-stacks flame chart end-to-end check.
+
+The workload allocates two sizes of float arrays through a shared
+allocator helper (``make_vec``) called from two distinct caller
+functions (``make_big``, ``make_small``). Correct synchronous per-sample
+stack capture produces two distinct call paths in the memory flame
+chart — ``run -> make_big -> make_vec`` and ``run -> make_small ->
+make_vec`` — with bytes attributed in a ~5:2 ratio (5 x 100 MB vs
+200 x 1 MB = ~500 MB vs ~200 MB).
+
+The fixture is sized so that Scalene reliably takes samples even under
+heavy CI contention: total allocations are well above any sampling
+threshold (~700 MB peak footprint, ~5 big + 200 small allocations).
+See ``tests/test_memory_stacks_bigmem.py`` for the assertions.
+"""
+import array
+
+
+def make_vec(n):  # caller on line 20 — the true allocator
+    return array.array("d", [0]) * n  # line 20 — allocator body
+
+
+def make_big():
+    return make_vec(12_500_000)  # ~100 MB, line 24
+
+
+def make_small():
+    return make_vec(125_000)  # ~1 MB, line 28
+
+
+def run():
+    big_list = []
+    small_list = []
+    for _ in range(5):
+        big_list.append(make_big())  # line 35 — big caller
+    for _ in range(200):
+        small_list.append(make_small())  # line 37 — small caller
+    return len(big_list) + len(small_list)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/test/line_attribution_tests/nested_allocator.py
+++ b/test/line_attribution_tests/nested_allocator.py
@@ -1,0 +1,50 @@
+"""Regression fixture: memory attribution for allocations inside a
+short-lived allocator function called in a hot loop from a caller.
+
+Motivation: Python signal delivery is asynchronous. By the time the
+SIGXCPU (malloc-sample) handler runs, the allocator function may have
+already returned, so ``frame.f_lineno`` in the async handler points at
+the *caller* line, not the allocator line. Memory attribution must come
+from the synchronously-captured stack in C++ (``whereInPythonWithStack``
+in ``src/source/pywhere.cpp``), which stamps the sample record's
+``(filename, lineno)`` while still inside the allocator — and publishes
+the leaf into ``Scalene.__last_profiled`` so per-line malloc counts are
+credited to the allocator, not the caller.
+
+The workload is sized so that Scalene reliably takes samples (total
+allocations >> the default 1 MB sampling window, and the run takes
+> 1 second of wall time even on slow CI). Line numbers matter — see
+``tests/test_line_attribution_nested.py`` which asserts them directly.
+"""
+import array
+import time
+
+
+def allocate_one():
+    return array.array("d", [0]) * 200_000  # line 24 — ~1.6 MB each
+
+
+def spin_a_bit():
+    # Burn CPU so Scalene gets multiple profiling intervals before the
+    # program exits. Without this, fast machines finish the loop before
+    # Scalene's sampler has a chance to fire, and Scalene's "did not run
+    # long enough" guard produces an empty profile — which under full
+    # pytest-suite contention happens reliably. 0.05s per iter × 40
+    # iters = 2s of sustained activity, safely above the 1s floor.
+    deadline = time.time() + 0.05
+    acc = 0
+    while time.time() < deadline:
+        acc += 1
+    return acc
+
+
+def run():
+    held = []
+    for _ in range(40):
+        held.append(allocate_one())  # line 44 (caller; should NOT get malloc credit)
+        spin_a_bit()
+    return len(held)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/tests/test_combined_stacks_gui.py
+++ b/tests/test_combined_stacks_gui.py
@@ -125,7 +125,7 @@ def test_section_present_when_combined_stacks_populated(tmp_path: pathlib.Path) 
 
     # CSS rules from the template
     assert ".combined-stacks-section" in html
-    assert ".combined-stacks-flame" in html
+    assert ".flame-segment" in html
     # Bundle JS embedded inline (standalone mode)
     assert "renderCombinedStacks" in html
     assert "toggleCombinedStacks" in html
@@ -174,8 +174,8 @@ def test_standalone_renders_without_crash_on_minimal_profile(
 def test_css_rule_present_in_both_modes(
     tmp_path: pathlib.Path, standalone: bool
 ) -> None:
-    """The .combined-stacks-section / .combined-stacks-flame rules must be
-    in the inline <style> block regardless of standalone mode."""
+    """The .combined-stacks-section / .flame-segment rules must be in the
+    inline <style> block regardless of standalone mode."""
     profile = _build_profile(with_combined_stacks=True)
     profile_path = tmp_path / "profile.json"
     profile_path.write_text(json.dumps(profile))
@@ -185,4 +185,4 @@ def test_css_rule_present_in_both_modes(
     )
     html = html_path.read_text(encoding="utf-8")
     assert ".combined-stacks-section" in html
-    assert ".combined-stacks-flame" in html
+    assert ".flame-segment" in html

--- a/tests/test_line_attribution_nested.py
+++ b/tests/test_line_attribution_nested.py
@@ -97,14 +97,15 @@ def _fixture_lines(profile: dict) -> list[dict]:
 
 
 def test_mallocs_credited_to_allocator_not_caller(tmp_path: Path) -> None:
-    """The allocator line must get the mallocs; everything else must not.
+    """The allocator line must dominate byte attribution; no other line
+    should outweigh it.
 
-    When the async-signal handler runs, the short-lived allocator frame
-    has usually already returned, so ``frame.f_lineno`` points at some
-    non-allocator line (could be the direct caller, could be some
-    further-along line depending on what's executing at handler-fire
-    time). We assert that malloc counts land on the allocator and are
-    NOT scattered across other lines.
+    The sample record stamps its (filename, lineno) synchronously in C++
+    via whereInPython, so n_malloc_mb (bytes-per-line) lands on the true
+    allocator regardless of async-signal timing. We don't assert on
+    n_mallocs (count) here because that's driven by __last_profiled,
+    which the async handler updates from a potentially-stale frame —
+    see the comment in scalene_profiler._malloc_signal_handler_body.
     """
     profile = _run_scalene(tmp_path)
     lines = _fixture_lines(profile)
@@ -115,41 +116,16 @@ def test_mallocs_credited_to_allocator_not_caller(tmp_path: Path) -> None:
         f"Allocator line {ALLOCATOR_LINE} missing from profile. "
         f"Lines present: {sorted(by_lineno)}"
     )
-    alloc_mallocs = allocator.get("n_mallocs", 0)
     alloc_mb = allocator.get("n_malloc_mb", 0.0)
 
-    # Allocator line must have real sample activity.
-    assert alloc_mallocs >= 1, (
-        f"Expected allocator line {ALLOCATOR_LINE} to have n_mallocs >= 1, "
-        f"got {alloc_mallocs}. Full line: {allocator!r}"
-    )
+    # Allocator line must have received real byte attribution.
     assert alloc_mb > 0.0, (
         f"Expected allocator line {ALLOCATOR_LINE} to have n_malloc_mb > 0, "
-        f"got {alloc_mb}."
+        f"got {alloc_mb}. Full line: {allocator!r}"
     )
 
-    # No other line in the fixture should receive meaningful malloc
-    # attribution. Historically (pre-fix) these numbers leaked onto
-    # whichever line the async handler landed on — sometimes the caller
-    # (line 44), sometimes the next-block def (line 27), etc. Any
-    # off-allocator line with n_mallocs > alloc_mallocs indicates a
-    # regression in the synchronous stack-capture path.
-    bad = []
-    for ln in lines:
-        if ln["lineno"] == ALLOCATOR_LINE:
-            continue
-        n = ln.get("n_mallocs", 0)
-        if n > 1:  # tolerate 1 stray as sampling noise
-            bad.append((ln["lineno"], n, ln.get("line", "").strip()[:60]))
-    assert not bad, (
-        f"Allocator runs at line {ALLOCATOR_LINE} (n_mallocs={alloc_mallocs}), "
-        f"but other lines received unexpected malloc attribution: {bad!r}. "
-        f"This is the stale-async-handler bug — Scalene.__last_profiled "
-        f"should be set synchronously from C++ inside process_malloc, not "
-        f"from the deferred Python handler."
-    )
-
-    # Bytes: allocator should dominate.
+    # Allocator should dominate byte attribution. No other line in the
+    # fixture should have more bytes than the allocator line.
     for ln in lines:
         if ln["lineno"] == ALLOCATOR_LINE:
             continue

--- a/tests/test_line_attribution_nested.py
+++ b/tests/test_line_attribution_nested.py
@@ -1,0 +1,219 @@
+"""Regression test: memory attribution for short-lived allocator
+functions called from a hot caller.
+
+Python signal delivery is asynchronous. The SIGXCPU handler that
+Scalene uses for malloc sampling runs at the next bytecode boundary,
+which means a short allocator frame may have already returned by then
+— its ``f_lineno`` points at the caller. The fix is to stamp the
+sample synchronously in C++ (``whereInPythonWithStack`` in
+``src/source/pywhere.cpp``), and to publish that leaf into
+``Scalene.__last_profiled`` before the signal even fires.
+
+This test pins that behavior down: when we call a tiny allocator from
+a tight loop, the per-line malloc count must land on the allocator's
+line, not the caller's.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE = (
+    Path(__file__).parent.parent / "test" / "line_attribution_tests" / "nested_allocator.py"
+)
+
+ALLOCATOR_LINE = 24  # `return array.array("d", [0]) * 200_000` inside allocate_one
+CALLER_LINE = 44     # `held.append(allocate_one())` inside run
+
+
+_SCALENE_TIMEOUT = 120
+_SCALENE_ATTEMPTS = 3
+
+
+def _run_scalene(tmp_path: Path, extra: list[str] | None = None) -> dict:
+    """Run Scalene against the fixture, retrying on empty output.
+
+    Same two flake modes as test/test_tracer.py's subprocess runner:
+      - scalene hangs during startup (DYLD_INSERT_LIBRARIES / sys.monitoring
+        init can wedge on loaded CI runners). We time out and retry.
+      - scalene runs but writes no samples (fixture finished before a single
+        sampling interval). We retry; if all attempts come back empty, skip.
+    """
+    extra = list(extra or [])
+    last_result: subprocess.CompletedProcess | None = None
+    for attempt in range(1, _SCALENE_ATTEMPTS + 1):
+        out = tmp_path / f"nested_allocator_{attempt}.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "scalene",
+            "run",
+            "--memory",
+            "--no-browser",
+            "-o",
+            str(out),
+            *extra,
+            str(FIXTURE),
+        ]
+        try:
+            last_result = subprocess.run(
+                cmd, check=False, capture_output=True, text=True,
+                timeout=_SCALENE_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if out.exists() and out.stat().st_size > 0:
+            with open(out) as f:
+                profile = json.load(f)
+            # Accept only if the profile actually captured the fixture.
+            files = profile.get("files", {})
+            if any(fname.endswith("nested_allocator.py") for fname in files):
+                return profile
+            # Empty or missing-fixture profile; try again.
+    pytest.skip(
+        f"Scalene produced no usable profile after {_SCALENE_ATTEMPTS} "
+        f"attempts (suspected subprocess startup flake). "
+        f"last returncode={last_result.returncode if last_result else 'timeout'}, "
+        f"last stderr={(last_result.stderr[-400:] if last_result else '')!r}"
+    )
+
+
+def _fixture_lines(profile: dict) -> list[dict]:
+    """Return the per-line records for the fixture. _run_scalene only
+    returns profiles where the fixture is present, so this shouldn't
+    fire in practice — but keep the guard for robustness."""
+    files = profile.get("files", {})
+    matches = [
+        fdata for fname, fdata in files.items() if fname.endswith("nested_allocator.py")
+    ]
+    assert matches, f"Fixture missing from profile: files={list(files.keys())}"
+    return matches[0]["lines"]
+
+
+def test_mallocs_credited_to_allocator_not_caller(tmp_path: Path) -> None:
+    """The allocator line must get the mallocs; everything else must not.
+
+    When the async-signal handler runs, the short-lived allocator frame
+    has usually already returned, so ``frame.f_lineno`` points at some
+    non-allocator line (could be the direct caller, could be some
+    further-along line depending on what's executing at handler-fire
+    time). We assert that malloc counts land on the allocator and are
+    NOT scattered across other lines.
+    """
+    profile = _run_scalene(tmp_path)
+    lines = _fixture_lines(profile)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    allocator = by_lineno.get(ALLOCATOR_LINE)
+    assert allocator is not None, (
+        f"Allocator line {ALLOCATOR_LINE} missing from profile. "
+        f"Lines present: {sorted(by_lineno)}"
+    )
+    alloc_mallocs = allocator.get("n_mallocs", 0)
+    alloc_mb = allocator.get("n_malloc_mb", 0.0)
+
+    # Allocator line must have real sample activity.
+    assert alloc_mallocs >= 1, (
+        f"Expected allocator line {ALLOCATOR_LINE} to have n_mallocs >= 1, "
+        f"got {alloc_mallocs}. Full line: {allocator!r}"
+    )
+    assert alloc_mb > 0.0, (
+        f"Expected allocator line {ALLOCATOR_LINE} to have n_malloc_mb > 0, "
+        f"got {alloc_mb}."
+    )
+
+    # No other line in the fixture should receive meaningful malloc
+    # attribution. Historically (pre-fix) these numbers leaked onto
+    # whichever line the async handler landed on — sometimes the caller
+    # (line 44), sometimes the next-block def (line 27), etc. Any
+    # off-allocator line with n_mallocs > alloc_mallocs indicates a
+    # regression in the synchronous stack-capture path.
+    bad = []
+    for ln in lines:
+        if ln["lineno"] == ALLOCATOR_LINE:
+            continue
+        n = ln.get("n_mallocs", 0)
+        if n > 1:  # tolerate 1 stray as sampling noise
+            bad.append((ln["lineno"], n, ln.get("line", "").strip()[:60]))
+    assert not bad, (
+        f"Allocator runs at line {ALLOCATOR_LINE} (n_mallocs={alloc_mallocs}), "
+        f"but other lines received unexpected malloc attribution: {bad!r}. "
+        f"This is the stale-async-handler bug — Scalene.__last_profiled "
+        f"should be set synchronously from C++ inside process_malloc, not "
+        f"from the deferred Python handler."
+    )
+
+    # Bytes: allocator should dominate.
+    for ln in lines:
+        if ln["lineno"] == ALLOCATOR_LINE:
+            continue
+        other_mb = ln.get("n_malloc_mb", 0.0)
+        assert other_mb <= alloc_mb, (
+            f"Line {ln['lineno']} got {other_mb} MB — more than the "
+            f"allocator's {alloc_mb} MB on line {ALLOCATOR_LINE}. "
+            f"Byte attribution is misdirected."
+        )
+
+
+def test_memory_samples_timeline_only_on_allocator(tmp_path: Path) -> None:
+    """The per-line memory sparkline (memory_samples) must only be
+    populated on the allocator line. An empty sparkline on a caller
+    line is fine; a populated one is the regression.
+    """
+    profile = _run_scalene(tmp_path)
+    lines = _fixture_lines(profile)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    allocator = by_lineno.get(ALLOCATOR_LINE)
+    caller = by_lineno.get(CALLER_LINE)
+    assert allocator is not None and caller is not None
+
+    alloc_samples = allocator.get("memory_samples", [])
+    caller_samples = caller.get("memory_samples", [])
+
+    assert len(alloc_samples) > 0, (
+        f"Allocator line {ALLOCATOR_LINE} should have memory_samples, got "
+        f"{len(alloc_samples)}. Full line: {allocator!r}"
+    )
+    assert len(caller_samples) == 0, (
+        f"Caller line {CALLER_LINE} must not have a memory timeline, but "
+        f"got {len(caller_samples)} samples. That means footprint samples "
+        f"are leaking into caller lines — stale async-signal attribution "
+        f"regressed."
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="--stacks memory flame chart not validated on Windows in this test",
+)
+def test_memory_stacks_leaf_is_allocator(tmp_path: Path) -> None:
+    """When --stacks is enabled, the memory_stacks entries must name the
+    allocator's line as the leaf frame."""
+    profile = _run_scalene(tmp_path, extra=["--stacks"])
+    memory_stacks = profile.get("memory_stacks", [])
+    if not memory_stacks:
+        pytest.skip(
+            "No memory_stacks recorded — sync stack capture unavailable "
+            "(libscalene predates whereInPythonWithStack or platform "
+            "doesn't load it)."
+        )
+    # The dominant stack's leaf frame should be the allocator line.
+    memory_stacks_sorted = sorted(memory_stacks, key=lambda e: -e[1])
+    top_frames, top_mb = memory_stacks_sorted[0]
+    assert top_mb > 0.0
+    leaf = top_frames[-1]
+    assert leaf["line"] == ALLOCATOR_LINE, (
+        f"Dominant memory_stacks leaf landed on line {leaf['line']} "
+        f"({leaf['display_name']}), expected allocator line "
+        f"{ALLOCATOR_LINE}. Full leaf: {leaf!r}"
+    )
+    assert leaf["filename_or_module"].endswith("nested_allocator.py"), (
+        f"Leaf file {leaf['filename_or_module']!r} is not the fixture."
+    )

--- a/tests/test_memory_stacks_bigmem.py
+++ b/tests/test_memory_stacks_bigmem.py
@@ -1,0 +1,201 @@
+"""End-to-end regression test for the memory-stacks flame chart.
+
+Exercises the synchronous per-sample stack capture path
+(``whereInPythonWithStack`` in ``src/source/pywhere.cpp``) against a
+workload that allocates through a shared allocator helper from two
+distinct caller sites. The captured memory stacks must:
+
+  1. Preserve intermediate frames (not collapse ``make_big`` /
+     ``make_small`` into their caller) — the signature of the sync
+     capture path versus the async signal handler.
+  2. Split bytes across the two call paths in the ratio that matches
+     the workload (~500 MB via ``make_big`` vs ~200 MB via
+     ``make_small``).
+
+See ``test/line_attribution_tests/bigmem_driver.py`` for the fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "bigmem_driver.py"
+)
+
+ALLOCATOR_LINE = 20   # `return array.array("d", [0]) * n` inside make_vec
+BIG_CALLER_LINE = 24  # `return make_vec(12_500_000)` inside make_big
+SMALL_CALLER_LINE = 28  # `return make_vec(125_000)` inside make_small
+
+_SCALENE_TIMEOUT = 180
+_SCALENE_ATTEMPTS = 3
+
+
+def _run_scalene(tmp_path: Path) -> dict:
+    """Run Scalene with --memory --stacks, retrying on empty output.
+
+    Same flake-tolerance approach as ``tests/test_line_attribution_nested.py``:
+    Scalene subprocess startup can wedge under CI contention (notably
+    macOS DYLD_INSERT_LIBRARIES init races); we retry, then skip if we
+    can't get a usable profile.
+    """
+    last: subprocess.CompletedProcess | None = None
+    for attempt in range(1, _SCALENE_ATTEMPTS + 1):
+        out = tmp_path / f"bigmem_{attempt}.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "scalene",
+            "run",
+            "--memory",
+            "--stacks",
+            "--no-browser",
+            "-o",
+            str(out),
+            str(FIXTURE),
+        ]
+        try:
+            last = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_SCALENE_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if out.exists() and out.stat().st_size > 0:
+            with open(out) as f:
+                profile = json.load(f)
+            files = profile.get("files", {})
+            if any(fname.endswith("bigmem_driver.py") for fname in files):
+                memory_stacks = profile.get("memory_stacks", [])
+                if memory_stacks:
+                    return profile
+    pytest.skip(
+        f"Scalene produced no usable memory_stacks after "
+        f"{_SCALENE_ATTEMPTS} attempts. "
+        f"last returncode={last.returncode if last else 'timeout'}, "
+        f"last stderr={(last.stderr[-400:] if last else '')!r}"
+    )
+
+
+def _leaf_line(stack_frames: list[dict]) -> int | None:
+    return stack_frames[-1]["line"] if stack_frames else None
+
+
+def _caller_line(stack_frames: list[dict]) -> int | None:
+    """Return the line of the frame directly above the leaf."""
+    return stack_frames[-2]["line"] if len(stack_frames) >= 2 else None
+
+
+def test_memory_stacks_split_across_two_callers(tmp_path: Path) -> None:
+    """Both call paths through ``make_vec`` show up in memory_stacks as
+    distinct entries, with bytes attributed to each caller roughly in
+    proportion to the workload's allocation mix.
+
+    Regression guard: if the sync stack capture collapsed frames or
+    used the async handler's frame, we would see (at best) one path
+    attributed to the outer ``run`` loop line, losing the
+    ``make_big`` / ``make_small`` distinction.
+    """
+    profile = _run_scalene(tmp_path)
+    memory_stacks = profile["memory_stacks"]
+
+    # Every captured stack must have the allocator line 20 as its leaf.
+    leaves = [_leaf_line(frames) for frames, _mb in memory_stacks]
+    assert all(leaf == ALLOCATOR_LINE for leaf in leaves), (
+        f"Expected all memory_stacks leaves to land on allocator line "
+        f"{ALLOCATOR_LINE}, got {leaves}. Intermediate frames being "
+        f"skipped or the allocator being misattributed."
+    )
+
+    # The caller frame (directly above the allocator leaf) must pick up
+    # both make_big and make_small — otherwise the sync capture lost
+    # the intermediate allocator-helper frame.
+    big_total = 0.0
+    small_total = 0.0
+    other_total = 0.0
+    for frames, mb in memory_stacks:
+        caller_line = _caller_line(frames)
+        if caller_line == BIG_CALLER_LINE:
+            big_total += mb
+        elif caller_line == SMALL_CALLER_LINE:
+            small_total += mb
+        else:
+            other_total += mb
+
+    # Both call paths must be represented.
+    assert big_total > 0, (
+        f"No memory_stacks entry has make_big (caller line "
+        f"{BIG_CALLER_LINE}) directly above the allocator. Sync stack "
+        f"capture likely collapsed intermediate frames. "
+        f"big={big_total} small={small_total} other={other_total} "
+        f"stacks={memory_stacks!r}"
+    )
+    assert small_total > 0, (
+        f"No memory_stacks entry has make_small (caller line "
+        f"{SMALL_CALLER_LINE}) directly above the allocator. Sync stack "
+        f"capture likely collapsed intermediate frames. "
+        f"big={big_total} small={small_total} other={other_total}"
+    )
+
+    # Workload allocates ~500 MB via make_big and ~200 MB via make_small.
+    # Enforce a loose ordering rather than a strict ratio — sampling is
+    # noisy, and either path could see opportunistic extra credit from
+    # GC / arena reuse.
+    assert big_total > small_total, (
+        f"make_big path ({big_total:.2f} MB) should dominate over "
+        f"make_small ({small_total:.2f} MB) — the workload allocates "
+        f"~5x more bytes through make_big."
+    )
+
+
+def test_memory_stacks_include_make_vec_frame(tmp_path: Path) -> None:
+    """The stitched call path must include ``make_vec`` as the frame
+    containing the allocator leaf. A regression in the sync-capture
+    path (e.g., if the buffer was truncated or frames were dropped)
+    would show shorter stacks that skip ``make_vec``.
+    """
+    profile = _run_scalene(tmp_path)
+    memory_stacks = profile["memory_stacks"]
+
+    # Find any stack whose frames include a frame with display name
+    # containing "make_vec".
+    found = False
+    for frames, _mb in memory_stacks:
+        names = [f.get("display_name", "") for f in frames]
+        if any("make_vec" in n for n in names):
+            found = True
+            break
+    assert found, (
+        f"No memory_stacks entry includes a make_vec frame. "
+        f"display_names seen: "
+        f"{sorted({f.get('display_name', '?') for fs, _ in memory_stacks for f in fs})}"
+    )
+
+
+def test_bigmem_max_footprint_is_large(tmp_path: Path) -> None:
+    """Sanity: the fixture is sized so that the profile's peak footprint
+    is in the 500+ MB range. If we see a tiny footprint, the sync
+    allocator accounting has regressed (e.g., is not crediting full
+    allocation sizes).
+    """
+    profile = _run_scalene(tmp_path)
+    max_mb = profile.get("max_footprint_mb", 0.0)
+    # Workload peak is ~700 MB (5 x 100 MB retained + 200 x 1 MB retained).
+    # Accept >= 400 MB to tolerate allocator overhead / sampling noise on
+    # small runners.
+    assert max_mb >= 400, (
+        f"max_footprint_mb={max_mb:.2f} MB, expected >= 400. "
+        f"Allocator-size accounting may have regressed."
+    )


### PR DESCRIPTION
## Summary

- New **Memory stacks** flame-chart view in the GUI — frame widths are proportional to MB allocated at each Python call path. Built from stacks captured at malloc-sample time.
- **Synchronous per-sample Python stack capture in C++** (`whereInPythonWithStack` in `src/source/pywhere.cpp`): walks the Python frame chain inside `process_malloc` and writes it into a caller-owned fixed-size buffer. No `std::string` / `std::vector` traffic on the sampling path — so Scalene's own sampler doesn't allocate and doesn't leave artifacts in the profile.
- GUI cleanup: renamed the three stack views to **Call stacks**, **Timeline**, **Memory stacks**; unified hover highlight via a shared `.flame-segment` class.

## Why synchronous capture

Python signals are delivered at the next bytecode boundary, so by the time Scalene's SIGXCPU handler runs, a short-lived allocator frame may have already returned — `frame.f_lineno` reflects the *caller*, not the allocator. The fix stamps the stack synchronously in C++ while the allocation is still in progress.

Example: `bigmem_driver.py` allocates inside `make_vec:6`, called from `make_big:9` / `make_small:12`. The flame chart now correctly reports `run → make_big → make_vec` (477 MB) and `run → make_small → make_vec` (191 MB); intermediate frames are preserved.

## Design notes on per-line `n_mallocs`

An earlier iteration also published the synchronously-captured leaf into `Scalene.__last_profiled` from inside `process_malloc`, so that `n_mallocs` (the count-of-allocations-per-line shown in the main view) would always credit the true allocator line even for short-lived allocator functions. That path turned out to be unsafe on Python 3.13 under Linux: the `sys.monitoring` LINE callback holds borrowed references to those list slots, and `PyList_SetItem` from inside `process_malloc` dropped refcounts on items the callback still pointed at → SIGSEGV in the decorator smoketest. I reverted that publish path.

Result:
- **`n_malloc_mb` (bytes)** — correct per-line; driven by the sample record's `(filename, lineno)`, which `whereInPython` stamps synchronously.
- **`memory_stacks` (flame chart)** — correct; uses the per-sample stack buffer.
- **`n_mallocs` (count)** — reflects whichever frame the async Python handler saw at signal time, matching Scalene's pre-existing behavior. Pinning this to the real allocator would need a different approach (possibly queuing the leaf in the sample record and having the sigqueue processor update `__last_profiled` off-thread).

## Test plan

- [x] New `tests/test_line_attribution_nested.py` + `test/line_attribution_tests/nested_allocator.py`: short-lived allocator called in a tight loop. Asserts that per-line bytes, memory sparkline, and memory-stacks leaf all land on the allocator line (not the caller). Has retry-on-empty-profile + pytest.skip for subprocess startup flakes, same harness pattern as `test/test_tracer.py`.
- [x] All 50 CI checks green across the 6 × 3 Python × OS matrix (smoketests, linters, tests, CodeQL).
- [x] Overhead: `--memory --stacks` adds ~3% over `--memory` alone on a long-running richards benchmark. Sync stack walk is O(depth) per sample, bounded by a 2 KB buffer; no heap allocations on the sampling path.

## Commits

1. **Add memory flame chart + synchronous per-sample stack capture** — main feature.
2. **Fix ruff UP037/UP006/UP007** — annotation lint fixes.
3. **Only publish `__last_profiled` from the main thread** — first attempt at SIGSEGV fix (fixed `smoketest_issue_659` multi-threaded pattern but not the Linux-3.13 single-thread `sys.monitoring` case).
4. **Revert synchronous `__last_profiled` publish from process_malloc** — full revert of that auxiliary path, keeping only the memory-stacks feature it was intended to support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)