### PR TITLE
Drop C-side smear from per-line memory attribution and the flame view

### DIFF
--- a/scalene/scalene_memory_profiler.py
+++ b/scalene/scalene_memory_profiler.py
@@ -24,7 +24,10 @@ from scalene.scalene_statistics import (
     ScaleneStatistics,
     StackFrame,
 )
-from scalene.scalene_utility import intern_stack_frame
+from scalene.scalene_utility import (
+    intern_stack_frame,
+    line_has_alloc_opcode,
+)
 
 
 class ScaleneMemoryProfiler:
@@ -267,9 +270,46 @@ class ScaleneMemoryProfiler:
             fname = item.filename
             lineno = item.lineno
 
+            # Smear suppression. The C++ interposer stamps every sample
+            # with the leaf user frame from ``whereInPython``, but
+            # CPython internals (arena resizes, GC, scalene's own
+            # bookkeeping under the GIL) emit raw mallocs whose bytes
+            # land on whichever leaf line the eval loop happens to be
+            # on. If that line's bytecode cannot have caused the alloc
+            # (no CALL / BUILD_ / LIST_ / … opcode — see
+            # ``line_has_alloc_opcode``), the sample is "smear".
+            #
+            # Earlier versions redirected smear up the captured stack
+            # to the nearest alloc-capable caller. That puts the bytes
+            # on whatever call site is currently active, which is
+            # misleading: e.g. ``x = doit2(x)`` is a CALL but doit2
+            # never allocates — the bytes really come from heap state
+            # set up by doit1 in a prior frame that's no longer on the
+            # stack. For the same reason, the captured stack itself
+            # isn't trustworthy here: it records which user frames
+            # were active at the moment of the malloc, none of which
+            # caused it. So we drop the sample from every per-line
+            # accumulator *and* from ``memory_stacks``. The bytes are
+            # still counted in the global running footprint (so the
+            # global peak / sparkline are accurate), but no line,
+            # function, or flame-chart path takes the blame.
+            leaf_can_alloc = line_has_alloc_opcode(fname, lineno)
+
+            count = item.count / self.BYTES_PER_MB
+            if not leaf_can_alloc:
+                # Keep the running per-item ``curr`` accurate so the
+                # next legitimate sparkline sample reflects the right
+                # footprint. Everything else (memory_stacks, per-line
+                # accumulators, allocs / last_malloc tracking) skips
+                # this sample.
+                if is_malloc:
+                    curr += count
+                else:
+                    curr -= count
+                continue
+
             # Add the byte index to the set for this line (if it's not there already).
             stats.bytei_map[fname][lineno].add(item.bytecode_index)
-            count = item.count / self.BYTES_PER_MB
             if is_malloc:
                 # Attribute the sampled bytes to the Python call stack
                 # captured *synchronously* in C++ inside process_malloc

--- a/scalene/scalene_utility.py
+++ b/scalene/scalene_utility.py
@@ -10,7 +10,7 @@ import sysconfig
 import tempfile
 import threading
 import webbrowser
-from types import BuiltinFunctionType, FrameType, FunctionType, ModuleType
+from types import BuiltinFunctionType, CodeType, FrameType, FunctionType, ModuleType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from scalene.scalene_config import scalene_date, scalene_version
@@ -996,3 +996,138 @@ def patch_module_functions_with_signal_blocking(
         if isinstance(attr, (BuiltinFunctionType, FunctionType)):
             wrapped_attr = signal_blocking_wrapper(attr)
             setattr(module, attr_name, wrapped_attr)
+
+
+# --------------------------------------------------------------------------- #
+#  Allocator-opcode detection (used by the smear-suppression path in
+#  scalene_memory_profiler.process_malloc_free_samples)
+# --------------------------------------------------------------------------- #
+#
+# The C++ heap interposer stamps every malloc / free sample with the leaf
+# Python frame from ``PyFrame_GetLineNumber``. When that leaf line's
+# bytecode cannot possibly have caused the allocation (e.g. ``z = z * z``
+# on two floats — only LOAD_FAST / BINARY_OP / STORE_FAST), but raw
+# ``malloc`` *does* fire under the GIL during that line (arena resizes,
+# GC, scalene's own bookkeeping, …), the bytes get smeared onto whichever
+# arithmetic line the eval loop happened to be on. ``line_has_alloc_opcode``
+# is the predicate the memory profiler uses to detect those samples; when
+# it returns False for the leaf the profiler drops the sample from every
+# per-line accumulator (the bytes still flow into the global footprint and
+# into ``memory_stacks``, so the flame view is unaffected).
+
+# Opcode-name prefixes that mark a line as potentially-allocating. CPython
+# guarantees these prefixes are stable across releases (the individual
+# opcodes inside them shift between versions — e.g. CALL_FUNCTION_EX,
+# CALL_KW, CALL_INTRINSIC_1 — but the CLAUDE.md guidance approves
+# ``.startswith("CALL")`` and the same shape applies to the others).
+_ALLOC_OPCODE_PREFIXES: Tuple[str, ...] = (
+    "CALL",        # CALL, CALL_KW, CALL_FUNCTION_EX, CALL_INTRINSIC_*, …
+    "BUILD_",      # BUILD_LIST / TUPLE / SET / MAP / STRING / SLICE / …
+    "LIST_",       # LIST_APPEND, LIST_EXTEND, LIST_TO_TUPLE
+    "SET_",        # SET_ADD, SET_UPDATE
+    "MAP_",        # MAP_ADD
+    "DICT_",       # DICT_UPDATE, DICT_MERGE
+    "IMPORT_",     # IMPORT_NAME / FROM / STAR
+    "MAKE_",       # MAKE_FUNCTION, MAKE_CELL
+    "FORMAT_",     # FORMAT_VALUE, FORMAT_SIMPLE, FORMAT_WITH_SPEC
+)
+
+# Exact opcode names that also count as allocation-capable. Includes
+# container iteration (which may call user ``__iter__`` / ``__next__``),
+# subscript / attr access (which may call ``__getitem__`` / ``__getattr__``
+# / etc.), and various async / exception / class-build entry points.
+# Keeping this list reasonably broad addresses the list-comprehension and
+# container-op case explicitly: a list comp without an inline range() call
+# still has BUILD_LIST, GET_ITER, FOR_ITER, and LIST_APPEND on its line.
+_ALLOC_OPCODE_EXACT: frozenset[str] = frozenset(
+    {
+        "GET_ITER",
+        "GET_YIELD_FROM_ITER",
+        "FOR_ITER",
+        "GET_AWAITABLE",
+        "GET_AITER",
+        "GET_ANEXT",
+        "SEND",
+        "YIELD_VALUE",
+        "YIELD_FROM",
+        "BINARY_SUBSCR",
+        "STORE_SUBSCR",
+        "DELETE_SUBSCR",
+        "LOAD_ATTR",
+        "STORE_ATTR",
+        "DELETE_ATTR",
+        "LOAD_BUILD_CLASS",
+        "RAISE_VARARGS",
+        "RERAISE",
+        "BEFORE_WITH",
+        "BEFORE_ASYNC_WITH",
+        "WITH_EXCEPT_START",
+        "CONVERT_VALUE",
+    }
+)
+
+# Per-file cache: filename → set of source lines containing at least one
+# allocation-capable opcode. ``None`` means the source could not be read or
+# compiled — in that case we trust the leaf attribution (don't redirect).
+_file_alloc_lines_cache: Dict[str, Optional[set[int]]] = {}
+
+
+def _is_alloc_opname(opname: str) -> bool:
+    if opname in _ALLOC_OPCODE_EXACT:
+        return True
+    return any(opname.startswith(prefix) for prefix in _ALLOC_OPCODE_PREFIXES)
+
+
+def _collect_alloc_lines(code: CodeType, out: set[int]) -> None:
+    """Walk a code object (and nested code consts) and record every
+    source line that carries at least one allocation-capable opcode."""
+    import dis  # local import: only used at serialization time
+
+    last_line: Optional[int] = None
+    for instr in dis.get_instructions(code):
+        # Python 3.13+ exposes ``Instruction.line_number`` (int|None on
+        # every instr). Older Pythons only set ``starts_line`` on the
+        # first instr per source line; propagate it forward manually.
+        ln = getattr(instr, "line_number", None)
+        if ln is None:
+            sl = getattr(instr, "starts_line", None)
+            if isinstance(sl, int):
+                last_line = sl
+        else:
+            last_line = ln
+        if last_line is not None and _is_alloc_opname(instr.opname):
+            out.add(last_line)
+    for const in getattr(code, "co_consts", ()):
+        if hasattr(const, "co_code"):
+            _collect_alloc_lines(const, out)
+
+
+def line_has_alloc_opcode(filename: str, lineno: int) -> bool:
+    """Return True if ``filename:lineno`` carries an allocation-capable
+    opcode. Sources that cannot be compiled are treated as "yes" so we
+    leave their attribution alone."""
+    if not filename or lineno <= 0:
+        return False
+    sentinel = _file_alloc_lines_cache
+    cached = _file_alloc_lines_cache.get(filename, sentinel)
+    if cached is sentinel:
+        import linecache  # local: only used at serialization time
+
+        alloc_lines: Optional[set[int]] = set()
+        try:
+            src = linecache.getlines(filename)
+            if src:
+                code = compile("".join(src), filename, "exec")
+                assert alloc_lines is not None
+                _collect_alloc_lines(code, alloc_lines)
+            else:
+                alloc_lines = None
+        except (SyntaxError, ValueError, TypeError, OSError):
+            alloc_lines = None
+        _file_alloc_lines_cache[filename] = alloc_lines
+        cached = alloc_lines
+    if cached is None:
+        return True
+    return lineno in cached
+
+

--- a/test/line_attribution_tests/arithmetic_smear.py
+++ b/test/line_attribution_tests/arithmetic_smear.py
@@ -1,0 +1,62 @@
+"""Regression fixture: pure-arithmetic hot loops must not be credited
+with C-side allocation traffic from CPython internals.
+
+The workload alternates two phases per outer iteration:
+
+  * ``do_allocs`` runs three list comprehensions of increasing size.
+    Those lines (15, 16, 17) genuinely allocate via Python bytecode
+    that has CALL (``range``) and ``BUILD_LIST`` / ``LIST_APPEND``
+    on it. They are the legitimate attribution target for bytes.
+
+  * ``hot_arith`` runs a tight ``while`` loop whose body is only
+    ``LOAD_FAST`` / ``BINARY_OP`` / ``STORE_FAST`` — no CALL, no
+    container-building opcode, no way to invoke a C-side allocator
+    from user code. Yet during this loop CPython internals (arena
+    resizes, GC, scalene's own bookkeeping under the GIL) emit raw
+    ``malloc`` calls. Pre-fix, those bytes were credited to whichever
+    arithmetic line the eval loop happened to be on — hundreds of MB
+    of phantom traffic on ``z = z * z``.
+
+Sized so Scalene reliably samples it: ``do_allocs`` retains a few
+hundred MB of transient buffer activity per outer iteration, and the
+outer loop runs long enough that the malloc sampler fires many times.
+"""
+
+
+def do_allocs():
+    """Real allocator work — list comprehensions on lines 15-17 have
+    CALL (``range``) and BUILD_LIST opcodes, so they are eligible
+    targets for byte attribution."""
+    a = [i * i for i in range(0, 100_000)][99_999]   # line 15
+    b = [i * i for i in range(0, 200_000)][199_999]  # line 16
+    c = [i for i in range(0, 300_000)][299_999]      # line 17
+    return a + b + c
+
+
+def hot_arith(x):
+    """Pure float arithmetic — no CALL, no BUILD_*, no allocator
+    opcode on lines 24-27. Any byte attribution that lands on these
+    lines is smear from CPython internals running under the GIL."""
+    z = 0.1
+    i = 0
+    while i < 100_000:
+        z = z * z       # line 24
+        z = x * x       # line 25
+        z = z * z       # line 26
+        z = z * z       # line 27
+        i += 1          # line 28
+    return z
+
+
+def run():
+    x = 1.01
+    for _ in range(9):
+        for _ in range(9):
+            do_allocs()       # line 36 — legitimate alloc caller
+            hot_arith(x)      # line 37 — smear target (caller of the
+                              # pure-arith loop; redirected smear lands here)
+    return x
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_memory_arithmetic_smear.py
+++ b/tests/test_memory_arithmetic_smear.py
@@ -1,0 +1,285 @@
+"""Regression tests: pure-arithmetic hot-loop lines must not receive
+phantom C-side memory traffic.
+
+The C++ heap interposer stamps every malloc sample with the leaf
+Python frame from ``whereInPython``. When the leaf is a pure-arithmetic
+line (``z = z * z``) and the underlying bytes are pure C-side (system
+``malloc``, ``python_fraction ≈ 0``) — typically from CPython arena
+resizes / GC / scalene's own bookkeeping under the GIL — those bytes
+get smeared onto whatever arithmetic line the eval loop happens to be
+on. The smear correction in ``scalene_memory_profiler.py`` reattributes
+such samples up the captured Python stack to the nearest frame whose
+line has a CALL-class opcode.
+
+These tests pin two behaviors:
+
+  1. Pure-arithmetic lines do not accumulate ``n_malloc_mb`` traffic
+     comparable to the legitimate allocator lines.
+  2. The synchronously-captured ``memory_stacks`` (``--stacks`` is the
+     default) still contains the legitimate allocator stack paths —
+     the per-line redistribution must not perturb that data.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "test"
+    / "line_attribution_tests"
+    / "arithmetic_smear.py"
+)
+
+# Line numbers in ``arithmetic_smear.py``. Keep these in sync if the
+# fixture is edited (the assertions below depend on exact lines).
+ALLOC_LINES = (30, 31, 32)             # list comps inside do_allocs
+ARITH_LINES = (43, 44, 45, 46)         # body of hot_arith — pure float ops
+HOT_ARITH_CALL_SITE = 56               # ``hot_arith(x)`` inside run
+
+_SCALENE_TIMEOUT = 180
+_SCALENE_ATTEMPTS = 3
+
+
+def _run_scalene(tmp_path: Path) -> dict:
+    """Run Scalene against the fixture with memory + stacks. Same retry
+    pattern as ``test_line_attribution_nested.py``: scalene's subprocess
+    startup can wedge under CI contention, and short fixtures sometimes
+    finish before the first sampling interval. Skip if all attempts
+    come back empty."""
+    last: subprocess.CompletedProcess | None = None
+    for attempt in range(1, _SCALENE_ATTEMPTS + 1):
+        out = tmp_path / f"arith_smear_{attempt}.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "scalene",
+            "run",
+            "--memory",
+            "--stacks",
+            "--no-browser",
+            "-o",
+            str(out),
+            str(FIXTURE),
+        ]
+        try:
+            last = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_SCALENE_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if out.exists() and out.stat().st_size > 0:
+            with open(out) as f:
+                profile = json.load(f)
+            files = profile.get("files", {})
+            if any(fname.endswith("arithmetic_smear.py") for fname in files):
+                return profile
+    pytest.skip(
+        f"Scalene produced no usable profile after {_SCALENE_ATTEMPTS} "
+        f"attempts. last returncode="
+        f"{last.returncode if last else 'timeout'}, "
+        f"last stderr={(last.stderr[-400:] if last else '')!r}"
+    )
+
+
+def _fixture_lines(profile: dict) -> list[dict]:
+    files = profile.get("files", {})
+    matches = [
+        f for fname, f in files.items() if fname.endswith("arithmetic_smear.py")
+    ]
+    assert matches, f"Fixture missing from profile: files={list(files.keys())}"
+    return matches[0]["lines"]
+
+
+def _by_lineno(profile: dict) -> dict[int, dict]:
+    return {ln["lineno"]: ln for ln in _fixture_lines(profile)}
+
+
+def test_arithmetic_lines_have_minimal_malloc_traffic(tmp_path: Path) -> None:
+    """The pure-arithmetic body of ``hot_arith`` must not collect
+    significant per-line malloc traffic.
+
+    Pre-fix, ``z = z * z`` could accumulate hundreds of MB on a single
+    line (the eval loop happens to be on whichever arithmetic line
+    when CPython internals fire a raw malloc). Post-fix the smear is
+    redirected up the captured stack, and the arithmetic lines stay
+    well below the legitimate allocator lines."""
+    profile = _run_scalene(tmp_path)
+    by_ln = _by_lineno(profile)
+
+    alloc_total = sum(by_ln.get(ln, {}).get("n_malloc_mb", 0.0) for ln in ALLOC_LINES)
+    if alloc_total < 50.0:
+        pytest.skip(
+            f"Fixture allocator lines saw only {alloc_total:.1f} MB total — "
+            f"the run was too short for sampling, can't draw conclusions."
+        )
+
+    # Each arithmetic line must be far below the allocator-line total.
+    # Pre-fix on the equivalent testme.py workload, line 24 sat at ~40%
+    # of the file total; the bound here (5%) is well above any residual
+    # legitimate pymalloc activity but well below the smear regression.
+    cap = 0.05 * alloc_total
+    offenders = {
+        ln: by_ln.get(ln, {}).get("n_malloc_mb", 0.0)
+        for ln in ARITH_LINES
+        if by_ln.get(ln, {}).get("n_malloc_mb", 0.0) > cap
+    }
+    assert not offenders, (
+        f"Arithmetic lines collected phantom malloc traffic exceeding "
+        f"{cap:.1f} MB (5% of {alloc_total:.1f} MB allocator total): "
+        f"{offenders}. Smear-correction in process_malloc_free_samples "
+        f"may have regressed."
+    )
+
+
+def test_allocator_lines_still_dominate(tmp_path: Path) -> None:
+    """The list-comprehension lines inside ``do_allocs`` must keep
+    getting the bulk of byte attribution — the smear fix must not
+    over-redirect and steal credit from legitimate allocator lines
+    (which carry CALL / BUILD_LIST opcodes)."""
+    profile = _run_scalene(tmp_path)
+    by_ln = _by_lineno(profile)
+
+    alloc_mb = sum(by_ln.get(ln, {}).get("n_malloc_mb", 0.0) for ln in ALLOC_LINES)
+    arith_mb = sum(by_ln.get(ln, {}).get("n_malloc_mb", 0.0) for ln in ARITH_LINES)
+
+    if alloc_mb == 0:
+        pytest.skip("No allocator-line samples this run; can't compare.")
+
+    # Allocator total should dominate arithmetic total by at least 5x.
+    # On a quiet run arith_mb can be 0, in which case any positive
+    # alloc_mb passes; we just want to guard against a regression that
+    # accidentally redistributes legitimate credit upstream.
+    assert alloc_mb > max(arith_mb * 5, 50.0), (
+        f"Allocator lines ({alloc_mb:.1f} MB across {ALLOC_LINES}) should "
+        f"dominate over arithmetic lines ({arith_mb:.1f} MB across "
+        f"{ARITH_LINES}) by more than 5x and clear 50 MB outright. If the "
+        f"ratio is small, the smear correction is either letting through "
+        f"too many spurious arithmetic-line credits or the allocator "
+        f"lines have lost their attribution."
+    )
+
+
+def test_function_rollup_does_not_smear_onto_arith_function(tmp_path: Path) -> None:
+    """The per-function rollup (the table the GUI shows above the
+    per-line view) must not credit ``hot_arith`` with allocator traffic.
+
+    ``hot_arith`` is pure float arithmetic — no CALL, no BUILD_*, no
+    container/iter opcode anywhere in its body. With the inline smear
+    redirect applied in ``process_malloc_free_samples``, every per-line
+    memory accumulator inside ``hot_arith`` stays at zero, so the
+    function-level sum (which is what the GUI's function-profile table
+    renders) is also zero.
+
+    Pre-fix this would show ``hot_arith`` with hundreds of MB of peak
+    memory and a sizable usage-fraction pie wedge, matching the visible
+    smear on ``doit2`` in the user's original screenshot of testme.py."""
+    profile = _run_scalene(tmp_path)
+    files = profile.get("files", {})
+    matches = [
+        f for fname, f in files.items() if fname.endswith("arithmetic_smear.py")
+    ]
+    assert matches, f"Fixture missing from profile: files={list(files.keys())}"
+    fdata = matches[0]
+
+    functions = fdata.get("functions", [])
+    by_name: dict[str, dict] = {fn.get("line", "").strip(): fn for fn in functions}
+
+    if "hot_arith" not in by_name:
+        pytest.skip(
+            "hot_arith function not present in profile (likely no samples "
+            "landed inside it this run)."
+        )
+
+    hot_arith = by_name["hot_arith"]
+    do_allocs = by_name.get("do_allocs", {})
+
+    do_allocs_mb = do_allocs.get("n_malloc_mb", 0.0)
+    if do_allocs_mb < 50.0:
+        pytest.skip(
+            f"do_allocs function only saw {do_allocs_mb:.1f} MB — the run "
+            f"was too short for sampling to mean anything."
+        )
+
+    hot_arith_mb = hot_arith.get("n_malloc_mb", 0.0)
+    hot_arith_peak = hot_arith.get("n_peak_mb", 0.0)
+    hot_arith_usage = hot_arith.get("n_usage_fraction", 0.0)
+
+    # The pure-arithmetic function should be effectively zero across
+    # all three memory columns. Generous bounds to tolerate any single
+    # legitimate pymalloc sample that happens to land here.
+    assert hot_arith_mb < 5.0, (
+        f"Function ``hot_arith`` accumulated {hot_arith_mb:.1f} MB of "
+        f"malloc traffic — pure float arithmetic shouldn't allocate. "
+        f"Inline smear redirect in process_malloc_free_samples may have "
+        f"regressed."
+    )
+    assert hot_arith_peak < 50.0, (
+        f"Function ``hot_arith`` peak memory is {hot_arith_peak:.1f} MB. "
+        f"Pre-fix this column was the most visible smear artifact "
+        f"(testme.py showed 810 MB on doit2). Inline redirect must "
+        f"also correct memory_max_footprint, not just memory_malloc_samples."
+    )
+    assert hot_arith_usage < 0.05, (
+        f"Function ``hot_arith`` usage fraction is {hot_arith_usage:.3f} "
+        f"(should be ~0). The memory-activity pie wedge in the GUI "
+        f"is computed from this; a non-zero value means smear is still "
+        f"reaching the function-level rollup."
+    )
+
+
+def test_memory_stacks_preserve_full_paths(tmp_path: Path) -> None:
+    """The ``--stacks`` memory-flame data must record legitimate full
+    Python call paths down to allocator leaves — and *only* those.
+    Smear samples must be dropped from ``memory_stacks`` too, not just
+    from the per-line accumulators: otherwise the flame chart credits
+    bytes along whichever call chain happened to be active when the
+    eval loop was on an arithmetic line, putting hot non-allocators
+    like ``hot_arith`` on the flame view even though no allocation
+    came from anything they did."""
+    profile = _run_scalene(tmp_path)
+    memory_stacks = profile.get("memory_stacks", [])
+    if not memory_stacks:
+        pytest.skip(
+            "No memory_stacks recorded — sync stack capture unavailable "
+            "on this platform / libscalene build."
+        )
+
+    fixture_tail = "arithmetic_smear.py"
+    seen_alloc_leaf = False
+    smear_leaves: list[tuple[int, float]] = []
+    for frames, mb in memory_stacks:
+        if not frames:
+            continue
+        leaf = frames[-1]
+        if not leaf.get("filename_or_module", "").endswith(fixture_tail):
+            continue
+        leaf_line = leaf.get("line")
+        if leaf_line in ALLOC_LINES:
+            seen_alloc_leaf = True
+        elif leaf_line in ARITH_LINES:
+            smear_leaves.append((leaf_line, mb))
+
+    assert seen_alloc_leaf, (
+        f"No memory_stacks entry has its leaf on one of the allocator "
+        f"lines {ALLOC_LINES}. Synchronous stack capture appears broken "
+        f"for this fixture."
+    )
+    assert not smear_leaves, (
+        f"memory_stacks contains entries whose leaf is on a pure-"
+        f"arithmetic line {ARITH_LINES}: {smear_leaves}. The smear "
+        f"suppression in process_malloc_free_samples should drop "
+        f"these from memory_stacks too — otherwise the flame chart "
+        f"credits bytes to whatever call chain was incidentally active "
+        f"(not the chain that actually caused the allocation)."
+    )


### PR DESCRIPTION
## Summary

This change should have been part of #1050 but didn't make it into the squash merge. Restoring it now as a follow-up.

A pure-arithmetic hot loop like `z = z * z` on floats was consistently showing hundreds of MB of malloc traffic, gigabyte-scale peak / sparkline values, a sizable wedge in the memory-activity pie, *and* a fat path in the `--stacks` memory-flame chart — even though the line's bytecode (LOAD_FAST / BINARY_OP / STORE_FAST) had no way to invoke a C-side allocator.

The mechanism: the C++ heap interposer stamps every malloc with the leaf user frame (and the captured Python stack) from `whereInPython`, but CPython internals (arena resizes, GC, scalene's own bookkeeping under the GIL) emit raw `malloc` calls whose stamped leaf is whichever line the eval loop happens to be on. The bytes are real but the attribution is wrong — they smear onto whatever's hot, both per-line *and* along the captured call chain.

## Fix

New helper `line_has_alloc_opcode(filename, lineno)` in `scalene_utility.py` compiles each user source once via `linecache.getlines + compile + dis.get_instructions`, recording the set of source lines whose bytecode contains at least one allocation-capable opcode. Set membership: `startswith(\"CALL\" / \"BUILD_\" / \"LIST_\" / \"SET_\" / \"MAP_\" / \"DICT_\" / \"IMPORT_\" / \"MAKE_\" / \"FORMAT_\")` plus exact opnames covering `GET_ITER`, `FOR_ITER`, `SEND`, `YIELD_VALUE`, `BINARY_SUBSCR`, `STORE_SUBSCR`, `LOAD_ATTR`, `STORE_ATTR`, `LOAD_BUILD_CLASS`, `RAISE_VARARGS`, `BEFORE_WITH`, `WITH_EXCEPT_START`, etc. Handles Python 3.13's `Instruction.line_number` change and the older `starts_line` semantics by propagating last-seen line forward through the instruction stream. Result is cached per file; subsequent lookups are O(1).

`process_malloc_free_samples` consults the helper for every sample. When the leaf line is *not* allocation-capable, the sample is dropped from every per-line accumulator — `memory_malloc_samples`, `memory_python_samples`, `memory_max_footprint`, `memory_current_footprint`, `memory_aggregate_footprint`, `per_line_footprint_samples`, `memory_free_samples`, `memory_free_count`, `bytei_map` — **and** from `stats.memory_stacks`. The bytes still flow into the global running footprint so the global peak and sparkline stay accurate, but no line, function, or flame-chart path takes the blame.

The reasoning for dropping `memory_stacks` too: the captured stack records which user frames were active at the moment of the malloc, but the actual cause is heap pressure set up by a prior frame that's already returned (e.g., `doit1` ran, allocated, returned; later GC fires during `doit2`'s arithmetic loop and the captured stack shows `doit2`, not `doit1`). Crediting the captured chain in the flame view smears the same way the per-line table did, just along a different axis. Two earlier drafts tried lighter touches — redirect-up-the-stack, and keep-flame-view-intact — and both failed for the same reason: there's no honest way to attribute these bytes from the synchronously-captured stack alone.

Frees use the same check. The C++ `process_free` path doesn't capture a stack so they couldn't be redirected anyway, but skipping them on smear-prone leaves keeps the per-line current-footprint and sparkline columns consistent with the dropped mallocs.

## Verification

On `test/testme.py` (the canonical reproducer):

**Pre-fix:**
- `doit2`'s body lines showed ~1.2 GB of phantom malloc traffic with a ~810 MB peak attributed to the inner \`z = z * z\` line.
- The flame chart showed a fat \`→ stuff → doit2 → z = z * z\` path.

**Post-fix:**
- Every column inside `doit2` and `stuff()`'s call sites is zero.
- Function-rollup view: `doit2` is zero, `doit1` carries its full ~1.9 GB.
- `memory_stacks` contains only the three legitimate paths through `doit1`'s list comprehensions (\`stuff:58 → doit1:47 → lines 13/14/15\`).

## Tests

`tests/test_memory_arithmetic_smear.py` (new, four tests) with fixture `test/line_attribution_tests/arithmetic_smear.py`:
- `test_arithmetic_lines_have_minimal_malloc_traffic` — per-line \`n_malloc_mb\` on arithmetic lines stays bounded.
- `test_allocator_lines_still_dominate` — guards against over-suppression: the legitimate list-comprehension lines keep their bytes.
- `test_function_rollup_does_not_smear_onto_arith_function` — function-level rollup row for the arithmetic function is zero across every memory column.
- `test_memory_stacks_preserve_full_paths` — `memory_stacks` contains legitimate alloc-leaf paths and **no** entries whose leaf is a pure-arithmetic line.

All existing memory-attribution / memory-stacks tests still pass (`test_line_attribution_nested.py` × 3, `test_memory_stacks_bigmem.py` × 3).

## Test plan

- [x] \`python3 -m pytest tests/test_memory_arithmetic_smear.py tests/test_line_attribution_nested.py tests/test_memory_stacks_bigmem.py\` — 10/10 pass
- [x] \`ruff check scalene/\` clean
- [x] \`mypy scalene/\` clean across all 65 source files
- [x] \`testme.py\` end-to-end: per-line + per-function memory view shows \`doit2\` and its \`z = z * z\` body at zero across every column; \`memory_stacks\` contains only \`doit1\`'s legitimate paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)