### PR TITLE
Fix #1056: signal-free CPU sampling on Apple Silicon with SME (M4+)

### DIFF
--- a/scalene/scalene_cpu_profiler.py
+++ b/scalene/scalene_cpu_profiler.py
@@ -32,7 +32,11 @@ class ScaleneCPUProfiler:
     """Handles CPU profiling sample processing."""
 
     def __init__(
-        self, stats: ScaleneStatistics, available_cpus: int, use_virtual_time: bool
+        self,
+        stats: ScaleneStatistics,
+        available_cpus: int,
+        use_virtual_time: bool,
+        thread_sampled: bool = False,
     ) -> None:
         """Initialize the CPU profiler.
 
@@ -41,10 +45,18 @@ class ScaleneCPUProfiler:
             available_cpus: Number of available CPUs for utilization calculations.
             use_virtual_time: Whether we're using virtual time (SIGVTALRM) or
                 wall clock time (SIGALRM) for CPU sampling.
+            thread_sampled: True when CPU samples are produced by a background
+                helper thread on a wall-clock cadence rather than a timer
+                signal (Apple SME path, issue #1056). In that mode there is no
+                virtual-timer deferral to exploit, so Python-vs-C time is
+                attributed purely from the bytecode at f_lasti (a CALL* opcode
+                means we're in a native call) — exactly as wall-clock mode
+                already does, regardless of the --use-virtual-time flag.
         """
         self._stats = stats
         self._available_cpus = available_cpus
         self._use_virtual_time = use_virtual_time
+        self._thread_sampled = thread_sampled
 
     def process_cpu_sample(
         self,
@@ -230,15 +242,24 @@ class ScaleneCPUProfiler:
                 # call, and ALL time (including python_time) should go to native.
                 # This handles the case where elapsed.virtual ≈ last_cpu_interval
                 # (c_time ≈ 0) but we're still returning from C code.
+                #
+                # The thread-sampled (Apple SME) path always uses this
+                # bytecode-based test: it has no virtual-timer deferral to
+                # measure c_time from, so the CALL* opcode at f_lasti is the
+                # sole signal for "this sample landed in a native call". This
+                # is the same classifier already used for worker threads.
                 is_at_call = ScaleneFuncUtils.is_call_function(
                     main_thread_frame.f_code,
                     ByteCodeIndex(main_thread_frame.f_lasti),
                 )
 
-                if not self._use_virtual_time and is_at_call:
-                    # Wall clock mode at a CALL instruction: attribute all time
-                    # to native on this line. The signal was deferred during the
-                    # C call, so even python_time was spent in C, not Python.
+                use_call_attribution = (
+                    not self._use_virtual_time or self._thread_sampled
+                )
+                if use_call_attribution and is_at_call:
+                    # At a CALL instruction: attribute all time to native on
+                    # this line. The sample landed inside the C call, so even
+                    # python_time was spent in C, not Python.
                     self._update_main_thread_stats(
                         fname,
                         lineno,

--- a/scalene/scalene_mac_sampler.py
+++ b/scalene/scalene_mac_sampler.py
@@ -1,0 +1,141 @@
+"""Signal-free CPU sampler for Apple Silicon with SME (issue #1056).
+
+On Apple M4+ chips the macOS kernel mis-saves/restores ARM SME
+("streaming"-mode) register state whenever a signal handler is invoked
+while a thread is mid-kernel in Accelerate BLAS. This silently corrupts
+in-flight numerical results — even an empty C signal handler triggers it
+(see scalene/issue-1056-probes and issue #1056). No handler-side change
+can fix it, because the corruption is applied by the kernel on
+``sigreturn``, after the handler returns.
+
+The only correctness-preserving mitigation is to stop delivering the
+CPU-profiling timer signal on these machines. This module replaces the
+``setitimer``/``SIGVTALRM`` mechanism with a background *helper thread*
+that periodically calls Scalene's CPU sample handler directly. Because no
+signal is ever delivered, the kernel never runs its buggy SME save/
+restore path, and the worker thread's matrix state stays intact.
+
+This mirrors the existing Windows approach (``windows_timer_loop`` in
+``scalene_signal_manager``), which already drives the CPU handler from a
+background thread for a different reason (``signal.raise_signal`` is
+unavailable off the main thread on Windows). The handler reads thread
+state via ``sys._current_frames()``, which is thread-safe and works from
+any thread, so calling it from this helper is sound.
+
+Python-vs-C time attribution still works: the CPU profiler classifies the
+main thread's time from the bytecode at ``f_lasti`` (a ``CALL*`` opcode
+means the frame is sitting in a native call) — the same rule already used
+for worker threads — rather than relying on the signal-deferral timing
+trick that needs an actual signal. See ``scalene_cpu_profiler`` and the
+``probe_frames_sampler`` prototype.
+"""
+import contextlib
+import threading
+from typing import Optional
+
+from scalene.scalene_signals import SignalHandlerFunction
+from scalene.scalene_sigqueue import ScaleneSigQueue
+
+
+class MacThreadSampler:
+    """Drives the CPU sample handler from a background thread (no signals).
+
+    The handler is called with ``frame=None`` (like the Windows path); it
+    collects all thread frames itself via ``sys._current_frames()``.
+
+    When memory profiling is enabled, this thread also polls the malloc/
+    free and memcpy sample queues. On the SME path those signals
+    (SIGXCPU/SIGXFSZ/SIGPROF) are set to SIG_IGN — delivering them would
+    corrupt SME state just like the CPU signal (issue #1056) — but the
+    native allocator always writes its sample record to the sample file
+    *before* raising the signal, so polling the queues here drains exactly
+    the same data with nothing lost. This mirrors Windows'
+    ``_windows_memory_poll_loop``.
+    """
+
+    # Poll memory queues at a fixed 10ms cadence, like the Windows path,
+    # independent of the (randomized, exponential) CPU sampling interval.
+    _MEM_POLL_INTERVAL = 0.01
+
+    def __init__(self) -> None:
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._handler: Optional[SignalHandlerFunction] = None
+        self._cpu_signal: int = 0
+        self._rate: float = 0.01
+        self._alloc_sigq: Optional[ScaleneSigQueue] = None
+        self._memcpy_sigq: Optional[ScaleneSigQueue] = None
+
+    def start(
+        self,
+        cpu_signal_handler: SignalHandlerFunction,
+        cpu_signal: int,
+        cpu_sampling_rate: float,
+        alloc_sigq: Optional[ScaleneSigQueue] = None,
+        memcpy_sigq: Optional[ScaleneSigQueue] = None,
+    ) -> None:
+        """Start the sampling thread.
+
+        cpu_signal_handler: Scalene's CPU sample handler.
+        cpu_signal: the signal number passed as the handler's first arg
+            (used only for bookkeeping; no signal is actually raised).
+        cpu_sampling_rate: seconds between samples.
+        alloc_sigq, memcpy_sigq: when memory profiling is on, the queues to
+            poll-drain (their handlers' signals are SIG_IGN'd on this path).
+        """
+        self._handler = cpu_signal_handler
+        self._cpu_signal = int(cpu_signal)
+        self._rate = cpu_sampling_rate
+        self._alloc_sigq = alloc_sigq
+        self._memcpy_sigq = memcpy_sigq
+        self._stop_event.clear()
+        # Non-daemon so sampling continues for short-running programs even
+        # if the main thread finishes quickly; cleanup is via stop().
+        self._thread = threading.Thread(target=self._loop, daemon=False)
+        self._thread.start()
+
+    def _loop(self) -> None:
+        """Periodically invoke the CPU handler (and poll memory) until stopped."""
+        # Initial delay so the first samples land in user code, not in
+        # Scalene's own startup (matches windows_timer_loop).
+        if self._stop_event.wait(0.01):
+            return
+        polling_memory = self._alloc_sigq is not None
+        while not self._stop_event.is_set():
+            # Sample first, then wait, so we still record something even if
+            # the program exits almost immediately after this point.
+            if self._handler is not None:
+                # The handler must not touch the timer on this path (no
+                # signal-based timing); the profiler guards that. Any
+                # exception in a sample must not kill the sampler thread.
+                with contextlib.suppress(Exception):
+                    self._handler(self._cpu_signal, None)
+            if polling_memory:
+                self._poll_memory()
+            # Wait the shorter of the CPU rate and the memory poll interval,
+            # so neither cadence is starved. Event.wait() (not time.sleep())
+            # lets stop() interrupt the wait immediately.
+            wait = self._rate
+            if polling_memory:
+                wait = min(wait, self._MEM_POLL_INTERVAL)
+            if self._stop_event.wait(wait):
+                break
+
+    def _poll_memory(self) -> None:
+        """Drain malloc/free and memcpy sample queues (data already on disk)."""
+        with contextlib.suppress(Exception):
+            if self._alloc_sigq is not None:
+                self._alloc_sigq.put([0])
+            if self._memcpy_sigq is not None:
+                self._memcpy_sigq.put((0, None))
+
+    def stop(self) -> None:
+        """Stop the sampling thread and wait for it to finish."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -129,6 +129,7 @@ from scalene.scalene_utility import (
     get_native_thread_id,
     install_native_stack_unwinder,
     install_perthread_sampler,
+    is_apple_silicon_sme,
     on_stack,
     patch_module_functions_with_signal_blocking,
     register_thread_for_sampling,
@@ -379,10 +380,17 @@ class Scalene:
         if not hasattr(Scalene, "_Scalene__availableCPUs"):
             cpu_count = os.cpu_count()
             Scalene.__availableCPUs = cpu_count if cpu_count is not None else 1
+        # On Apple Silicon with SME, CPU sampling is driven by a background
+        # thread (no timer signal — issue #1056), so Python-vs-C attribution
+        # must rely on the CALL*-bytecode test rather than virtual-timer
+        # deferral. Detection is cached, so calling it here and in
+        # enable_signals() is cheap and consistent.
+        thread_sampled = sys.platform == "darwin" and is_apple_silicon_sme()
         Scalene.__cpu_profiler = ScaleneCPUProfiler(
             Scalene.__stats,
             Scalene.__availableCPUs,
             Scalene.__args.use_virtual_time,
+            thread_sampled=thread_sampled,
         )
         Scalene.__tracing = ScaleneTracing(
             Scalene.__args,
@@ -806,9 +814,20 @@ class Scalene:
             now.wallclock = time.perf_counter()
             Scalene.__last_signal_time = now
         # On Windows, pass the signal queues for memory polling only if memory profiling is enabled
+        # Apple Silicon with SME (M4+): delivering ANY signal while a thread
+        # is in Accelerate's SME streaming mode corrupts numerical results
+        # (issue #1056 — a macOS kernel save/restore bug). On these machines
+        # drive CPU sampling from a background thread instead of a timer
+        # signal, so nothing is ever delivered to an SME thread.
+        use_thread_sampler = (
+            sys.platform == "darwin" and is_apple_silicon_sme()
+        )
+        # The sample queues are needed for memory poll-draining whenever a
+        # background thread (Windows timer thread, or the Apple-SME sampler)
+        # owns memory processing instead of the malloc/free/memcpy signals.
         alloc_sigq = None
         memcpy_sigq = None
-        if sys.platform == "win32" and Scalene.__args.memory:
+        if Scalene.__args.memory and (sys.platform == "win32" or use_thread_sampler):
             alloc_sigq = Scalene.__alloc_sigq
             memcpy_sigq = Scalene.__memcpy_sigq
         Scalene.__signal_manager.enable_signals(
@@ -820,6 +839,7 @@ class Scalene:
             next_interval,
             alloc_sigq,
             memcpy_sigq,
+            use_thread_sampler=use_thread_sampler,
         )
         # If --stacks was requested, install a C-level sigaction handler on
         # the CPU sampling signal that captures the interrupted thread's
@@ -836,17 +856,32 @@ class Scalene:
         # Use the signal manager's view of the CPU signal — Scalene.__signals
         # is a separate ScaleneSignals instance that may not reflect the
         # virtual-vs-real-time choice driven by --use-virtual-time.
+        # The --stacks machinery is signal-based: it chains a sigaction on
+        # the CPU signal and delivers SIGPROF to every thread to capture
+        # native stacks. On Apple SME that re-introduces exactly the signal
+        # delivery we are avoiding (issue #1056), so skip it there. CPU/line
+        # profiling still works via the thread sampler; only native-stack
+        # capture is unavailable.
         if Scalene.__args.stacks and sys.platform != "win32":
-            install_native_stack_unwinder(
-                Scalene.__signal_manager.get_signals().cpu_signal
-            )
-            # Install per-thread sampler on SIGPROF for worker thread stacks.
-            # This allows capturing native stacks from threads other than main.
-            # SIGPROF doesn't interfere with SIGVTALRM (CPU sampling) or
-            # SIGALRM (real-time mode).
-            install_perthread_sampler(signal.SIGPROF)
-            # Register the main thread so we track it in diagnostics
-            register_thread_for_sampling()
+            if use_thread_sampler:
+                print(
+                    "Scalene: --stacks (native stack capture) is disabled on "
+                    "Apple M4+ (SME) because it requires signal delivery that "
+                    "corrupts SME numerical state (issue #1056). CPU and line "
+                    "profiling are unaffected.",
+                    file=sys.stderr,
+                )
+            else:
+                install_native_stack_unwinder(
+                    Scalene.__signal_manager.get_signals().cpu_signal
+                )
+                # Install per-thread sampler on SIGPROF for worker thread stacks.
+                # This allows capturing native stacks from threads other than main.
+                # SIGPROF doesn't interfere with SIGVTALRM (CPU sampling) or
+                # SIGALRM (real-time mode).
+                install_perthread_sampler(signal.SIGPROF)
+                # Register the main thread so we track it in diagnostics
+                register_thread_for_sampling()
 
     @staticmethod
     def cpu_signal_handler(
@@ -1353,6 +1388,9 @@ class Scalene:
             Scalene.stop_signal_queues()
             return
         try:
+            # Stop the Apple-SME signal-free CPU sampler thread if it's
+            # running (issue #1056). No-op when the timer-signal path is used.
+            Scalene.__signal_manager.stop_mac_sampler()
             signals = Scalene.__signal_manager.get_signals()
             assert signals.cpu_timer_signal is not None
             Scalene.__orig_setitimer(signals.cpu_timer_signal, 0)

--- a/scalene/scalene_signal_manager.py
+++ b/scalene/scalene_signal_manager.py
@@ -11,8 +11,9 @@ import os
 import signal
 import sys
 import threading
-from typing import Any, List, Optional, Set
+from typing import Any, List, Optional, Set, Tuple, Union
 
+from scalene.scalene_mac_sampler import MacThreadSampler
 from scalene.scalene_signals import ScaleneSignals, SignalHandlerFunction
 from scalene.scalene_sigqueue import ScaleneSigQueue
 
@@ -67,6 +68,11 @@ class ScaleneSignalManager:
         self.__lifecycle_watcher_thread: Optional[threading.Thread] = None
         self.__lifecycle_watcher_active = False
 
+        # Signal-free CPU sampler for Apple Silicon with SME (issue #1056).
+        # When active, the CPU timer signal is NOT armed; a background thread
+        # drives the CPU handler directly. Lazily created in enable_signals().
+        self.__mac_sampler: Optional[MacThreadSampler] = None
+
     def get_signals(self) -> ScaleneSignals:
         """Return the ScaleneSignals instance."""
         return self.__signals
@@ -88,6 +94,12 @@ class ScaleneSignalManager:
         """Stop the signal processing queues (i.e., their threads)."""
         for sigq in self.__sigqueues:
             sigq.stop()
+
+    def stop_mac_sampler(self) -> None:
+        """Stop the Apple-SME signal-free CPU sampler thread, if running."""
+        if self.__mac_sampler is not None:
+            self.__mac_sampler.stop()
+            self.__mac_sampler = None
 
     def stop_timer_thread(self) -> None:
         """Stop the Windows timer thread and wait for it to finish."""
@@ -212,9 +224,15 @@ class ScaleneSignalManager:
         cpu_sampling_rate: float,
         alloc_sigq: Optional[ScaleneSigQueue] = None,
         memcpy_sigq: Optional[ScaleneSigQueue] = None,
+        use_thread_sampler: bool = False,
     ) -> None:
         """Set up the signal handlers to handle interrupts for profiling and start the
-        timer interrupts."""
+        timer interrupts.
+
+        use_thread_sampler: when True (Apple Silicon with SME, issue #1056),
+            do NOT arm the CPU timer signal. A background thread drives the
+            CPU handler directly so no signal is delivered to SME threads.
+        """
         if sys.platform == "win32":
             self.enable_signals_win32(
                 cpu_signal_handler, cpu_sampling_rate, alloc_sigq, memcpy_sigq
@@ -223,21 +241,62 @@ class ScaleneSignalManager:
 
         self.start_signal_queues()
         # Set signal handlers for various events.
-        for sig, handler in [
-            (self.__signals.malloc_signal, malloc_signal_handler),
-            (self.__signals.free_signal, free_signal_handler),
-            (self.__signals.memcpy_signal, memcpy_signal_handler),
+        #
+        # On the Apple-SME thread-sampler path, the memory signals
+        # (malloc/free/memcpy) are set to SIG_IGN instead of their real
+        # handlers: delivering them would corrupt SME state exactly like the
+        # CPU signal (issue #1056). The native allocator writes each sample
+        # to its sample file *before* raising the signal, so a SIG_IGN'd
+        # signal loses no data — the helper thread poll-drains the queues
+        # instead (see MacThreadSampler). The CPU handler is still registered
+        # so any externally-delivered cpu_signal is handled gracefully, but
+        # we never arm the timer ourselves.
+        # Element type matches signal.signal's handler arg (a handler
+        # callable, or signal.Handlers like SIG_IGN). Annotated so the two
+        # branches below (real handlers vs SIG_IGN) unify cleanly.
+        HandlerArg = Union[SignalHandlerFunction, signal.Handlers]
+        mem_handlers: List[Tuple[Any, HandlerArg]]
+        if use_thread_sampler:
+            mem_handlers = [
+                (self.__signals.malloc_signal, signal.SIG_IGN),
+                (self.__signals.free_signal, signal.SIG_IGN),
+                (self.__signals.memcpy_signal, signal.SIG_IGN),
+            ]
+        else:
+            mem_handlers = [
+                (self.__signals.malloc_signal, malloc_signal_handler),
+                (self.__signals.free_signal, free_signal_handler),
+                (self.__signals.memcpy_signal, memcpy_signal_handler),
+            ]
+        all_handlers: List[Tuple[Any, HandlerArg]] = [
+            *mem_handlers,
             (signal.SIGTERM, term_signal_handler),
             (self.__signals.cpu_signal, cpu_signal_handler),
-        ]:
+        ]
+        for sig, handler in all_handlers:
             self.__orig_signal(sig, handler)
         # Set every signal to restart interrupted system calls.
         for s in self.__signals.get_all_signals():
             self.__orig_siginterrupt(s, False)
-        self.__orig_setitimer(
-            self.__signals.cpu_timer_signal,
-            cpu_sampling_rate,
-        )
+        if use_thread_sampler:
+            # Apple SME: drive CPU sampling (and memory poll-draining) from a
+            # helper thread instead of arming SIGVTALRM/SIGALRM. No profiling
+            # signal is ever delivered, so the macOS kernel never corrupts
+            # in-flight SME state (#1056). alloc_sigq/memcpy_sigq are non-None
+            # only when memory profiling is enabled.
+            self.__mac_sampler = MacThreadSampler()
+            self.__mac_sampler.start(
+                cpu_signal_handler,
+                int(self.__signals.cpu_signal),
+                cpu_sampling_rate,
+                alloc_sigq,
+                memcpy_sigq,
+            )
+        else:
+            self.__orig_setitimer(
+                self.__signals.cpu_timer_signal,
+                cpu_sampling_rate,
+            )
         # Unmask Scalene's profiling signals in the calling (main) thread.
         # pytest-xdist's execnet, and other libraries that fan out work via
         # subprocess.Popen, can leave the worker process with Scalene's CPU
@@ -405,9 +464,13 @@ class ScaleneSignalManager:
     def restart_timer(self, interval: float) -> None:
         """Restart the CPU profiling timer with the specified interval.
 
-        On Windows, this is a no-op because the timer thread runs at a fixed
-        sampling rate and doesn't need to be restarted after each sample.
+        On Windows, and on the Apple-SME thread-sampler path, this is a
+        no-op because a background thread runs at a fixed sampling rate and
+        doesn't need the timer restarted after each sample. (Calling
+        setitimer from the sampler thread would also raise.)
         """
+        if self.__mac_sampler is not None:
+            return
         if sys.platform != "win32":
             self.__orig_setitimer(
                 self.__signals.cpu_timer_signal,

--- a/scalene/scalene_utility.py
+++ b/scalene/scalene_utility.py
@@ -63,6 +63,35 @@ except ImportError:
     _native_unwind_available = False
 
 
+@functools.lru_cache(maxsize=1)
+def is_apple_silicon_sme() -> bool:
+    """True iff running on an Apple Silicon CPU that implements ARM SME.
+
+    SME (Scalable Matrix Extension) first appears in the Apple M4 family.
+    On these chips, Apple's Accelerate BLAS runs matrix kernels in SME
+    "streaming" mode, and the macOS kernel mis-saves/restores that state
+    when a signal handler is invoked while a thread is mid-kernel —
+    corrupting in-flight numerical results (scalene issue #1056). Even an
+    empty C signal handler triggers it, so the only correctness-preserving
+    mitigation is to avoid delivering profiling signals on these machines.
+
+    Detected via ``sysctl hw.optional.arm.FEAT_SME`` (== 1 when present).
+    Cached: the answer never changes during a run.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        out = subprocess.run(
+            ["sysctl", "-n", "hw.optional.arm.FEAT_SME"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return out.returncode == 0 and out.stdout.strip() == "1"
+
+
 # Per-process intern caches for stitched-stack frame keys.
 #
 # Every CPU sample that captures a stitched stack constructs a fresh tuple of

--- a/tests/test_mac_sampler.py
+++ b/tests/test_mac_sampler.py
@@ -1,0 +1,155 @@
+"""Tests for the Apple-SME signal-free CPU sampler (issue #1056).
+
+These exercise the platform-independent mechanics of MacThreadSampler and
+the SME-detection helper. They run on any platform — the sampler is just a
+background thread that calls a handler, so we can drive it with a fake
+handler and fake sample queues without needing real SME hardware.
+"""
+import sys
+import threading
+import time
+
+import pytest
+
+from scalene.scalene_mac_sampler import MacThreadSampler
+
+
+def test_sampler_invokes_handler_repeatedly():
+    """The sampler thread should call the CPU handler more than once."""
+    calls = []
+    lock = threading.Lock()
+
+    def handler(signum, frame):
+        with lock:
+            calls.append((signum, frame))
+
+    sampler = MacThreadSampler()
+    sampler.start(handler, cpu_signal=42, cpu_sampling_rate=0.005)
+    assert sampler.is_running
+    time.sleep(0.2)
+    sampler.stop()
+    assert not sampler.is_running
+
+    with lock:
+        # At ~200Hz over 200ms we expect many; assert a conservative lower
+        # bound to avoid flakiness on a loaded CI machine.
+        assert len(calls) >= 2
+        # Handler is always called with frame=None (Windows-style) and the
+        # signal number we passed.
+        assert all(signum == 42 and frame is None for signum, frame in calls)
+
+
+def test_sampler_handler_exception_does_not_kill_thread():
+    """An exception in the handler must not stop sampling."""
+    count = {"n": 0}
+
+    def bad_handler(signum, frame):
+        count["n"] += 1
+        raise RuntimeError("boom")
+
+    sampler = MacThreadSampler()
+    sampler.start(bad_handler, cpu_signal=1, cpu_sampling_rate=0.005)
+    time.sleep(0.15)
+    still_running = sampler.is_running
+    sampler.stop()
+
+    assert still_running, "sampler thread died on handler exception"
+    assert count["n"] >= 2, "sampler stopped calling handler after exception"
+
+
+def test_sampler_stop_is_idempotent_and_prompt():
+    """stop() should join quickly and be safe to call when not started."""
+    sampler = MacThreadSampler()
+    # Never started: stop() must not raise.
+    sampler.stop()
+
+    sampler.start(lambda s, f: None, cpu_signal=1, cpu_sampling_rate=0.01)
+    t0 = time.perf_counter()
+    sampler.stop()
+    assert time.perf_counter() - t0 < 2.0
+    # Double stop is harmless.
+    sampler.stop()
+
+
+class _FakeSigQueue:
+    """Minimal stand-in for ScaleneSigQueue recording put() calls."""
+
+    def __init__(self):
+        self.items = []
+        self.lock = threading.Lock()
+
+    def put(self, item):
+        with self.lock:
+            self.items.append(item)
+
+
+def test_sampler_polls_memory_queues_when_provided():
+    """With memory profiling on, the sampler poll-drains both queues."""
+    alloc = _FakeSigQueue()
+    memcpy = _FakeSigQueue()
+
+    sampler = MacThreadSampler()
+    sampler.start(
+        lambda s, f: None,
+        cpu_signal=1,
+        cpu_sampling_rate=0.01,
+        alloc_sigq=alloc,
+        memcpy_sigq=memcpy,
+    )
+    time.sleep(0.15)
+    sampler.stop()
+
+    with alloc.lock:
+        assert len(alloc.items) >= 2
+    with memcpy.lock:
+        assert len(memcpy.items) >= 2
+
+
+def test_sampler_does_not_poll_when_no_queues():
+    """Without memory profiling, no queue polling happens (queues are None)."""
+    sampler = MacThreadSampler()
+    sampler.start(lambda s, f: None, cpu_signal=1, cpu_sampling_rate=0.005)
+    time.sleep(0.1)
+    sampler.stop()
+    # Nothing to assert beyond "did not crash"; the None queues must not be
+    # dereferenced. Reaching here without error is the assertion.
+
+
+def test_is_apple_silicon_sme_false_off_darwin(monkeypatch):
+    """SME detection must be False on non-macOS platforms without calling sysctl."""
+    from scalene import scalene_utility
+
+    scalene_utility.is_apple_silicon_sme.cache_clear()
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert scalene_utility.is_apple_silicon_sme() is False
+    scalene_utility.is_apple_silicon_sme.cache_clear()
+
+
+def test_is_apple_silicon_sme_reads_sysctl(monkeypatch):
+    """On darwin, the result reflects the sysctl FEAT_SME value."""
+    from scalene import scalene_utility
+
+    class _Result:
+        def __init__(self, stdout):
+            self.returncode = 0
+            self.stdout = stdout
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    scalene_utility.is_apple_silicon_sme.cache_clear()
+    monkeypatch.setattr(
+        scalene_utility.subprocess, "run", lambda *a, **k: _Result("1\n")
+    )
+    assert scalene_utility.is_apple_silicon_sme() is True
+
+    scalene_utility.is_apple_silicon_sme.cache_clear()
+    monkeypatch.setattr(
+        scalene_utility.subprocess, "run", lambda *a, **k: _Result("0\n")
+    )
+    assert scalene_utility.is_apple_silicon_sme() is False
+
+    scalene_utility.is_apple_silicon_sme.cache_clear()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

On Apple **M4+** chips (which implement ARM **SME**), running Scalene against numpy/Accelerate BLAS code silently **corrupts numerical results** — a by-construction-Hermitian matrix comes out non-Hermitian (max deviation jumps from ~1e-12 to ~1e3). Reported in #1056.

A diagnostic probe matrix run on **real M4 hardware** (macOS 26.5, FEAT_SME=1) pinned the root cause:

| probe | result |
|---|---|
| baseline (no signals) | clean |
| `SIG_IGN` (no handler invoked) | **clean** |
| empty **C** handler | **CORRUPT** |
| C handler on alternate stack | **CORRUPT** |
| Python no-op handler | **CORRUPT** |
| SIGPROF / SIGALRM variants | **CORRUPT** |

Only `SIG_IGN` is clean; an *empty* C handler corrupts as hard as a Python one, on any stack, for every signal/timer type. **The macOS kernel mis-saves/restores SME streaming state on `sigreturn`** — so no handler-side change can fix it. (Distinct from numpy #28687, which was spurious FP *warnings* fixed in numpy 2.3; this is real data corruption, still present with numpy 2.3.2.)

## Fix

Stop delivering profiling signals on these machines. Gated on `sysctl hw.optional.arm.FEAT_SME == 1`:

- **`scalene_mac_sampler.py`** (new): `MacThreadSampler` drives the CPU handler from a background thread on a wall-clock cadence (mirrors the existing Windows `windows_timer_loop`); no timer signal armed.
- **`scalene_utility.py`**: `is_apple_silicon_sme()` cached detection.
- **`scalene_signal_manager.py`**: `enable_signals(use_thread_sampler=...)` skips `setitimer`; `restart_timer` no-ops; `stop_mac_sampler()`. **Memory profiling preserved** by SIG_IGN'ing malloc/free/memcpy and poll-draining the sample queues from the sampler thread — safe because the native allocator writes each sample to its file *before* `raise()`.
- **`scalene_cpu_profiler.py`**: `thread_sampled` flag makes Python-vs-C attribution use the CALL\*-bytecode classifier (already used for worker threads) instead of virtual-timer deferral.
- **`scalene_profiler.py`**: detects SME, routes to the sampler, disables `--stacks` (with a warning) since its SIGPROF-to-all-threads would re-introduce the corruption.

**Non-SME platforms are completely unaffected** — the timer-signal path is unchanged.

## Testing

- New `tests/test_mac_sampler.py` (7 tests): sampler cadence, exception resilience, idempotent stop, memory poll-draining, SME detection.
- Full suite: 372 passed (1 pre-existing unrelated failure).
- On M2 (no SME): normal path unchanged; forced-SME path verified end-to-end — CPU + memory sampling work, and a mixed workload attributes matmul lines to C, Python loops to Python.

## ⚠️ Still needs M4 sign-off

The final *corruption-is-gone* proof requires SME hardware (maintainer's machine is M2). A one-command verifier (`verify_fix.sh`) and the diagnostic kit are prepared for that run. Opening now so **CI exercises the non-SME paths** across the support matrix while M4 verification is in flight.

Closes #1056 (pending M4 verification).