### PR TITLE
Shrink stack+timeline RAM, harden profiler self-exclusion

### DIFF
--- a/scalene/scalene_json.py
+++ b/scalene/scalene_json.py
@@ -65,6 +65,7 @@ class _ResolvedNativeFrame:
     pure cost here.
     """
 
+    __slots__ = ("module", "symbol", "ip", "offset")
     module: str
     symbol: str
     ip: int

--- a/scalene/scalene_memory_profiler.py
+++ b/scalene/scalene_memory_profiler.py
@@ -24,6 +24,7 @@ from scalene.scalene_statistics import (
     ScaleneStatistics,
     StackFrame,
 )
+from scalene.scalene_utility import intern_stack_frame
 
 
 class ScaleneMemoryProfiler:
@@ -158,7 +159,7 @@ class ScaleneMemoryProfiler:
                         except ValueError:
                             continue
                         frames.append(
-                            StackFrame(
+                            intern_stack_frame(
                                 filename=fn,
                                 function_name="",
                                 line_number=ln,

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -118,6 +118,7 @@ from scalene.scalene_tracer import (
 from scalene.scalene_tracing import ScaleneTracing
 from scalene.scalene_utility import (
     add_stack,
+    clear_intern_caches,
     compute_frames_to_record,
     drain_native_stacks,
     enter_function_meta,
@@ -1203,6 +1204,11 @@ class Scalene:
                 file=sys.stderr,
             )
             sys.exit(1)
+        # Drop any frame-key intern cache carried over from a prior session
+        # (Jupyter magic cells, repeated profile runs in the same process,
+        # etc.). Must happen before we start sampling so the cache reflects
+        # only the current run.
+        clear_intern_caches()
         Scalene.__stats.start_clock()
         Scalene.enable_signals()
         Scalene.__start_time = time.monotonic_ns()
@@ -1230,10 +1236,20 @@ class Scalene:
         if Scalene.__args.async_profile:
             ScaleneAsync.disable()
 
-        if Scalene.__args.memory:
+        # Flip p_scalene_done back to true so the allocator interposer
+        # stops recording — in particular, allocations made while we
+        # serialize the profile to JSON must not land in the profile
+        # itself. Called unconditionally (not gated on --memory) so the
+        # invariant "no allocations are tracked after stop()" holds even
+        # on code paths that exit through term_signal_handler or other
+        # non-standard shutdown routes. When libscalene isn't preloaded
+        # (CPU-only mode), set_scalene_done_true is a no-op by design.
+        try:
             from scalene import pywhere  # type: ignore
 
             pywhere.set_scalene_done_true()
+        except ImportError:
+            pass
 
         Scalene._disable_signals()
         Scalene.__stats.stop_clock()
@@ -1698,14 +1714,31 @@ class Scalene:
     @staticmethod
     def _register_files_to_profile() -> None:
         """Tells the pywhere module, which tracks memory, which files to profile."""
+        import scalene as _scalene_pkg
         from scalene import pywhere  # type: ignore
 
         profile_only_list = Scalene.__args.profile_only.split(",")
+
+        # Pass the canonical path of the installed scalene package so the C++
+        # TraceConfig can exclude Scalene-internal frames via an absolute-path
+        # prefix match, not just a parent-directory-name heuristic. The
+        # fallback "scalene" parent-directory check stays in place; this is
+        # additive belt-and-suspenders.
+        scalene_pkg_path: str | None = None
+        try:
+            scalene_pkg_file = getattr(_scalene_pkg, "__file__", None)
+            if scalene_pkg_file:
+                scalene_pkg_path = os.path.realpath(
+                    os.path.dirname(scalene_pkg_file)
+                )
+        except (TypeError, ValueError, OSError):
+            scalene_pkg_path = None
 
         pywhere.register_files_to_profile(
             list(Scalene.__files_to_profile) + profile_only_list,
             Scalene.__program_path,
             Scalene.__args.profile_all,
+            scalene_pkg_path,
         )
 
     @staticmethod

--- a/scalene/scalene_statistics.py
+++ b/scalene/scalene_statistics.py
@@ -42,8 +42,15 @@ class PyFrameKey:
     Frozen so instances are hashable and usable as parts of dict keys
     (specifically inside CombinedStackKey tuples used to key
     ``ScaleneStatistics.combined_stacks``).
+
+    __slots__ keeps each instance at ~200 bytes instead of ~650 bytes
+    (no per-instance __dict__). At the scale of the stitched-stacks
+    timeline this is the single biggest in-process memory win. Manual
+    slots tuple rather than ``slots=True`` because Scalene supports
+    Python 3.8.
     """
 
+    __slots__ = ("filename", "function", "line")
     filename: str
     function: str
     line: int
@@ -56,6 +63,7 @@ class NativeFrameKey:
     in the signal handler. Frozen for the same reason as PyFrameKey.
     """
 
+    __slots__ = ("ip",)
     ip: int
 
 
@@ -84,8 +92,14 @@ class CombinedStackRun:
         stack_key: The stitched stack — same shape as the keys of
             ``ScaleneStatistics.combined_stacks``.
         count: Number of consecutive CPU samples in this run.
+
+    Non-frozen so ``count`` can be incremented in place when the next
+    sample hits the same stack. __slots__ drops the per-run overhead
+    from ~590 bytes to ~150 bytes, which matters because the timeline
+    can hold up to ``combined_stacks_timeline_max_runs`` (100K) entries.
     """
 
+    __slots__ = ("timestamp", "stack_key", "count")
     timestamp: float
     stack_key: CombinedStackKey
     count: int
@@ -152,7 +166,16 @@ class MemcpyProfilingSample:
 
 
 class StackFrame:
-    """Represents a single frame in the stack."""
+    """Represents a single frame in the stack.
+
+    __slots__ drops each instance from ~660 bytes to ~80 bytes by
+    eliminating the per-instance __dict__. StackFrame is the element
+    type of ``ScaleneStatistics.memory_stacks`` keys, where every
+    malloc sample that flows through ``process_malloc_free_samples``
+    constructs fresh frames before the dict dedupes by equality.
+    """
+
+    __slots__ = ("filename", "function_name", "line_number")
 
     def __init__(self, filename: str, function_name: str, line_number: int) -> None:
         self.filename = filename
@@ -177,6 +200,8 @@ class StackFrame:
 
 class StackStats:
     """Represents statistics for a stack."""
+
+    __slots__ = ("count", "python_time", "c_time", "cpu_samples")
 
     def __init__(
         self, count: int, python_time: float, c_time: float, cpu_samples: float

--- a/scalene/scalene_utility.py
+++ b/scalene/scalene_utility.py
@@ -62,6 +62,91 @@ except ImportError:
     _native_unwind_available = False
 
 
+# Per-process intern caches for stitched-stack frame keys.
+#
+# Every CPU sample that captures a stitched stack constructs a fresh tuple of
+# PyFrameKey / NativeFrameKey instances. Without interning, two consecutive
+# samples on the same line allocate two distinct frame objects that compare
+# equal, and only the `combined_stacks` dict de-duplicates them (the one fed
+# into the timeline is retained for the lifetime of the profile). At high
+# sample rates the timeline list holds millions of these redundant objects.
+#
+# These caches ensure that equal frames share a single instance, so a tuple
+# captured twice at the same point is represented by the same Python objects
+# throughout. Combined with __slots__ on the frame dataclasses, this collapses
+# the timeline's per-run memory cost by roughly an order of magnitude.
+#
+# The caches are module-level because they belong to the profiler process (one
+# profile per process) and because add_combined_stack / add_async_await_run
+# are called from the CPU-sample sigqueue thread on a hot path — a single
+# dict lookup is cheaper than constructing a fresh dataclass instance.
+# Cleared on each ``clear_intern_caches()`` call (invoked from Scalene.start()
+# so that multiprocess runs / repeated magic-cell invocations don't leak state
+# across profiling sessions).
+_py_frame_intern: Dict[Tuple[str, str, int], PyFrameKey] = {}
+_native_frame_intern: Dict[int, NativeFrameKey] = {}
+
+
+def _intern_py_frame(filename: str, function: str, line: int) -> PyFrameKey:
+    """Return the shared PyFrameKey for (filename, function, line),
+    constructing and caching a new one on first sight. Not thread-safe by
+    design: callers are single-threaded (the sigqueue worker and the
+    CPU-sample Python handler, which are serialized by the GIL + sigqueue
+    lock). A racy double-insert would still be correctness-safe (both keys
+    hash-equal) but waste a slot.
+    """
+    key = (filename, function, line)
+    cached = _py_frame_intern.get(key)
+    if cached is None:
+        cached = PyFrameKey(filename=filename, function=function, line=line)
+        _py_frame_intern[key] = cached
+    return cached
+
+
+def _intern_native_frame(ip: int) -> NativeFrameKey:
+    """Return the shared NativeFrameKey for ``ip``, constructing one on
+    first sight. Same thread-safety caveat as _intern_py_frame."""
+    cached = _native_frame_intern.get(ip)
+    if cached is None:
+        cached = NativeFrameKey(ip=ip)
+        _native_frame_intern[ip] = cached
+    return cached
+
+
+def clear_intern_caches() -> None:
+    """Drop all cached frame-key instances. Safe to call any time the
+    profiler is between sessions. After a clear, subsequent samples
+    repopulate the caches from scratch."""
+    _py_frame_intern.clear()
+    _native_frame_intern.clear()
+    _stack_frame_intern.clear()
+
+
+# StackFrame intern cache for the memory-stacks path (parallel rationale to
+# the PyFrameKey cache above, but for the memory_stacks dict). Keyed by
+# (filename, function_name, line_number). Populated by ``intern_stack_frame``;
+# callers outside this module (notably scalene_memory_profiler) reuse it to
+# avoid reconstructing equal StackFrame objects for every malloc sample.
+_stack_frame_intern: Dict[Tuple[str, str, int], StackFrame] = {}
+
+
+def intern_stack_frame(
+    filename: str, function_name: str, line_number: int
+) -> StackFrame:
+    """Return a shared StackFrame for (filename, function_name, line_number).
+    Constructs and caches a new one on first sight."""
+    key = (filename, function_name, line_number)
+    cached = _stack_frame_intern.get(key)
+    if cached is None:
+        cached = StackFrame(
+            filename=filename,
+            function_name=function_name,
+            line_number=line_number,
+        )
+        _stack_frame_intern[key] = cached
+    return cached
+
+
 def enter_function_meta(
     frame: FrameType,
     should_trace: Callable[[Filename, str], bool],
@@ -190,14 +275,12 @@ def add_stack(
         if should_trace(Filename(f.f_code.co_filename), f.f_code.co_name):
             stk.insert(
                 0,
-                StackFrame(
-                    filename=str(f.f_code.co_filename),
-                    function_name=str(get_fully_qualified_name(f)),
-                    line_number=(
-                        int(f.f_lineno)
-                        if f.f_lineno is not None
-                        else int(f.f_code.co_firstlineno)
-                    ),
+                intern_stack_frame(
+                    str(f.f_code.co_filename),
+                    str(get_fully_qualified_name(f)),
+                    int(f.f_lineno)
+                    if f.f_lineno is not None
+                    else int(f.f_code.co_firstlineno),
                 ),
             )
         f = f.f_back
@@ -297,10 +380,10 @@ def add_combined_stack(
             )
             py_chain.insert(
                 0,
-                PyFrameKey(
-                    filename=str(f.f_code.co_filename),
-                    function=str(get_fully_qualified_name(f)),
-                    line=line,
+                _intern_py_frame(
+                    str(f.f_code.co_filename),
+                    str(get_fully_qualified_name(f)),
+                    line,
                 ),
             )
         f = f.f_back
@@ -312,7 +395,7 @@ def add_combined_stack(
         # native-entry -> native-leaf, which means reversing the
         # leaf-first tuple from the unwinder.
         native_segment: Tuple[NativeFrameKey, ...] = tuple(
-            NativeFrameKey(ip=ip) for ip in reversed(native_stk)
+            _intern_native_frame(ip) for ip in reversed(native_stk)
         )
         key: CombinedStackKey = py_chain_tuple + native_segment
         combined_stacks[key] += 1
@@ -398,10 +481,10 @@ def add_async_await_run(
                     else (cfunc or "<coroutine>")
                 )
                 py_frames.append(
-                    PyFrameKey(
-                        filename=str(cf_filename),
-                        function=func_label,
-                        line=int(cl),
+                    _intern_py_frame(
+                        str(cf_filename),
+                        func_label,
+                        int(cl),
                     )
                 )
 
@@ -414,10 +497,10 @@ def add_async_await_run(
                 continue
             func_name: str = task.func_name or "<await>"
             py_frames.append(
-                PyFrameKey(
-                    filename=str(filename),
-                    function=f"[await] {func_name}{task_suffix}",
-                    line=int(task.lineno),
+                _intern_py_frame(
+                    str(filename),
+                    f"[await] {func_name}{task_suffix}",
+                    int(task.lineno),
                 )
             )
 

--- a/src/include/traceconfig.hpp
+++ b/src/include/traceconfig.hpp
@@ -28,7 +28,8 @@
 
 class TraceConfig {
  public:
-  TraceConfig(PyObject* list_wrapper, PyObject* base_path, bool profile_all_b) {
+  TraceConfig(PyObject* list_wrapper, PyObject* base_path, bool profile_all_b,
+              PyObject* scalene_pkg_path_obj = nullptr) {
     // Assumes that each item is a bytes object
     owner = list_wrapper;
     path_owner = base_path;
@@ -44,6 +45,24 @@ class TraceConfig {
       items.push_back(s);
     }
     scalene_base_path = PyBytes_AsString(PyUnicode_AsEncodedString(base_path, "utf-8", "strict"));
+    // Canonical path of the ``scalene`` package directory, used by
+    // should_trace() to recognize Scalene-internal frames even when the
+    // package lives in a directory not literally named "scalene" (vendoring,
+    // editable installs under symlinks, test layouts, etc.). Optional:
+    // callers that predate this field pass nullptr and we fall back to the
+    // legacy parent-directory-name check alone.
+    if (scalene_pkg_path_obj && scalene_pkg_path_obj != Py_None) {
+      scalene_pkg_path_owner = scalene_pkg_path_obj;
+      Py_IncRef(scalene_pkg_path_owner);
+      auto enc =
+          PyUnicode_AsEncodedString(scalene_pkg_path_obj, "utf-8", "strict");
+      if (enc) {
+        scalene_pkg_path = std::string(PyBytes_AsString(enc));
+        Py_DecRef(enc);
+      }
+    } else {
+      scalene_pkg_path_owner = nullptr;
+    }
   }
 
   bool should_trace(char* filename) {
@@ -73,14 +92,41 @@ class TraceConfig {
 
     // Always exclude Scalene's own files, regardless of profile_all.
     //
-    // Scalene's package lives in a directory named exactly "scalene". A file
-    // is a scalene-internal file iff its *immediate* parent directory is
-    // "scalene". The previous check (strstr for "scalene/scalene") was a
-    // substring match that also matched user paths like
+    // Two complementary checks run here:
+    //
+    //   1. Canonical-path prefix against the known scalene package
+    //      directory (captured at TraceConfig construction time from the
+    //      installed ``scalene.__file__``). This is the robust check: it
+    //      works even if the package has been renamed or vendored into a
+    //      parent directory that is not literally called "scalene".
+    //
+    //   2. The historical "immediate parent directory is literally
+    //      'scalene'" check. Kept as a defensive fallback for any path that
+    //      slips past #1 (e.g. a TraceConfig built by an older code path
+    //      that didn't pass scalene_pkg_path, or a resolved path on one
+    //      host being compared against a non-resolved path on another).
+    //
+    // Historical note: the previous "scalene/scalene" substring check
+    // also matched user paths like
     // /home/runner/work/scalene/scalene/test/foo.py (the GitHub Actions
     // checkout path for this very repo), which caused the stack walker to
-    // skip user frames and misattribute allocations to threading.py instead
-    // of issue_659_workload.py — see #659.
+    // skip user frames and misattribute allocations to threading.py
+    // instead of issue_659_workload.py — see #659. The two-step check
+    // here preserves that fix.
+    if (!scalene_pkg_path.empty()) {
+      const size_t pkg_len = scalene_pkg_path.size();
+      if (strncmp(filename, scalene_pkg_path.c_str(), pkg_len) == 0) {
+        // Make sure we match on a path boundary so "/opt/scalene-thing.py"
+        // doesn't get excluded because the package lives at "/opt/scalene".
+        const char boundary = filename[pkg_len];
+        if (boundary == '/' || boundary == '\\' || boundary == '\0') {
+          std::lock_guard<std::mutex> lock(_memoizeMutex);
+          _memoize.insert(
+              std::pair<std::string, bool>(std::string(filename), false));
+          return false;
+        }
+      }
+    }
     {
       const char* last_slash = strrchr(filename, '/');
       const char* last_bslash = strrchr(filename, '\\');
@@ -186,10 +232,14 @@ class TraceConfig {
  private:
   std::vector<char*> items;
   char* scalene_base_path;
+  // Canonical path to the Scalene package directory. Empty when the
+  // caller did not supply one (legacy path). See should_trace().
+  std::string scalene_pkg_path;
   // This is to keep the object in scope so that
   // the data pointers are always valid
   PyObject* owner;
   PyObject* path_owner;
+  PyObject* scalene_pkg_path_owner;
   bool profile_all;
 
   static std::mutex _instanceMutex;

--- a/src/source/pywhere.cpp
+++ b/src/source/pywhere.cpp
@@ -149,21 +149,26 @@ PyObject* set_last_profiled_invalidated_false(PyObject* self, PyObject* args) {
 }
 
 PyObject* set_scalene_done_true(PyObject* self, PyObject* args) {
+  // Resolve p_scalene_done from the preloaded libscalene. The symbol is
+  // only present on runs that preloaded the allocator interposer (i.e.
+  // memory profiling). When it's absent (CPU-only / platforms without
+  // libscalene) there is nothing to gate, so return successfully rather
+  // than raising — this lets callers safely invoke set_scalene_done_true
+  // during shutdown regardless of the profiling mode.
   auto scalene_done = (std::atomic_bool*)dlsym(RTLD_DEFAULT, "p_scalene_done");
-  if (scalene_done == nullptr) {
-    PyErr_SetString(PyExc_Exception, "Unable to find p_scalene_done");
-    return NULL;
+  if (scalene_done != nullptr) {
+    *scalene_done = true;
   }
-  *scalene_done = true;
   Py_RETURN_NONE;
 }
 PyObject* set_scalene_done_false(PyObject* self, PyObject* args) {
+  // Symmetric to set_scalene_done_true. When the interposer isn't
+  // loaded, nothing is tracking allocations and there is nothing to
+  // un-gate; silently succeed.
   auto scalene_done = (std::atomic_bool*)dlsym(RTLD_DEFAULT, "p_scalene_done");
-  if (scalene_done == nullptr) {
-    PyErr_SetString(PyExc_Exception, "Unable to find p_whereInPython");
-    return NULL;
+  if (scalene_done != nullptr) {
+    *scalene_done = false;
   }
-  *scalene_done = false;
   Py_RETURN_NONE;
 }
 
@@ -371,14 +376,21 @@ static PyObject* setup_trace_config(PyObject* self, PyObject* args) {
   PyObject* a_list;
   PyObject* base_path;
   int profile_all;
-  if (!PyArg_ParseTuple(args, "OOp", &a_list, &base_path, &profile_all))
+  PyObject* scalene_pkg_path = nullptr;
+  // Optional 4th arg: canonical path to the scalene package directory, used
+  // by TraceConfig::should_trace to recognize Scalene-internal frames via
+  // an absolute-path prefix match. Callers that don't pass it fall back to
+  // the legacy "immediate parent directory named scalene" heuristic alone.
+  if (!PyArg_ParseTuple(args, "OOp|O", &a_list, &base_path, &profile_all,
+                        &scalene_pkg_path))
     return NULL;
   auto is_list = PyList_Check(a_list);
   if (!is_list) {
     PyErr_SetString(PyExc_Exception, "Requires list or list-like object");
     return NULL;
   }
-  TraceConfig::setInstance(new TraceConfig(a_list, base_path, profile_all));
+  TraceConfig::setInstance(
+      new TraceConfig(a_list, base_path, profile_all, scalene_pkg_path));
   Py_RETURN_NONE;
 }
 
@@ -386,14 +398,17 @@ static PyObject* register_files_to_profile(PyObject* self, PyObject* args) {
   PyObject* a_list;
   PyObject* base_path;
   int profile_all;
-  if (!PyArg_ParseTuple(args, "OOp", &a_list, &base_path, &profile_all))
+  PyObject* scalene_pkg_path = nullptr;
+  if (!PyArg_ParseTuple(args, "OOp|O", &a_list, &base_path, &profile_all,
+                        &scalene_pkg_path))
     return NULL;
   auto is_list = PyList_Check(a_list);
   if (!is_list) {
     PyErr_SetString(PyExc_Exception, "Requires list or list-like object");
     return NULL;
   }
-  TraceConfig::setInstance(new TraceConfig(a_list, base_path, profile_all));
+  TraceConfig::setInstance(
+      new TraceConfig(a_list, base_path, profile_all, scalene_pkg_path));
 
   auto p_where =
       (decltype(p_whereInPython)*)dlsym(RTLD_DEFAULT, "p_whereInPython");

--- a/tests/test_coverup_78.py
+++ b/tests/test_coverup_78.py
@@ -32,7 +32,14 @@ def test_register_files_to_profile(scalene_cleanup):
         # Call the method under test
         Scalene._register_files_to_profile()
 
-        # Check that pywhere.register_files_to_profile was called with the correct arguments
-        mock_register_files_to_profile.assert_called_once_with(
-            ["test3.py", "test1.py", "test2.py"], ".", False
-        )
+        # The 4th positional arg is the canonical path of the installed
+        # scalene package (used by TraceConfig to exclude Scalene-internal
+        # frames via an absolute-path prefix check). Value depends on the
+        # installation path, so assert it is a non-empty str rather than a
+        # fixed string.
+        assert mock_register_files_to_profile.call_count == 1
+        args, kwargs = mock_register_files_to_profile.call_args
+        assert args[0] == ["test3.py", "test1.py", "test2.py"]
+        assert args[1] == "."
+        assert args[2] is False
+        assert isinstance(args[3], str) and args[3]  # non-empty package path


### PR DESCRIPTION
## Summary

Audit of the stitched-stacks + memory-flame-chart pipeline surfaced one
dominant in-process RAM cost (the timeline's per-run dataclass overhead)
and two load-bearing-but-fragile self-exclusion checks. Four focused
changes, ranked by leverage:

- **P1. `__slots__` on the per-sample dataclasses** (`PyFrameKey`,
  `NativeFrameKey`, `CombinedStackRun`, `StackFrame`, `StackStats`,
  `_ResolvedNativeFrame`). These types are instantiated per CPU/malloc
  sample and retained in long-lived dicts + the timeline list. Manual
  `__slots__` tuples (not `slots=True`) because Scalene still supports
  3.8.
- **P2. Per-process frame-key intern caches** in `scalene_utility`
  (`add_stack` / `add_combined_stack` / `add_async_await_run`) and
  `scalene_memory_profiler` (per-malloc `StackFrame` construction).
  Before: every sample constructed fresh dataclass instances that
  compared equal; only `combined_stacks` de-duplicated them, and the
  timeline retained all the redundant objects for the lifetime of the
  run. After: equal frames share one instance. Caches are cleared in
  `Scalene.start()` so repeated profile sessions start fresh.
- **P10. Canonical-path prefix check for Scalene-internal files** in
  C++ `TraceConfig::should_trace`. The existing "immediate parent
  directory literally named `scalene`" heuristic stays as a defensive
  fallback (it handled the #659 fix); the prefix check makes exclusion
  robust to vendoring, editable installs under symlinks, and packaging
  layouts that don't name the dir `scalene`. The path is sourced from
  `os.path.realpath(os.path.dirname(scalene.__file__))`.
  `register_files_to_profile` / `setup_trace_config` take the path as
  an optional 4th argument.
- **P11. Unconditional `p_scalene_done = True` on `Scalene.stop()`**,
  not gated on `args.memory`. Guarantees that allocations made while we
  serialize the profile to JSON — or via atypical shutdown routes like
  `term_signal_handler` — cannot land in the profile itself.
  `set_scalene_done_{true,false}` in `pywhere.cpp` become no-ops when
  `libscalene` isn't preloaded, so the unconditional flip is safe in
  `--cpu-only` mode.

## Measured overhead drop

Workload: `big_workload.py` (~10s, 3 threads, `--memory --stacks`).

| | Before | After | Δ |
|---|---:|---:|---:|
| `ScaleneStatistics` total RAM | 1616 KB | **215 KB** | **−86.7%** |
| `combined_stacks_timeline` RAM (425 runs) | 1544 KB | **123 KB** | **−92.0%** |
| `combined_stacks` RAM | 243 KB | **23 KB** | **−90.5%** |
| avg `CombinedStackRun` | 4688 B | 1920 B | −59.0% |
| `PyFrameKey` per-instance | 664 B | 192 B | −71.1% |
| `NativeFrameKey` per-instance | 424 B | 72 B | −83.0% |

JSON-on-disk size is intentionally unchanged (P1/P2 target in-process
RAM; the on-disk wins are in the follow-up P4/P5/P6 proposals).

## Test plan

- [x] `ruff check scalene/` — clean
- [x] `mypy scalene/` — clean on all 63 source files (with
  `types-PyYAML` installed)
- [x] `pytest tests/` — **397 passed, 19 skipped** (includes the
  dedicated memory-stacks, line-attribution-nested, native-stacks,
  async-profiling, and combined-stacks-GUI suites)
- [x] `tests/test_coverup_78.py` updated to assert the new 4-arg
  `register_files_to_profile` signature (4th arg: non-empty
  package-path string)
- [x] Smoketests: `smoketest_issue_659`, `smoketest_pool_spawn`
  (incl. the `--cpu-only` path that exercises P11),
  `smoketest_profile_decorator` all pass.
- [ ] `smoketest_line_invalidation` fails on md5 mismatches — verified
  pre-existing on master, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)