### PR TITLE
CI: flip fail-fast to true on all matrix workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,9 @@ jobs:
       security-events: write
 
     strategy:
-      fail-fast: false
+      # fail-fast: if cpp analysis fails, don't wait for python (and
+      # vice versa). Matches the policy applied to tests / smoketests.
+      fail-fast: true
       matrix:
         language: [ cpp, python ]
 

--- a/.github/workflows/test-smoketests.yml
+++ b/.github/workflows/test-smoketests.yml
@@ -21,10 +21,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
-      # One matrix entry failing should NOT cancel others — they cover
-      # different OS/Python combinations and we want full coverage even
-      # when one configuration regresses.
-      fail-fast: false
+      # fail-fast: any matrix entry failure cancels the rest. Trades
+      # full-coverage-on-failure for faster feedback and lower CI burn —
+      # if Windows 3.10 spawn-pool flakes we want to know within seconds,
+      # not 30 minutes later after every other combo finishes.
+      fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,11 @@ jobs:
     # subprocesses), leaving no headroom for the parity step that follows.
     timeout-minutes: 30
     strategy:
-      fail-fast: false
+      # fail-fast: any matrix entry failure cancels the rest. Trades
+      # full-coverage-on-failure for faster feedback and lower CI burn —
+      # if Python 3.10 on Ubuntu breaks we want to know within seconds,
+      # not 30 minutes later after every other entry finishes.
+      fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
         python: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.13t', '3.14t' ]


### PR DESCRIPTION
## Summary

Cancel the rest of the matrix as soon as any entry fails, on every PR-path workflow.

Previously \`tests.yml\`, \`test-smoketests.yml\`, and \`codeql.yml\` all set \`fail-fast: false\` to let every matrix entry run to completion when one failed. The intent was full-coverage on failure (\"surface all the regressions in one run\"). In practice, with the wide matrices currently configured (16 entries for tests, 18 for smoketests), a single known-flaky combo — Windows spawn-pool, mostly — burns 30+ minutes of CI after the failure with no actionable information added.

Flipping to \`fail-fast: true\` matches the standard GitHub Actions default. The first failure cancels the rest immediately.

## What's still protected

The \`continue-on-error\` carve-outs already in \`tests.yml\` (free-threaded Python 3.13t / 3.14t test steps) keep their effect: those steps don't mark the matrix entry as failed, so a free-threaded regression won't trigger fail-fast on the rest of the matrix. Intentional non-blocking failures stay non-blocking.

## Affected workflows

| Workflow | Matrix size | Notes |
|---|---|---|
| \`tests.yml\` | 8 Python × 2 OS = 16 | The big one. Includes free-threaded carve-outs above. |
| \`test-smoketests.yml\` | 6 Python × 3 OS = 18 | Windows spawn-pool is the most frequent first-faller. |
| \`codeql.yml\` | 2 languages | Cheap (~2 min/entry); flipped for policy consistency. |

\`build-and-upload.yml\` only runs on releases / manual dispatch — not in the PR path the user is optimizing — left alone.

## Test plan

- [x] All three workflow YAMLs parse cleanly and report \`strategy.fail-fast == true\`.
- [ ] First CI run on this branch confirms the new policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)