### PR TITLE
Fix issue #1022: pytest-xdist + --profile-all on Linux dropped user samples

### DIFF
--- a/.github/workflows/test-smoketests.yml
+++ b/.github/workflows/test-smoketests.yml
@@ -68,6 +68,17 @@ jobs:
       run: python test/smoketest_pool_spawn.py
       timeout-minutes: 5
 
+    # Regression test for pytest-xdist + --profile-all on Linux (issue
+    # #1022). The bug was Linux-specific: execnet worker subprocesses
+    # inherited a sigmask with Scalene's CPU sampling signal blocked,
+    # so the timer fired but the handler never ran and the user's code
+    # was absent from the merged profile. The smoketest itself self-
+    # skips on non-Linux platforms.
+    - name: pytest-xdist + --profile-all (issue #1022)
+      if: matrix.os == 'ubuntu-latest'
+      run: python test/smoketest_issue_1022.py
+      timeout-minutes: 5
+
       # Note: test/smoketest.py only handles single JSON, rather than multiple in sequence.
     - name: profile-interval smoke test
       run: python -m scalene run --profile-interval=2 test/testme.py && python -m scalene view --cli

--- a/scalene/scalene_signal_manager.py
+++ b/scalene/scalene_signal_manager.py
@@ -238,6 +238,24 @@ class ScaleneSignalManager:
             self.__signals.cpu_timer_signal,
             cpu_sampling_rate,
         )
+        # Unmask Scalene's profiling signals in the calling (main) thread.
+        # pytest-xdist's execnet, and other libraries that fan out work via
+        # subprocess.Popen, can leave the worker process with Scalene's CPU
+        # sampling signal blocked in its inherited sigmask — most visibly
+        # when the parent's patched os module (issue #841) intersects with
+        # the subprocess fork window. Without this unblock the SIGALRM
+        # timer fires but the handler never runs, leaving the worker with
+        # zero CPU and zero allocation samples. See issue #1022.
+        unblock_set = {
+            self.__signals.cpu_signal,
+            self.__signals.malloc_signal,
+            self.__signals.free_signal,
+            self.__signals.memcpy_signal,
+        }
+        unblock_set.discard(None)
+        if unblock_set:
+            with contextlib.suppress(ValueError, OSError):
+                signal.pthread_sigmask(signal.SIG_UNBLOCK, unblock_set)
 
     def setup_lifecycle_signals(
         self,

--- a/test/smoketest_issue_1022.py
+++ b/test/smoketest_issue_1022.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Smoketest for pytest-xdist + ``--profile-all`` (regression for #1022).
+
+Workers spawned by pytest-xdist inherit a sigmask that, in combination
+with Scalene's ``patch_module_functions_with_signal_blocking`` shim
+(issue #841), used to land with Scalene's CPU sampling signal blocked.
+The setitimer fires, but the handler never runs, so each worker
+collects zero samples; the parent then merges nothing and the user's
+code is absent from the profile while ``"did not run for long enough"``
+warnings print twice (once per worker).
+
+This smoketest reproduces the exact shape: ``-n 2`` workers running a
+CPU-busy fixture under ``--profile-all``. It asserts that the user's
+source file appears in the merged profile. Pre-fix on Linux 3.13 the
+profile contains only stdlib/execnet; post-fix it contains the fixture
+source.
+
+Linux-only: macOS and Windows did not exhibit the bug in the wild
+(macOS goes through a different path that doesn't leak the sigmask
+across subprocess fork; Windows doesn't use the LD_PRELOAD/sigmask
+machinery at all).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+if sys.platform != "linux":
+    print(f"skipping issue-1022 smoketest on {sys.platform}: bug is Linux-only")
+    sys.exit(0)
+
+# Install pytest-xdist into the running environment if missing. The
+# smoketest workflow already installs scalene + numpy; xdist is the
+# only extra requirement and pinning it isn't worth a separate step.
+try:
+    import xdist  # noqa: F401
+except ImportError:
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--quiet", "pytest-xdist"]
+    )
+
+workdir = tempfile.mkdtemp(prefix="scalene-1022-")
+src_dir = os.path.join(workdir, "src")
+os.makedirs(src_dir, exist_ok=True)
+
+# Fixture: a CPU-busy function the workers will run. Each test calls it
+# with 10M iterations so even on slow runners there is more than enough
+# wall-clock time for the timer to fire many times per worker.
+with open(os.path.join(src_dir, "__init__.py"), "w") as f:
+    f.write(
+        textwrap.dedent(
+            """
+            def crunch(n):
+                total = 0
+                for i in range(n):
+                    total += i * i
+                return total
+            """
+        ).lstrip()
+    )
+
+with open(os.path.join(workdir, "test_heavy.py"), "w") as f:
+    f.write(
+        textwrap.dedent(
+            """
+            from src import crunch
+
+            def test_a():
+                assert crunch(10_000_000) > 0
+
+            def test_b():
+                assert crunch(10_000_000) > 0
+
+            def test_c():
+                assert crunch(10_000_000) > 0
+
+            def test_d():
+                assert crunch(10_000_000) > 0
+            """
+        ).lstrip()
+    )
+
+profile_path = os.path.join(workdir, "issue1022.json")
+cmd = [
+    sys.executable,
+    "-m",
+    "scalene",
+    "run",
+    "--profile-all",
+    "-o",
+    profile_path,
+    "---",
+    "-m",
+    "pytest",
+    "-n",
+    "2",
+    "test_heavy.py",
+]
+print("COMMAND", " ".join(cmd))
+proc = subprocess.run(cmd, cwd=workdir, capture_output=True, text=True, timeout=180)
+print(proc.stdout)
+print(proc.stderr, file=sys.stderr)
+
+if proc.returncode != 0:
+    print(f"scalene exited with rc={proc.returncode}")
+    sys.exit(proc.returncode)
+
+if not os.path.exists(profile_path):
+    print(f"No profile produced at {profile_path}")
+    sys.exit(1)
+
+with open(profile_path) as f:
+    data = json.load(f)
+
+files = data.get("files", {})
+if not files:
+    print("Profile has empty 'files' dict — issue #1022 regression")
+    sys.exit(1)
+
+# The fixture lives in workdir; the entry we expect to see is
+# "<workdir>/src/__init__.py" since that's where ``crunch`` runs. We
+# match by path suffix to stay tolerant of symlinked tmpdirs.
+user_file_suffix = os.path.join("src", "__init__.py")
+matching = [name for name in files if name.endswith(user_file_suffix)]
+if not matching:
+    print(
+        f"User-code file (...{user_file_suffix}) absent from profile. "
+        f"Files present: {sorted(files)}"
+    )
+    sys.exit(1)
+
+print(
+    f"OK: issue #1022 fix holds. Profiled {len(files)} files, "
+    f"user code at {matching[0]!r}, elapsed={data.get('elapsed_time_sec'):.2f}s"
+)
+sys.exit(0)


### PR DESCRIPTION
## Summary

- Fixes [issue #1022](https://github.com/plasma-umass/scalene/issues/1022): under `pytest-xdist`'s `-n N` + `--profile-all` on Linux, every xdist worker printed *"Scalene: The specified code did not run for long enough to profile."* and the user's source file was absent from the merged profile.
- Root cause: workers inherited a sigmask with Scalene's CPU sampling signal blocked. The parent's `patch_module_functions_with_signal_blocking` shim (added for issue #841) wraps every `os.*` call with `pthread_sigmask(SIG_BLOCK, [SIGALRM])` / restore. When that wrapper intersects `subprocess.Popen`'s fork window, the child inherits the blocked mask. `setitimer` fires every 10 ms, but the kernel keeps the signal pending and the Python handler never runs — workers see 0 CPU and 0 allocation samples.
- Fix in `enable_signals()`: unconditionally `pthread_sigmask(SIG_UNBLOCK, ...)` Scalene's profiling signals in the calling (main) thread so children clear any inherited block before the timer starts.

## Repro (pre-fix, Linux 3.13 aarch64)

```
$ python -m scalene run --profile-all -o p.json --- -m pytest -n 2 test_heavy.py
....                                                                     [100%]
Scalene: The specified code did not run for long enough to profile.
Scalene: The specified code did not run for long enough to profile.
============================== 4 passed in 6.28s ===============================
$ jq '.files | keys' p.json
[".../execnet/gateway_base.py", "/usr/lib/python3.13/ast.py", ...]   ← no user code
```

Diagnostic confirming the mechanism (debug-instrumented build, since reverted):

```
[1022-EARLY pid=parent ]  main() entry mask=[]    SIGALRM_in=False
[1022-EARLY pid=worker1] main() entry mask=[14]   SIGALRM_in=True    ← inherited blocked
[1022-EARLY pid=worker2] main() entry mask=[14]   SIGALRM_in=True
[1022-DEBUG worker1] cpu_handler_calls=0 cpu_samples=0  elapsed=5.2s  cpu_signal_masked_at_setup=True
```

## Post-fix

User code (`src/__init__.py`) now appears in the profile and no warning prints. The two newly-failing tests I initially observed (`test_off_then_on_via_signal`, `test_perthread_native_stack_stitching`) were timing-flaky — both pass in isolation and on rerun. The 6 pre-existing test failures in the broader suite (`test_combined_stacks_gui`, `test_native_stacks`) reproduce on master without this PR.

## Test plan

- [x] Local repro on Linux aarch64 / Python 3.13.13 reproduces the bug pre-fix and passes post-fix.
- [x] No-xdist case (`pytest --cov=src test_heavy.py` under scalene) still profiles user code correctly.
- [x] `tests/` pytest suite: signal/fork/subprocess subset is 60 passed / 1 pre-existing PYTHONPATH failure.
- [x] `test/smoketest_pool_spawn.py` (issue #998 regression) still passes.
- [x] `ruff check` and `mypy` clean on the changed file.
- [x] New `test/smoketest_issue_1022.py` self-skips on non-Linux; wired into `test-smoketests.yml` under `if: matrix.os == 'ubuntu-latest'`. Verified it correctly exits 1 with the warning when reverted, and 0 with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)