### PR TITLE
Add memory allocation attribution tests (single- and multithreaded)

### DIFF
--- a/test/line_attribution_tests/mt_gil_release_worker.py
+++ b/test/line_attribution_tests/mt_gil_release_worker.py
@@ -1,0 +1,39 @@
+"""Multithreaded fixture: worker allocates under a released GIL (numpy).
+
+Used by ``tests/test_memory_multithreaded_gil_release.py``. This is the
+asserting form of ``test/test-native-thread-alloc.py`` and pins issue
+#857: when OpenBLAS/MKL drop the GIL inside a numpy allocation, the
+sampled bytes must still be attributed to the worker thread's Python
+frame, not to ``time.sleep`` on the main thread where the GIL happens
+to be held.
+
+Line numbers are load-bearing: WORKER_ALLOC_LINE, MAIN_SLEEP_LINE are
+referenced as integer constants. If numpy is unavailable, exit cleanly
+so the test skips.
+"""
+import sys
+import threading
+import time
+
+try:
+    import numpy as np
+except ImportError:
+    sys.exit(0)
+
+
+def worker():
+    for _ in range(40):
+        a = np.zeros((1024, 1024), dtype=np.float64)  # line 26 — ~8 MB via libc malloc, GIL often released (WORKER_ALLOC_LINE)
+        a += 1.0
+        del a
+
+
+def main():
+    t = threading.Thread(target=worker)
+    t.start()
+    time.sleep(2.0)  # line 34 — main-thread idle; must NOT be charged with worker bytes (MAIN_SLEEP_LINE)
+    t.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/line_attribution_tests/mt_two_workers.py
+++ b/test/line_attribution_tests/mt_two_workers.py
@@ -1,0 +1,58 @@
+"""Multithreaded fixture: two worker threads, each with its own allocator line.
+
+Used by ``tests/test_memory_multithreaded.py`` and
+``tests/test_memory_multithreaded_stacks.py``. Both workers allocate pure
+Python ``array.array`` objects under the GIL — no numpy, no GIL release
+— so any attribution gap across threads reflects the stack-walk path in
+``whereInPythonWithStack``, not a GIL-release confounder.
+
+Per-worker allocator lines get compared directly against each other
+(same iteration count; allocation sizes differ by 4x). The main thread's
+``sleep`` and ``join`` lines must NOT be charged with worker bytes — that
+would mean Scalene is walking the wrong thread's Python stack when a
+sample fires inside a worker.
+
+Line numbers are load-bearing: WORKER_A_ALLOC_LINE, WORKER_B_ALLOC_LINE,
+MAIN_SLEEP_LINE, MAIN_JOIN_LINE are referenced as integer constants.
+"""
+import array
+import threading
+import time
+
+
+def spin_a_bit():
+    deadline = time.time() + 0.05
+    acc = 0
+    while time.time() < deadline:
+        acc += 1
+    return acc
+
+
+def worker_a():
+    held = []
+    for _ in range(50):
+        held.append(array.array("d", [0]) * 200_000)  # line 34 — ~1.6 MB (WORKER_A_ALLOC_LINE)
+        spin_a_bit()
+    return len(held)
+
+
+def worker_b():
+    held = []
+    for _ in range(50):
+        held.append(array.array("d", [0]) * 800_000)  # line 42 — ~6.4 MB (WORKER_B_ALLOC_LINE)
+        spin_a_bit()
+    return len(held)
+
+
+def main():
+    t_a = threading.Thread(target=worker_a)
+    t_b = threading.Thread(target=worker_b)
+    t_a.start()
+    t_b.start()
+    time.sleep(2.5)  # line 52 — main-thread idle (MAIN_SLEEP_LINE)
+    t_a.join()       # line 53 — main-thread idle (MAIN_JOIN_LINE)
+    t_b.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/line_attribution_tests/st_python_vs_c.py
+++ b/test/line_attribution_tests/st_python_vs_c.py
@@ -1,0 +1,51 @@
+"""Single-threaded fixture: Python-allocator vs C-allocator byte split.
+
+Used by ``tests/test_memory_python_vs_c.py``. The CPython bytes allocator
+counts toward the interposer's ``_pythonCount`` (see
+``src/include/sampleheap.hpp``); numpy's ``np.zeros`` goes through libc
+``malloc`` and counts toward ``_cCount``. The Python-fraction field in
+the JSON output (``n_python_fraction``) should reflect this split
+per-line.
+
+Line numbers are load-bearing: PYTHON_LINE and C_LINE are asserted on
+directly. If numpy is unavailable, exit cleanly so the test skips
+instead of failing spuriously.
+"""
+import sys
+import time
+
+try:
+    import numpy as np
+except ImportError:
+    # Fixture degrades cleanly: no samples attributed to this file,
+    # the test recognizes the missing fixture and skips.
+    sys.exit(0)
+
+
+def spin_a_bit():
+    deadline = time.time() + 0.05
+    acc = 0
+    while time.time() < deadline:
+        acc += 1
+    return acc
+
+
+def python_alloc():
+    return bytes(2 * 10_485_767)  # line 34 — ~20 MB via CPython allocator (PYTHON_LINE)
+
+
+def c_alloc():
+    return np.zeros(2_000_000, dtype=np.float64)  # line 38 — ~16 MB via libc malloc (C_LINE)
+
+
+def run():
+    held = []
+    for _ in range(30):
+        held.append(python_alloc())
+        held.append(c_alloc())
+        spin_a_bit()
+    return len(held)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/test/line_attribution_tests/st_two_allocators.py
+++ b/test/line_attribution_tests/st_two_allocators.py
@@ -1,0 +1,45 @@
+"""Single-threaded fixture: two allocator functions with different byte sizes.
+
+Used by ``tests/test_memory_two_allocators.py`` and
+``tests/test_memory_stack_leaf_singlethread.py``. Both allocator functions
+run the same number of times, so per-line byte attribution should be
+proportional to each allocator's per-call size (~4x spread here, tests
+only assert a loose 2x to absorb sampling noise).
+
+Line numbers are load-bearing: the tests reference SMALL_LINE and BIG_LINE
+by integer constants. Do not reformat without updating those constants.
+"""
+import array
+import time
+
+
+def spin_a_bit():
+    # Burn CPU so Scalene takes multiple sampling intervals before the
+    # program exits. Without this, the loop can complete before a single
+    # SIGVTALRM fires, and Scalene emits an empty profile.
+    deadline = time.time() + 0.05
+    acc = 0
+    while time.time() < deadline:
+        acc += 1
+    return acc
+
+
+def small_alloc():
+    return array.array("d", [0]) * 150_000  # line 28 — ~1.2 MB (SMALL_LINE)
+
+
+def big_alloc():
+    return array.array("d", [0]) * 600_000  # line 32 — ~4.8 MB (BIG_LINE)
+
+
+def run():
+    held = []
+    for _ in range(40):
+        held.append(small_alloc())
+        held.append(big_alloc())
+        spin_a_bit()
+    return len(held)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/tests/_scalene_subprocess.py
+++ b/tests/_scalene_subprocess.py
@@ -1,0 +1,114 @@
+"""Shared helper for end-to-end memory-attribution tests.
+
+Runs Scalene as a subprocess against a fixture, retries on empty output,
+and skips cleanly if no usable profile ever comes back. Factored out of
+``tests/test_line_attribution_nested.py`` and ``tests/test_memory_stacks_bigmem.py``
+once a third family of tests started needing the same logic.
+
+Not a test module — pytest ignores files whose basename starts with ``_``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+
+def run_scalene_memory_profile(
+    tmp_path: Path,
+    fixture: Path,
+    *,
+    extra_args: Optional[List[str]] = None,
+    timeout: int = 120,
+    attempts: int = 3,
+    require_memory_stacks: bool = False,
+) -> dict:
+    """Profile *fixture* with ``--memory``; return the parsed JSON profile.
+
+    Retries on two known flake modes:
+      - Scalene startup wedges (``DYLD_INSERT_LIBRARIES`` / ``sys.monitoring``
+        init under CI contention): caught via ``TimeoutExpired``.
+      - Scalene runs but writes no samples for the fixture (program finished
+        before a sampling interval): detected by the fixture path not being
+        present in ``profile["files"]``.
+
+    If ``require_memory_stacks`` is set, an otherwise-valid profile whose
+    ``memory_stacks`` is empty is also treated as a failed attempt. Used by
+    tests that assert on the synchronous stack-capture output.
+    """
+    extra = list(extra_args or [])
+    fixture_name = fixture.name
+    last: Optional[subprocess.CompletedProcess] = None
+    for attempt in range(1, attempts + 1):
+        out = tmp_path / f"{fixture.stem}_{attempt}.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "scalene",
+            "run",
+            "--memory",
+            "--no-browser",
+            "-o",
+            str(out),
+            *extra,
+            str(fixture),
+        ]
+        try:
+            last = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if not (out.exists() and out.stat().st_size > 0):
+            continue
+        with open(out) as f:
+            profile = json.load(f)
+        files = profile.get("files", {})
+        if not any(fname.endswith(fixture_name) for fname in files):
+            continue
+        if require_memory_stacks and not profile.get("memory_stacks"):
+            continue
+        return profile
+    pytest.skip(
+        f"Scalene produced no usable profile for {fixture_name} after "
+        f"{attempts} attempts (suspected subprocess startup flake). "
+        f"last returncode={last.returncode if last else 'timeout'}, "
+        f"last stderr={(last.stderr[-400:] if last else '')!r}"
+    )
+
+
+def fixture_lines(profile: dict, fixture_basename: str) -> List[dict]:
+    """Return the per-line records for the file whose path ends in *fixture_basename*.
+
+    ``run_scalene_memory_profile`` only returns profiles where the fixture is
+    present, so the guard here is for misuse (wrong basename) rather than
+    flake.
+    """
+    files = profile.get("files", {})
+    matches = [
+        fdata for fname, fdata in files.items() if fname.endswith(fixture_basename)
+    ]
+    assert matches, (
+        f"Fixture {fixture_basename!r} missing from profile: "
+        f"files={list(files.keys())}"
+    )
+    return matches[0]["lines"]
+
+
+def leaf_line(frames: List[dict]) -> Optional[int]:
+    """Line number of the innermost (leaf) frame in a ``memory_stacks`` entry."""
+    return frames[-1]["line"] if frames else None
+
+
+def leaf_filename(frames: List[dict]) -> Optional[str]:
+    """Filename of the innermost frame."""
+    return frames[-1].get("filename_or_module") if frames else None

--- a/tests/test_memory_multithreaded.py
+++ b/tests/test_memory_multithreaded.py
@@ -1,0 +1,119 @@
+"""End-to-end test: pure-Python multithreaded memory attribution.
+
+Two worker threads run distinct allocator functions under the GIL.
+Per-line byte attribution must:
+
+1. Credit BOTH worker lines (neither thread silently loses samples).
+2. Stay roughly balanced (within 10x — true allocation-size ratio is 4x).
+3. NOT smear onto the main thread's idle ``sleep``/``join`` lines, which
+   is the issue-#857 regression mode in pure-Python form (no GIL
+   release — that is covered separately in
+   ``test_memory_multithreaded_gil_release.py``).
+
+We assert only on ``n_malloc_mb`` (the synchronous byte-attribution
+signal). ``n_mallocs`` is driven by the async handler's ``__last_profiled``
+view of a Python frame and is known unreliable across platforms.
+
+Bumped timeout to 180s (same as ``test_memory_stacks_bigmem.py``) because
+this fixture launches threads and runs ~3s of allocations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from _scalene_subprocess import fixture_lines, run_scalene_memory_profile
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "mt_two_workers.py"
+)
+
+WORKER_A_ALLOC_LINE = 34
+WORKER_B_ALLOC_LINE = 42
+MAIN_SLEEP_LINE = 52
+MAIN_JOIN_LINE = 53
+
+
+def test_both_worker_allocators_credited(tmp_path: Path) -> None:
+    """Both worker allocator lines receive nonzero byte attribution.
+
+    If one thread's samples all land on the other thread's line (or on
+    the main thread's line), the stack-walk path is picking the wrong
+    ``PyThreadState`` when a sample fires.
+    """
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE, timeout=180)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    a = by_lineno.get(WORKER_A_ALLOC_LINE)
+    b = by_lineno.get(WORKER_B_ALLOC_LINE)
+    assert a is not None, (
+        f"Worker A allocator line {WORKER_A_ALLOC_LINE} missing. "
+        f"Lines present: {sorted(by_lineno)}"
+    )
+    assert b is not None, (
+        f"Worker B allocator line {WORKER_B_ALLOC_LINE} missing. "
+        f"Lines present: {sorted(by_lineno)}"
+    )
+    assert a["n_malloc_mb"] > 0.0, (
+        f"Worker A ({WORKER_A_ALLOC_LINE}) got zero bytes: {a!r}"
+    )
+    assert b["n_malloc_mb"] > 0.0, (
+        f"Worker B ({WORKER_B_ALLOC_LINE}) got zero bytes: {b!r}"
+    )
+
+
+def test_workers_balanced_within_10x(tmp_path: Path) -> None:
+    """Neither worker should dominate the other by more than 10x.
+
+    True per-call ratio is 4x (Worker B allocates 4x bigger blocks).
+    10x is intentionally loose: one thread getting *no* samples at all
+    is the regression we want to catch, not a 2x ratio drift.
+    """
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE, timeout=180)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    a_mb = by_lineno[WORKER_A_ALLOC_LINE]["n_malloc_mb"]
+    b_mb = by_lineno[WORKER_B_ALLOC_LINE]["n_malloc_mb"]
+    hi, lo = max(a_mb, b_mb), min(a_mb, b_mb)
+    # Floor the denominator so a near-zero worker trips the assertion
+    # rather than silently passing on a division-by-zero escape hatch.
+    assert hi <= 10.0 * max(lo, 0.1), (
+        f"Workers unbalanced: A={a_mb} MB, B={b_mb} MB. Ratio {hi/max(lo, 1e-9):.1f}x "
+        f"exceeds 10x tolerance. One thread's samples may be getting "
+        f"funneled into the other thread's line."
+    )
+
+
+def test_main_thread_not_charged_with_worker_bytes(tmp_path: Path) -> None:
+    """``time.sleep`` and ``t.join()`` on the main thread must not be
+    charged with worker allocations.
+
+    This is the pure-Python form of issue #857: the main thread is
+    blocked in a C function (sleep/join) holding no allocating frames,
+    so the synchronous stack capture firing from inside a worker must
+    walk the worker's ``PyThreadState``, not the main thread's.
+    """
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE, timeout=180)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    a_mb = by_lineno[WORKER_A_ALLOC_LINE]["n_malloc_mb"]
+    b_mb = by_lineno[WORKER_B_ALLOC_LINE]["n_malloc_mb"]
+    min_worker = min(a_mb, b_mb)
+
+    main_sleep_mb = by_lineno.get(MAIN_SLEEP_LINE, {}).get("n_malloc_mb", 0.0)
+    main_join_mb = by_lineno.get(MAIN_JOIN_LINE, {}).get("n_malloc_mb", 0.0)
+    main_idle_mb = main_sleep_mb + main_join_mb
+
+    assert main_idle_mb <= 0.1 * min_worker, (
+        f"Main-thread idle lines got {main_idle_mb} MB (sleep="
+        f"{main_sleep_mb}, join={main_join_mb}); worker minimum is "
+        f"{min_worker} MB. Worker allocations appear to be smearing "
+        f"onto the main thread's idle frames."
+    )

--- a/tests/test_memory_multithreaded_gil_release.py
+++ b/tests/test_memory_multithreaded_gil_release.py
@@ -1,0 +1,102 @@
+"""End-to-end test: issue #857 regression — GIL-releasing worker allocations.
+
+Fixture ``mt_gil_release_worker.py`` has a worker thread calling
+``np.zeros((1024, 1024))``. OpenBLAS/MKL typically release the GIL
+around large numpy allocations, which historically made the sampled
+bytes land on the *main* thread's idle ``time.sleep`` line (the main
+thread holds the GIL during sleep). The synchronous stack capture in
+``whereInPythonWithStack`` must walk the *allocating* thread's
+``PyThreadState``, not whichever thread happens to hold the GIL.
+
+Skipped if numpy isn't available — the fixture exits early, leaving
+no samples; the subprocess helper skips on missing-fixture profiles.
+
+The ``--stacks``-based variant is additionally skipped on Windows:
+``libscalene.dll`` intercepts allocations via Detours and records
+leaf ``(filename, lineno)`` correctly, but does not implement
+``whereInPythonWithStack``, so ``memory_stacks`` is always empty
+(see ``scalene_profiler.py:839``). The byte-attribution variant
+(``test_worker_alloc_outweighs_main_sleep``) runs on Windows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from _scalene_subprocess import (
+    fixture_lines,
+    leaf_filename,
+    leaf_line,
+    run_scalene_memory_profile,
+)
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "mt_gil_release_worker.py"
+)
+
+WORKER_ALLOC_LINE = 26
+MAIN_SLEEP_LINE = 34
+
+
+def test_worker_alloc_outweighs_main_sleep(tmp_path: Path) -> None:
+    """Worker line must dominate the main-thread idle line by >= 10x.
+
+    Regression this pins: if the stack-walk uses the GIL-holder's
+    frames instead of the allocator's thread, the main thread's
+    ``time.sleep`` line ends up with the worker's bytes.
+    """
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE, timeout=180)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    worker = by_lineno.get(WORKER_ALLOC_LINE)
+    assert worker is not None, (
+        f"Worker line {WORKER_ALLOC_LINE} missing. "
+        f"Lines present: {sorted(by_lineno)}"
+    )
+    worker_mb = worker["n_malloc_mb"]
+    main_mb = by_lineno.get(MAIN_SLEEP_LINE, {}).get("n_malloc_mb", 0.0)
+
+    assert worker_mb > 0.0, (
+        f"Worker line {WORKER_ALLOC_LINE} got zero bytes: {worker!r}"
+    )
+    assert worker_mb >= 10.0 * max(main_mb, 0.1), (
+        f"Worker line {WORKER_ALLOC_LINE} got {worker_mb} MB but main "
+        f"sleep line {MAIN_SLEEP_LINE} got {main_mb} MB. Expected "
+        f"worker >= 10x main. This is the issue-#857 regression: "
+        f"worker-thread allocations leaking onto the main thread's "
+        f"idle frame because the stack walker picked the GIL holder "
+        f"instead of the allocating thread."
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows libscalene.dll doesn't implement whereInPythonWithStack; memory_stacks is always empty (scalene_profiler.py:839)",
+)
+def test_memory_stacks_leaf_is_worker(tmp_path: Path) -> None:
+    """With ``--stacks``, at least one ``memory_stacks`` entry must
+    leaf on the worker's allocator line in the fixture file."""
+    profile = run_scalene_memory_profile(
+        tmp_path, FIXTURE, extra_args=["--stacks"], timeout=180,
+        require_memory_stacks=True,
+    )
+    found = False
+    for frames, _mb in profile["memory_stacks"]:
+        fn = leaf_filename(frames) or ""
+        ln = leaf_line(frames)
+        if fn.endswith(FIXTURE.name) and ln == WORKER_ALLOC_LINE:
+            found = True
+            break
+    assert found, (
+        f"No memory_stacks entry leafed on worker allocator line "
+        f"{WORKER_ALLOC_LINE} of {FIXTURE.name}. Stack capture is "
+        f"picking the wrong thread."
+    )

--- a/tests/test_memory_multithreaded_stacks.py
+++ b/tests/test_memory_multithreaded_stacks.py
@@ -1,0 +1,105 @@
+"""End-to-end test: memory_stacks covers both worker threads.
+
+Runs ``mt_two_workers.py`` with ``--stacks`` and inspects the
+``memory_stacks`` wire output. The synchronous stack capture must walk
+the *allocating* thread's ``PyThreadState`` each time a sample fires,
+so the flame-chart output should contain entries leafing on both
+``worker_a``'s and ``worker_b``'s allocator lines. Every leaf should
+point back to the fixture file — not to threading-internal frames
+leaking through.
+
+Skipped on Windows: the Windows libscalene DLL tracks allocations
+via Detours but does not capture full Python stacks, so
+``memory_stacks`` is always empty (see ``scalene_profiler.py:839``).
+Multithreaded byte attribution on Windows is covered by
+``tests/test_memory_multithreaded.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from _scalene_subprocess import (
+    leaf_filename,
+    leaf_line,
+    run_scalene_memory_profile,
+)
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "mt_two_workers.py"
+)
+
+WORKER_A_ALLOC_LINE = 34
+WORKER_B_ALLOC_LINE = 42
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows libscalene.dll doesn't implement whereInPythonWithStack; memory_stacks is always empty (scalene_profiler.py:839)",
+)
+
+
+def test_memory_stacks_cover_both_workers(tmp_path: Path) -> None:
+    """At least one stack for each worker's allocator line."""
+    profile = run_scalene_memory_profile(
+        tmp_path, FIXTURE, extra_args=["--stacks"], timeout=180,
+        require_memory_stacks=True,
+    )
+    a_seen = False
+    b_seen = False
+    for frames, _mb in profile["memory_stacks"]:
+        fn = leaf_filename(frames) or ""
+        if not fn.endswith(FIXTURE.name):
+            continue
+        line = leaf_line(frames)
+        if line == WORKER_A_ALLOC_LINE:
+            a_seen = True
+        elif line == WORKER_B_ALLOC_LINE:
+            b_seen = True
+    assert a_seen, (
+        f"No memory_stacks entry leafed on Worker A line "
+        f"{WORKER_A_ALLOC_LINE}. Worker A's stack walk may be broken "
+        f"or its samples are being credited to Worker B."
+    )
+    assert b_seen, (
+        f"No memory_stacks entry leafed on Worker B line "
+        f"{WORKER_B_ALLOC_LINE}. Worker B's stack walk may be broken "
+        f"or its samples are being credited to Worker A."
+    )
+
+
+def test_memory_stacks_leaves_are_fixture(tmp_path: Path) -> None:
+    """Every ``memory_stacks`` entry whose leaf has a line number set
+    must leaf inside our fixture. Stacks leafing elsewhere mean the
+    capture is pulling in threading-internal or C-extension frames.
+
+    (Entries with zero bytes or missing line info are skipped.)
+    """
+    profile = run_scalene_memory_profile(
+        tmp_path, FIXTURE, extra_args=["--stacks"], timeout=180,
+        require_memory_stacks=True,
+    )
+    # We require that the majority of leaf bytes land in the fixture.
+    # An absolute "every leaf must be the fixture" is too strict —
+    # background Python bookkeeping can allocate too. The signal we
+    # want is that fixture frames dominate.
+    fixture_mb = 0.0
+    other_mb = 0.0
+    for frames, mb in profile["memory_stacks"]:
+        fn = leaf_filename(frames) or ""
+        if fn.endswith(FIXTURE.name):
+            fixture_mb += float(mb)
+        else:
+            other_mb += float(mb)
+    assert fixture_mb > other_mb, (
+        f"Non-fixture leaves ({other_mb} MB) outweigh fixture leaves "
+        f"({fixture_mb} MB) in memory_stacks. Stack capture is pulling "
+        f"the wrong frames or the fixture isn't running long enough."
+    )

--- a/tests/test_memory_python_vs_c.py
+++ b/tests/test_memory_python_vs_c.py
@@ -1,0 +1,83 @@
+"""End-to-end test: Python-allocator vs C-allocator split.
+
+Asserts that ``n_python_fraction`` reflects which code path Scalene's
+interposer sees the allocation from:
+
+- ``bytes(N)`` → CPython's ``PyBytes_FromSize`` → PyMem domain → counted
+  toward ``_pythonCount`` in ``src/include/sampleheap.hpp``.
+- ``np.zeros(...)`` → numpy allocator → libc ``malloc`` → counted
+  toward ``_cCount``.
+
+Margins are loose (0.7 / 0.3) because sampling noise and the fractional
+accounting both contribute variance. Tight bounds would be flaky.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _scalene_subprocess import fixture_lines, run_scalene_memory_profile
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "st_python_vs_c.py"
+)
+
+PYTHON_LINE = 34  # `return bytes(2 * 10_485_767)` in python_alloc
+C_LINE = 38       # `return np.zeros(2_000_000, dtype=np.float64)` in c_alloc
+
+
+def _profile_or_skip(tmp_path: Path) -> dict:
+    """Profile the fixture, skipping if numpy is missing (fixture exits
+    early, leaving no samples for this file)."""
+    try:
+        return run_scalene_memory_profile(tmp_path, FIXTURE)
+    except pytest.skip.Exception:
+        raise  # propagate the helper's own skip
+    # Unreachable but makes the control flow explicit.
+
+
+def test_python_line_is_python_dominated(tmp_path: Path) -> None:
+    profile = _profile_or_skip(tmp_path)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    py = by_lineno.get(PYTHON_LINE)
+    assert py is not None, (
+        f"Python-allocator line {PYTHON_LINE} missing. "
+        f"Lines present: {sorted(by_lineno)}"
+    )
+    assert py["n_malloc_mb"] > 0.0, (
+        f"Python-allocator line {PYTHON_LINE} got zero bytes: {py!r}"
+    )
+    assert py["n_python_fraction"] >= 0.7, (
+        f"Python-allocator line {PYTHON_LINE} has n_python_fraction="
+        f"{py['n_python_fraction']}, expected >= 0.7. The interposer "
+        f"should count bytes() as a Python allocation."
+    )
+
+
+def test_c_line_is_c_dominated(tmp_path: Path) -> None:
+    profile = _profile_or_skip(tmp_path)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    c = by_lineno.get(C_LINE)
+    assert c is not None, (
+        f"C-allocator line {C_LINE} missing. "
+        f"Lines present: {sorted(by_lineno)}"
+    )
+    assert c["n_malloc_mb"] > 0.0, (
+        f"C-allocator line {C_LINE} got zero bytes: {c!r}"
+    )
+    assert c["n_python_fraction"] <= 0.3, (
+        f"C-allocator line {C_LINE} has n_python_fraction="
+        f"{c['n_python_fraction']}, expected <= 0.3. numpy's allocator "
+        f"goes through libc malloc, not PyMem, so this line should be "
+        f"dominated by C-allocator samples."
+    )

--- a/tests/test_memory_stack_leaf_singlethread.py
+++ b/tests/test_memory_stack_leaf_singlethread.py
@@ -1,0 +1,89 @@
+"""End-to-end test: memory_stacks leaves match the allocator lines (single-threaded).
+
+Runs ``st_two_allocators.py`` with ``--stacks`` and inspects the
+``memory_stacks`` wire output (``List[[frames, mb]]`` — see
+``scalene/scalene_json.py:376``). The *synchronous* stack capture in
+``whereInPythonWithStack`` (``src/source/pywhere.cpp:279-298``) writes
+the leaf frame while still inside the allocator function, so the
+dominant stack entry grouped by leaf line must land on the allocator
+whose bytes it represents.
+
+Skipped on Windows: the Windows build of libscalene is loaded via
+Detours + DLL injection (``src/source/libscalene_windows.cpp``) and
+supports byte attribution, but does not implement
+``whereInPythonWithStack`` — only the leaf frame is captured. As a
+result ``scalene_profiler.py:839`` gates ``install_native_stack_unwinder``
+on ``sys.platform != "win32"`` and ``memory_stacks`` is always empty
+on Windows. Same gate rationale as ``tests/test_line_attribution_nested.py:168-171``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from _scalene_subprocess import leaf_line, run_scalene_memory_profile
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "st_two_allocators.py"
+)
+
+SMALL_LINE = 28
+BIG_LINE = 32
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows libscalene.dll doesn't implement whereInPythonWithStack; memory_stacks is always empty (scalene_profiler.py:839)",
+)
+
+
+def _totals_by_leaf(memory_stacks: List) -> Dict[int, float]:
+    """Group memory_stacks entries by leaf line number, summing MB."""
+    totals: Dict[int, float] = {}
+    for frames, mb in memory_stacks:
+        line = leaf_line(frames)
+        if line is None:
+            continue
+        totals[line] = totals.get(line, 0.0) + float(mb)
+    return totals
+
+
+def test_both_allocator_leaves_present(tmp_path: Path) -> None:
+    """Every ``memory_stacks`` leaf for our fixture should land on one
+    of the two allocator lines — nothing should leaf on the loop body
+    in ``run()``."""
+    profile = run_scalene_memory_profile(
+        tmp_path, FIXTURE, extra_args=["--stacks"], require_memory_stacks=True
+    )
+    totals = _totals_by_leaf(profile["memory_stacks"])
+    assert totals.get(SMALL_LINE, 0.0) > 0.0, (
+        f"No memory_stacks entry leafed on small allocator line "
+        f"{SMALL_LINE}. Leaf totals: {totals}"
+    )
+    assert totals.get(BIG_LINE, 0.0) > 0.0, (
+        f"No memory_stacks entry leafed on big allocator line "
+        f"{BIG_LINE}. Leaf totals: {totals}"
+    )
+
+
+def test_big_leaf_outweighs_small_leaf(tmp_path: Path) -> None:
+    """The 4x allocation-size ratio should show up in the stacks view
+    (asserted loosely at 1.5x)."""
+    profile = run_scalene_memory_profile(
+        tmp_path, FIXTURE, extra_args=["--stacks"], require_memory_stacks=True
+    )
+    totals = _totals_by_leaf(profile["memory_stacks"])
+    small = totals.get(SMALL_LINE, 0.0)
+    big = totals.get(BIG_LINE, 0.0)
+    assert big >= 1.5 * small, (
+        f"BIG leaf total ({big} MB) should exceed SMALL leaf total "
+        f"({small} MB). Leaf totals: {totals}"
+    )

--- a/tests/test_memory_two_allocators.py
+++ b/tests/test_memory_two_allocators.py
@@ -1,0 +1,92 @@
+"""End-to-end test: two allocator functions with different byte sizes.
+
+Asserts proportional per-line byte attribution. The synchronous
+``whereInPythonWithStack`` capture in the C++ interposer stamps each
+sample's ``(filename, lineno)`` before the async signal fires, so
+``n_malloc_mb`` on each allocator line should track the allocator's
+true per-call size regardless of signal-handler timing.
+
+We assert on ``n_malloc_mb`` only — never ``n_mallocs``, which is
+driven by the async handler's (potentially stale) view of
+``__last_profiled`` and is known unreliable across platforms (see the
+FIXME at ``src/source/pywhere.cpp:911-912``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from _scalene_subprocess import fixture_lines, run_scalene_memory_profile
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "st_two_allocators.py"
+)
+
+SMALL_LINE = 28  # `return array.array("d", [0]) * 150_000` in small_alloc
+BIG_LINE = 32    # `return array.array("d", [0]) * 600_000` in big_alloc
+
+
+def test_both_allocators_have_nonzero_bytes(tmp_path: Path) -> None:
+    """Neither allocator line may come back with zero byte attribution."""
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    small = by_lineno.get(SMALL_LINE)
+    big = by_lineno.get(BIG_LINE)
+    assert small is not None, (
+        f"Small allocator line {SMALL_LINE} missing. Lines present: {sorted(by_lineno)}"
+    )
+    assert big is not None, (
+        f"Big allocator line {BIG_LINE} missing. Lines present: {sorted(by_lineno)}"
+    )
+    assert small["n_malloc_mb"] > 0.0, (
+        f"Small allocator line {SMALL_LINE} got zero bytes: {small!r}"
+    )
+    assert big["n_malloc_mb"] > 0.0, (
+        f"Big allocator line {BIG_LINE} got zero bytes: {big!r}"
+    )
+
+
+def test_big_dominates_small(tmp_path: Path) -> None:
+    """BIG_LINE allocates ~4x more per call than SMALL_LINE. Assert at
+    least 2x, loose enough to absorb sampling noise on a 1 MB window.
+    """
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+
+    small_mb = by_lineno[SMALL_LINE]["n_malloc_mb"]
+    big_mb = by_lineno[BIG_LINE]["n_malloc_mb"]
+    assert big_mb >= 2.0 * small_mb, (
+        f"BIG line {BIG_LINE} got {big_mb} MB; SMALL line {SMALL_LINE} "
+        f"got {small_mb} MB. Expected BIG >= 2 * SMALL (true ratio ~4x)."
+    )
+
+
+def test_no_other_line_outweighs_big(tmp_path: Path) -> None:
+    """Nothing in the fixture should outweigh the biggest allocator.
+
+    If some caller line (the loop body, ``run()``) ends up with more
+    bytes than ``big_alloc()``, the synchronous stamp is leaking into
+    the caller frame — the regression mode this whole family guards
+    against.
+    """
+    profile = run_scalene_memory_profile(tmp_path, FIXTURE)
+    lines = fixture_lines(profile, FIXTURE.name)
+    by_lineno = {ln["lineno"]: ln for ln in lines}
+    big_mb = by_lineno[BIG_LINE]["n_malloc_mb"]
+
+    for ln in lines:
+        if ln["lineno"] == BIG_LINE:
+            continue
+        other = ln["n_malloc_mb"]
+        assert other <= big_mb, (
+            f"Line {ln['lineno']} got {other} MB — more than the BIG "
+            f"allocator's {big_mb} MB on line {BIG_LINE}. Attribution "
+            f"has smeared onto a non-allocator line."
+        )


### PR DESCRIPTION
## Summary

- **14 new asserting tests** across 6 files covering memory allocation attribution, split into single-threaded byte proportionality, Python-vs-C allocator fraction, and multithreaded per-thread attribution.
- **4 new fixtures** in `test/line_attribution_tests/` — pure-Python and numpy-based workloads sized to reliably clear the 1 MB sampling window and run for >= 2s wall time.
- **Shared subprocess helper** (`tests/_scalene_subprocess.py`) factored out of the `_run_scalene` duplication between `tests/test_line_attribution_nested.py` and `tests/test_memory_stacks_bigmem.py`. New tests use it; the two existing files keep their local copies for now to keep this diff focused.

### Coverage added

| Test file | What it pins |
|---|---|
| `test_memory_two_allocators.py` | Two sibling allocators, 4x byte ratio; no caller smearing. |
| `test_memory_python_vs_c.py` | `n_python_fraction` split: `bytes()` >= 0.7 Python, numpy allocations <= 0.3 Python. |
| `test_memory_stack_leaf_singlethread.py` | `--stacks` leaves land on both allocator lines. |
| `test_memory_multithreaded.py` | Two worker threads each credited; main-thread `sleep`/`join` not charged with worker bytes. |
| `test_memory_multithreaded_gil_release.py` | **Issue #857 regression guard**: numpy worker under released GIL must not smear onto main-thread `time.sleep`. Now also serves as an acceptance test for the smear-suppression fix in #1051 — the `time.sleep` line cannot allocate (no CALL on a `sleep` call site for a no-op idle wait — `time.sleep` is at the syscall boundary, and the smear bytes get dropped from per-line attribution rather than landing on the wait line). |
| `test_memory_multithreaded_stacks.py` | `memory_stacks` covers both worker threads' call chains. |

### Design notes

- Only asserts on `n_malloc_mb`, `n_python_fraction`, and `memory_stacks`. Never `n_mallocs` — documented unreliable via the FIXME in `src/source/pywhere.cpp:911-912` and the note at `src/source/pywhere.cpp:282-298`.
- Windows skip on `--stacks`-dependent tests (3 of 6 files). Rationale: Windows `libscalene.dll` supports byte attribution via Detours but doesn't implement `whereInPythonWithStack`, so `memory_stacks` is always empty (`scalene_profiler.py:839`). The non-stack tests run on Windows unchanged.
- Every fixture uses the proven `spin_a_bit()` idiom from `nested_allocator.py` so Scalene reliably takes samples on slow runners.
- Helper handles the two documented flake modes (startup hang, empty profile) with 3 retries then `pytest.skip`. 180s timeout on multithreaded tests (matches `test_memory_stacks_bigmem.py`).

### Rebased onto current master

Branch rebased onto master (which has since received #1050 / #1051 / #1052). Clean — every commit on this branch is purely additive (11 new files, no modifications to existing files), so rebase fast-forwarded with no conflicts.

Verified locally after the rebase:
- **14/14 new tests pass** (~83s).
- **24/24 pass when run together with the pre-existing memory-attribution suite** (`test_line_attribution_nested.py`, `test_memory_stacks_bigmem.py`) and the new `test_memory_arithmetic_smear.py` from #1051 — ~2m total. No interaction with the smear-suppression change.

## Test plan

- [x] `python3 -m pytest tests/test_memory_two_allocators.py tests/test_memory_python_vs_c.py tests/test_memory_stack_leaf_singlethread.py tests/test_memory_multithreaded.py tests/test_memory_multithreaded_gil_release.py tests/test_memory_multithreaded_stacks.py -v` — 14/14 pass on macOS arm64 / Python 3.14 after rebase onto master.
- [x] Full memory-attribution suite (new + existing + arithmetic-smear from #1051) — 24/24 pass in ~2m.
- [x] Each fixture runs standalone (`python3 test/line_attribution_tests/<name>.py`).
- [ ] Cross-version loop (`for v in 3.9 3.10 3.11 3.12 3.13 3.14`) — local verification only.
- [ ] Linux CI — relies on GitHub Actions matrix (ubuntu-latest × Python 3.9–3.14 + free-threaded 3.13t/3.14t).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
