### PR TITLE
Declare free-threaded safety for _scalene_unwind module

### DIFF
--- a/src/source/native_unwind.cpp
+++ b/src/source/native_unwind.cpp
@@ -806,6 +806,13 @@ PyModuleDef moduledef = {
 extern "C" PyObject* PyInit__scalene_unwind(void) {
   PyObject* m = PyModule_Create(&moduledef);
   if (!m) return nullptr;
+#ifdef Py_GIL_DISABLED
+  // Declare free-threaded safety so importing this module does not silently
+  // re-enable the GIL on free-threaded (3.13t/3.14t) builds. Without this,
+  // CPython restores the GIL with a RuntimeWarning, so Scalene never actually
+  // runs free-threaded -- matches pywhere.cpp and get_line_atomic.cpp.
+  PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
   PyModule_AddIntConstant(m, "available", SCALENE_UNWIND_AVAILABLE);
   // Expose the per-call cap so callers (and tests) read the single
   // source of truth instead of hard-coding the value.


### PR DESCRIPTION
## Problem

On free-threaded builds (`3.13t`/`3.14t`), the `_scalene_unwind` native extension (built from `src/source/native_unwind.cpp`) was the only one of Scalene's three C extension modules that did **not** call `PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED)` in its init. `pywhere.cpp` and `get_line_atomic.cpp` both already do.

On free-threaded Python, importing a module that has not declared free-threaded safety makes CPython silently **re-enable the GIL** with a `RuntimeWarning`. Because Scalene always imports `_scalene_unwind`, the GIL was restored on every free-threaded run — adding startup overhead and serializing threads, so Scalene never actually ran free-threaded.

## Fix

One module-init call, guarded by `#ifdef Py_GIL_DISABLED`, matching `pywhere.cpp` / `get_line_atomic.cpp`.

## Verification (Linux, real 3.13t and 3.14t interpreters)

- Isolated each `.so`: `pywhere` and `get_line_atomic` keep the GIL off; `_scalene_unwind` was the sole module re-enabling it.
- After the fix: `sys._is_gil_enabled()` stays `False` after importing scalene; RuntimeWarning gone.
- Free-threaded parity test passes with the contention ratio dropping below 1.0 (0.81x on 3.13t, 0.87x on 3.14t) — real parallel scaling previously masked by the re-enabled GIL.

_Scope note: this PR is now just the GIL declaration. The free-threaded CI memory-test skips turned out to be a separate test-harness state leak, fixed in a follow-up PR._