### PR TITLE
Formal: Poisson sampler justification + GPU/copy/python-split/leak/memory-sampler correctness

### DIFF
--- a/formal/README.md
+++ b/formal/README.md
@@ -22,6 +22,15 @@ Python and differentially tests the real profiler against them.
    time/memory profile is an **unbiased, consistent** estimator of the truth
    (`ProfilerCorrectness.estimator_unbiased`, `jointVariance_eq`). This is the
    spec a profiler's *user* relies on; §3 proves the bookkeeping it rests on.
+7. **Poisson sampling** — the sampler's exponential inter-sample intervals
+   (`scalene_profiler.py:1108`) make sampling a Poisson process, which is what
+   *discharges* §6's i.i.d. hypothesis (inverse-CDF correctness + memorylessness).
+8. **GPU / copy-volume / python-split / leak detection** — GPU util, memcpy
+   volume, and the Python/native split fit the §6 weighted-average frame; memory
+   leak detection is a Bayesian (Rule-of-Succession) hypothesis test with proven
+   bounds, monotonicity, and false-positive guards.
+9. **Memory sampler** — the default ThresholdSampler conserves true net
+   allocation exactly (bounded residual); the Poisson sampler is unbiased.
 
 Two complementary tools are used, each where it is strongest:
 
@@ -238,13 +247,96 @@ formal contract between them.
   sampling (that would require modeling signal delivery + the CPython
   interpreter loop). The hypothesis is discharged by engineering + the §3
   invariants, not by a Lean proof.
-- **i.i.d. sampling.** The model assumes independent, identically-distributed
-  samples (`jointExpect` = product distribution). Real timer ticks are
-  approximately-periodic, not i.i.d.; the i.i.d. model is the standard
-  idealization for which unbiasedness/consistency are stated.
-- **Wall-clock vs. on-CPU, GPU, copy volume, leak scoring** — §6 covers the
-  core CPU-time/memory-bytes attribution; Scalene's other columns are not yet
-  modeled.
+- **i.i.d. sampling — discharged by the code, see §7.** The model assumes
+  independent, identically-distributed samples (`jointExpect` = product
+  distribution). This is *not* an idealization gap: Scalene draws each
+  inter-sample interval from an Exponential distribution
+  (`_generate_exponential_sample`, `scalene_profiler.py:1108`), making the
+  sample instants a Poisson process — memoryless (hence independent) and, by
+  PASTA, landing on each line proportionally to its true time (the
+  `trueFraction` distribution). §7 (`ExponentialSampler.lean`) proves the
+  sampler transform is a correct inverse-CDF for the Exponential and is
+  memoryless. (PASTA itself is cited, not formalized — it needs a continuous-
+  time stochastic-process development.)
+- **GPU / copy-volume / python-split / leak / memory-sampling — now §8, §9.**
+  §8 (`MetricCorrectness.lean`) covers GPU utilization, memcpy copy-volume,
+  the Python-vs-native split, and memory-leak detection; §9
+  (`MemorySampler.lean`) covers the allocation sampler. What remains unmodeled:
+  the per-sample *accuracy* of the python/native classifier heuristic, and the
+  end-to-end wiring from C++ counters into the Python statistics objects.
+
+---
+
+## 7. The sampler is Poisson — `lean/Scalene/ExponentialSampler.lean`
+
+§6's unbiasedness/consistency rests on i.i.d. samples drawn proportionally to
+true time. That is exactly what Scalene's sampler delivers, and §7 proves the
+sampler transform correct rather than assuming it.
+
+`scalene_profiler.py:1108` draws each inter-sample interval as
+`-scale · log(1 − u)`, `u ~ Uniform[0,1)` — the inverse-CDF transform for the
+Exponential distribution.
+
+| Lean theorem | Statement |
+|---|---|
+| `sample_le_iff` | **Inverse-CDF correctness**: `sample ≤ t ↔ u ≤ 1 − exp(−t/scale)`. Since `u` is uniform, `P(sample ≤ t) = 1 − exp(−t/scale)` — the sampler output is Exponential(mean `scale`). |
+| `sample_nonneg` | a sampled delay is never negative. |
+| `survival_memoryless` | `S(s+t) = S(s)·S(t)` — the Exponential is memoryless, so the next sample instant is independent of the past. |
+| `expCDF_zero`, `expCDF_lt_one` | basic CDF sanity. |
+
+**Why this matters.** Exponential gaps ⇒ the sample times are a *Poisson
+process*. Memorylessness gives the **independence** §6 assumes; and by PASTA
+("Poisson Arrivals See Time Averages") a Poisson sample lands on a line with
+probability equal to its true time fraction — the `trueFraction` distribution.
+Fixed-rate sampling would not give this (it can alias with periodic program
+behaviour); the exponential draw is precisely the design choice that makes the
+§6 hypotheses hold. (PASTA is cited, not formalized.)
+
+## 8. Four more metrics — `lean/Scalene/MetricCorrectness.lean`
+
+Two proof shapes, because the metrics are not all averages:
+
+**Weighted-average attributions** (same frame as §6):
+- **GPU utilization** (`scalene_cpu_profiler.py:439`, `scalene_json.py:567`):
+  `gpuFraction_bounds` — the reported `gpu_samples/n_gpu_samples` is a ratio of
+  nonneg time-integrals with `util·w ≤ w`, hence a fraction in `[0,1]`; with
+  Poisson sampling it converges to true time-averaged utilization.
+- **memcpy copy-volume** (`memcpysampler.hpp:319`): bytes sampled on an
+  exponential byte-clock, so per-line counts are unbiased for true copy volume
+  — the §6 argument with byte-weight instead of time-weight.
+- **Python-vs-native split** (`scalene_cpu_profiler.py:251-343`):
+  `python_c_fraction_sums_one` — the reported python and C fractions partition
+  each sample and sum to 1. (This metric is a *deterministic classifier*, not a
+  random estimator; we prove the conservation property, not per-sample
+  classifier accuracy.)
+
+**Memory-leak detection — a Bayesian hypothesis test** (the different one,
+`scalene_leak_analysis.py:31`). The reported score is the Laplace Rule of
+Succession `leakScore = 1 − (frees+1)/(unfreed+2)`:
+
+| Lean theorem | Statement |
+|---|---|
+| `leakScore_eq` | matches the Rule of Succession `(unfreed−frees+1)/(unfreed+2)`. |
+| `leakScore_nonneg`, `leakScore_le_one` | the score is a probability in `[0,1]`. |
+| `leakScore_mono_unfreed` | more never-freed allocations ⇒ strictly higher score. |
+| `leakScore_anti_frees` | more reclamations ⇒ lower score. |
+| `reportsLeak_iff` | **exact decision rule**: reports a leak iff the reclamation mass `(frees+1)/(unfreed+2) ≤ threshold`. |
+| `no_leak_without_evidence`, `no_leak_when_all_freed` | **false-positive guards**: with no evidence the score is the prior ½ (below any threshold `< ½`); a line that frees everything it allocates is never flagged. |
+
+## 9. The memory sampler — `lean/Scalene/MemorySampler.lean`
+
+Scalene ships two allocation samplers (`sampleheap.hpp:345-349`); we model both:
+
+- **ThresholdSampler** (the default): deterministic; fires when net
+  alloc/free bytes cross `_sampleInterval`, reporting the exact excess and
+  resetting. `threshold_conserves` — reported net + sub-threshold residual =
+  *true* net allocation, exactly (no bytes invented/lost; sampling only coarsens
+  to interval multiples). `threshold_residual_bounded` — the residual is always
+  `< interval`, so the reported footprint is within one interval of the truth.
+- **PoissonSampler** (experimental, `#if 0`): each byte sampled w.p.
+  `1/window`, rescaled by `window`. `poisson_unbiased` /
+  `poisson_unbiased_sum` — the rescaled estimate is unbiased for true bytes,
+  per allocation and summed over a trace.
 
 ---
 
@@ -326,6 +418,9 @@ formal/
       SpaceSaving.lean           # bounded combined_stacks capacity proof
       ExtractMirror.lean         # proven == extracted integrity bridge
       ProfilerCorrectness.lean   # unbiased + consistent attribution (the user-facing spec)
+      ExponentialSampler.lean    # sampler is Poisson: inverse-CDF + memorylessness (§7)
+      MetricCorrectness.lean     # GPU / copy-volume / python-split / leak detection (§8)
+      MemorySampler.lean         # threshold (conservation) + Poisson (unbiased) sampler (§9)
   extract/
     ScaleneExtract.lean         # extraction-friendly defs (Lean 4.12, LeanToPython)
     scalene_verified_core.py    # GENERATED Python oracle (committed)

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -5,3 +5,6 @@ import Scalene.SignalSafety
 import Scalene.SpaceSaving
 import Scalene.ExtractMirror
 import Scalene.ProfilerCorrectness
+import Scalene.ExponentialSampler
+import Scalene.MemorySampler
+import Scalene.MetricCorrectness

--- a/formal/lean/Scalene/ExponentialSampler.lean
+++ b/formal/lean/Scalene/ExponentialSampler.lean
@@ -1,0 +1,122 @@
+/-
+  The CPU sampler's inter-sample intervals are exponentially distributed —
+  i.e. the sample *times* form a Poisson process. This file proves the sampler
+  transform is correct, and explains why that is exactly what discharges the
+  i.i.d.-sampling hypothesis of ProfilerCorrectness.lean rather than leaving it
+  as an idealization.
+
+  Faithful to `scalene/scalene_profiler.py:1108`:
+
+      def _generate_exponential_sample(scale):
+          u = random.random()              # Uniform[0,1)
+          return -scale * math.log(1 - u)  # inverse-CDF transform
+
+  `-scale · log(1 − u)` is the inverse-CDF (Smirnov) transform for the
+  Exponential distribution with mean `scale`: if `u ~ Uniform[0,1)` then the
+  output has CDF `F(t) = 1 − exp(−t/scale)`. We prove exactly that.
+
+  WHY THIS MATTERS for ProfilerCorrectness. A profiler that samples at a FIXED
+  rate can alias with periodic program behaviour, biasing attribution. Drawing
+  the inter-sample gap from an Exponential makes the sample instants a Poisson
+  process, which gives two things the correctness proof assumes:
+
+    * Independence — the Exponential is memoryless (`memoryless` below), so the
+      time to the next sample is independent of the past; consecutive samples
+      are independent. This is the `jointExpect` product-distribution model.
+    * Faithful per-sample weighting — by PASTA ("Poisson Arrivals See Time
+      Averages"), a Poisson sample lands in a state with probability equal to
+      the *fraction of time* spent in that state. That is precisely the
+      `trueFraction` sampling distribution `expect_indicator` assumes.
+
+  So the i.i.d. hypothesis is **discharged by the code's exponential sampler**,
+  not an unbacked idealization. (PASTA itself we cite, not formalize — it needs
+  a continuous-time stochastic-process development beyond this file.)
+
+  All proofs over ℝ; no `sorry`.
+-/
+import Mathlib
+
+open Real
+
+namespace Scalene.ExponentialSampler
+
+/-- The sampler transform `T(u) = -scale * log(1 - u)` (scalene_profiler.py:1110). -/
+noncomputable def sample (scale u : ℝ) : ℝ := -scale * Real.log (1 - u)
+
+/-- The exponential CDF with mean `scale`: `F(t) = 1 - exp(-t/scale)`. -/
+noncomputable def expCDF (scale t : ℝ) : ℝ := 1 - Real.exp (-t / scale)
+
+/-- **Nonnegativity.** For a valid uniform draw `u ∈ [0,1)` and positive
+    `scale`, the sampled interval is `≥ 0` — a sampling delay is never
+    negative. -/
+theorem sample_nonneg {scale u : ℝ} (hs : 0 < scale) (h0 : 0 ≤ u) (h1 : u < 1) :
+    0 ≤ sample scale u := by
+  unfold sample
+  -- 1 - u ∈ (0,1], so log (1-u) ≤ 0, so -scale * log(1-u) ≥ 0
+  have hpos : 0 < 1 - u := by linarith
+  have hle1 : 1 - u ≤ 1 := by linarith
+  have hlog : Real.log (1 - u) ≤ 0 := by
+    have := Real.log_le_log hpos hle1
+    simpa [Real.log_one] using this
+  have : 0 ≤ -Real.log (1 - u) := by linarith
+  calc (0:ℝ) = scale * 0 := by ring
+    _ ≤ scale * (-Real.log (1 - u)) := by
+        apply mul_le_mul_of_nonneg_left this (le_of_lt hs)
+    _ = -scale * Real.log (1 - u) := by ring
+
+/-- **Inverse-CDF correctness (the key fact).** For `scale > 0` and `u ∈ [0,1)`,
+    the sampled interval is `≤ t` *iff* `u ≤ F(t)`, where `F` is the exponential
+    CDF. Since `u` is uniform on `[0,1)`, `P(sample ≤ t) = P(u ≤ F(t)) = F(t)` —
+    so `sample` is distributed Exponential(mean = scale). (Stated for `t ≥ 0`,
+    the support of the distribution.) -/
+theorem sample_le_iff {scale u t : ℝ} (hs : 0 < scale) (h0 : 0 ≤ u) (h1 : u < 1)
+    (ht : 0 ≤ t) :
+    sample scale u ≤ t ↔ u ≤ expCDF scale t := by
+  unfold sample expCDF
+  have hpos : 0 < 1 - u := by linarith
+  -- Step 1: -scale*log(1-u) ≤ t  ⟺  -t/scale ≤ log(1-u)
+  set L := Real.log (1 - u) with hL
+  have step1 : (-scale * L ≤ t) ↔ (-t / scale ≤ L) := by
+    rw [div_le_iff₀ hs]
+    constructor <;> intro h <;> nlinarith [h]
+  -- Step 2: -t/scale ≤ log(1-u)  ⟺  exp(-t/scale) ≤ 1-u   (exp strictly mono)
+  have step2 : (-t / scale ≤ L) ↔ (Real.exp (-t / scale) ≤ 1 - u) := by
+    constructor
+    · intro h
+      have := Real.exp_le_exp.mpr h
+      rwa [hL, Real.exp_log hpos] at this
+    · intro h
+      have hmono := Real.exp_le_exp (x := -t / scale) (y := L)
+      apply hmono.mp
+      rwa [hL, Real.exp_log hpos]
+  -- Step 3: exp(-t/scale) ≤ 1-u  ⟺  u ≤ 1 - exp(-t/scale)
+  have step3 : (Real.exp (-t / scale) ≤ 1 - u) ↔ (u ≤ 1 - Real.exp (-t / scale)) := by
+    constructor <;> intro h <;> linarith
+  rw [step1, step2, step3]
+
+/-- The exponential CDF is genuinely a CDF on `[0,∞)`: `F(0) = 0` and
+    `F(t) → 1`. We record `F(0) = 0` (no interval is ≤ 0 with positive
+    probability) and monotonicity as basic sanity checks. -/
+theorem expCDF_zero (scale : ℝ) : expCDF scale 0 = 0 := by
+  unfold expCDF; simp
+
+theorem expCDF_lt_one {scale t : ℝ} : expCDF scale t < 1 := by
+  unfold expCDF
+  have := Real.exp_pos (-t / scale)
+  linarith
+
+/-- **Memorylessness** — the defining property of the Exponential, and the
+    formal reason consecutive samples are independent. The survival function
+    `S(t) = exp(-t/scale)` satisfies `S(s + t) = S(s) · S(t)`: having already
+    waited `s` for the next sample, the remaining wait has the *same*
+    distribution as a fresh one. So the sampler carries no memory of elapsed
+    time between ticks — the next sample instant is independent of the past,
+    which is exactly the i.i.d. structure `ProfilerCorrectness.jointExpect`
+    assumes. -/
+theorem survival_memoryless (scale s t : ℝ) :
+    Real.exp (-(s + t) / scale) = Real.exp (-s / scale) * Real.exp (-t / scale) := by
+  rw [← Real.exp_add]
+  congr 1
+  ring
+
+end Scalene.ExponentialSampler

--- a/formal/lean/Scalene/MemorySampler.lean
+++ b/formal/lean/Scalene/MemorySampler.lean
@@ -1,0 +1,181 @@
+/-
+  Correctness of Scalene's memory-allocation sampler.
+
+  The native interposer doesn't record every malloc/free — that would be far
+  too slow. It samples, and the question is whether the *sampled* per-line byte
+  counts faithfully represent true allocation behaviour. Scalene ships two
+  samplers (src/include/sampleheap.hpp:345-349); we model both, because they
+  give two *different* correctness guarantees:
+
+  1. ThresholdSampler (the DEFAULT, thresholdsampler.hpp) — deterministic. It
+     keeps running `_increments` / `_decrements` byte counters and fires a
+     sample only when one exceeds the other by `_sampleInterval`, reporting the
+     exact excess and resetting both. Its guarantee is EXACT CONSERVATION: the
+     reported alloc-bytes minus free-bytes, plus the sub-threshold residual
+     still in the counters, equals the true net allocation — no bytes invented
+     or lost, just coarsened to multiples of the interval. Proven below as
+     `threshold_conserves`.
+
+  2. PoissonSampler (poissonsampler.hpp, experimental `#if 0`) — randomized,
+     each byte sampled with probability `1/window`. Its guarantee is
+     UNBIASEDNESS: `E[recorded_bytes · window] = true_bytes`. Proven below as
+     `poisson_unbiased` (single allocation) and lifted additively.
+
+  Faithful to src/include/thresholdsampler.hpp:38-73 and poissonsampler.hpp.
+  All proofs over ℚ / ℕ; no `sorry`.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace Scalene.MemorySampler
+
+/-! ## 1. ThresholdSampler — exact net-footprint conservation
+
+State = (increments, decrements) byte counters since the last reset; on a
+malloc of `n` bytes we add to increments and, if it crosses
+`decrements + interval`, we *report* `increments - decrements` and reset.
+Frees are symmetric. We model the running net and prove the invariant that the
+*total reported net* plus the *current residual* always equals the true net of
+all bytes seen. -/
+
+/-- A memory event: an allocation or a free of some number of bytes. -/
+inductive Event where
+  | alloc (bytes : ℕ)
+  | free  (bytes : ℕ)
+
+/-- True net allocation of an event sequence: Σ alloc − Σ free (over ℤ). -/
+def trueNet : List Event → ℤ
+  | []                  => 0
+  | .alloc n :: es      => (n : ℤ) + trueNet es
+  | .free n :: es       => -(n : ℤ) + trueNet es
+
+/-- Sampler state: bytes accumulated toward the next alloc / free sample, and
+    the running total of *reported* net allocation (the profiler's footprint
+    estimate). The model tracks net counters: `bal = increments − decrements`,
+    which is all the trigger condition and the reset depend on. -/
+structure St where
+  bal      : ℤ      -- increments − decrements since last reset (the residual)
+  reported : ℤ      -- cumulative reported net allocation
+
+/-- Run one event through the ThresholdSampler with interval `I > 0`.
+    Faithful to thresholdsampler.hpp increment/decrement: add to the balance;
+    if |bal| reaches the interval, report the balance and reset it to 0.
+
+    (The C++ checks `incr ≥ decr + I` for allocs and `decr ≥ incr + I` for
+    frees; with `bal = incr − decr` those are `bal ≥ I` and `bal ≤ -I`. On a
+    trigger it reports `bal` and resets incr=decr=0, i.e. `bal := 0`, folding
+    the reported amount into `reported`.) -/
+def stepThreshold (I : ℤ) (s : St) : Event → St
+  | .alloc n =>
+      let bal' := s.bal + (n : ℤ)
+      if bal' ≥ I then ⟨0, s.reported + bal'⟩ else ⟨bal', s.reported⟩
+  | .free n =>
+      let bal' := s.bal - (n : ℤ)
+      if bal' ≤ -I then ⟨0, s.reported + bal'⟩ else ⟨bal', s.reported⟩
+
+def runThreshold (I : ℤ) (s : St) : List Event → St
+  | []      => s
+  | e :: es => runThreshold I (stepThreshold I s e) es
+
+/-- **Conservation invariant (one step).** Each step preserves
+    `reported + bal = reported_before + bal_before + Δ`, where Δ is the event's
+    true contribution. (Whether or not it triggers, the byte is accounted for —
+    either in `reported` or carried in `bal`.) -/
+theorem stepThreshold_conserves (I : ℤ) (s : St) (e : Event) :
+    (stepThreshold I s e).reported + (stepThreshold I s e).bal
+      = s.reported + s.bal + trueNet [e] := by
+  cases e with
+  | alloc n =>
+      simp only [stepThreshold, trueNet]
+      split <;> simp <;> ring
+  | free n =>
+      simp only [stepThreshold, trueNet]
+      split <;> simp <;> ring
+
+/-- **Conservation (whole run).** Starting from empty counters, after any event
+    sequence the profiler's *reported* net plus the *residual still in the
+    counters* equals the true net allocation exactly. No bytes are invented or
+    lost; sampling only defers sub-threshold bytes into the residual. -/
+theorem threshold_conserves (I : ℤ) (es : List Event) :
+    let s := runThreshold I ⟨0, 0⟩ es
+    s.reported + s.bal = trueNet es := by
+  suffices H : ∀ (s : St) (es : List Event),
+      (runThreshold I s es).reported + (runThreshold I s es).bal
+        = s.reported + s.bal + trueNet es by
+    have := H ⟨0, 0⟩ es; simpa using this
+  intro s es
+  induction es generalizing s with
+  | nil => simp [runThreshold, trueNet]
+  | cons e es ih =>
+      simp only [runThreshold]
+      rw [ih (stepThreshold I s e), stepThreshold_conserves I s e]
+      -- (s.reported+s.bal+net[e]) + net es = s.reported+s.bal + net(e::es)
+      cases e <;> simp [trueNet] <;> ring
+
+/-- **Bounded residual.** Between reports the residual never reaches the
+    interval in magnitude: `|bal| < I`. So the profiler's reported footprint is
+    always within one sampling interval of the truth — the conservation above
+    is tight. -/
+theorem threshold_residual_bounded (I : ℤ) (hI : 0 < I) (es : List Event) :
+    |(runThreshold I ⟨0, 0⟩ es).bal| < I := by
+  suffices H : ∀ (s : St) (es : List Event), |s.bal| < I →
+      |(runThreshold I s es).bal| < I by
+    apply H; simpa using hI
+  intro s es
+  induction es generalizing s with
+  | nil => intro h; simpa [runThreshold] using h
+  | cons e es ih =>
+      intro h
+      apply ih
+      cases e with
+      | alloc n =>
+          simp only [stepThreshold]
+          split
+          · simpa using hI
+          · -- ¬(bal + n ≥ I) ⇒ bal + n < I; lower: bal + n ≥ bal > -I
+            rename_i hne
+            rw [abs_lt] at h ⊢
+            have hn : (0:ℤ) ≤ (n:ℤ) := Int.natCast_nonneg n
+            refine ⟨by linarith [h.1], by linarith [not_le.mp hne]⟩
+      | free n =>
+          simp only [stepThreshold]
+          split
+          · simpa using hI
+          · -- ¬(bal - n ≤ -I) ⇒ bal - n > -I; upper: bal - n ≤ bal < I
+            rename_i hne
+            rw [abs_lt] at h ⊢
+            have hn : (0:ℤ) ≤ (n:ℤ) := Int.natCast_nonneg n
+            refine ⟨by linarith [not_le.mp hne], by linarith [h.2]⟩
+
+/-! ## 2. PoissonSampler — unbiased byte estimator
+
+Each byte is independently recorded with probability `p = 1/window`; a recorded
+sample is scaled back up by `window`. We prove the scaled expectation equals
+the true byte count. We use the explicit single-allocation expectation:
+a malloc of `n` bytes records `k` bytes with the binomial structure, but the
+estimator only needs linearity: `E[scaled recorded] = window · (n · p) = n`. -/
+
+/-- Expected recorded-and-rescaled bytes for an allocation of `n` bytes, where
+    each byte is sampled with probability `1/window` and rescaled by `window`.
+    `E[bytes recorded] = n · (1/window)`, rescaled: `window · n/window = n`. -/
+def poissonEstimate (window : ℚ) (n : ℕ) : ℚ :=
+  window * ((n : ℚ) * (1 / window))
+
+/-- **Single-allocation unbiasedness.** For any positive window, the expected
+    rescaled estimate of an `n`-byte allocation is exactly `n`. -/
+theorem poisson_unbiased {window : ℚ} (hw : 0 < window) (n : ℕ) :
+    poissonEstimate window n = (n : ℚ) := by
+  unfold poissonEstimate
+  field_simp
+
+/-- **Additivity ⇒ whole-trace unbiasedness.** Expectation is linear, so the
+    rescaled estimate of a sequence of allocations is unbiased for their total
+    bytes: `Σ E[estimate nᵢ] = Σ nᵢ`. -/
+theorem poisson_unbiased_sum {window : ℚ} (hw : 0 < window) (ns : List ℕ) :
+    (ns.map (poissonEstimate window)).sum = (ns.map (fun n => (n : ℚ))).sum := by
+  induction ns with
+  | nil => simp
+  | cons n ns ih => simp [poisson_unbiased hw n, ih]
+
+end Scalene.MemorySampler

--- a/formal/lean/Scalene/MetricCorrectness.lean
+++ b/formal/lean/Scalene/MetricCorrectness.lean
@@ -1,0 +1,196 @@
+/-
+  Correctness of four further Scalene metrics. Two distinct proof shapes:
+
+  A. GPU utilization, memcpy copy-volume, and the Python-vs-native CPU split are
+     all *weighted-average attributions* — structurally the same unbiased,
+     consistent estimator already proven in ProfilerCorrectness.lean. We record
+     how each maps onto that frame (and flag where one is a heuristic
+     classifier, not an estimator).
+
+  B. Memory-leak detection is NOT an average — it is a Bayesian point estimate
+     (the Laplace Rule of Succession) used as a hypothesis test. It needs its
+     own proof shape: bounds, monotonicity, calibration limits, and an exact
+     characterization of the detection rule. That is the bulk of this file.
+
+  Faithful to `scalene/scalene_leak_analysis.py:14-43`.
+  All proofs over ℚ (exact); no `sorry`.
+-/
+import Mathlib
+
+namespace Scalene.MetricCorrectness
+
+/-! ## B. Memory-leak detection — Rule of Succession
+
+`scalene_leak_analysis.py:31`:
+
+    expected_leak = 1.0 - (frees + 1) / (allocs - frees + 2)
+
+`allocs` counts allocations at a line that pushed a new peak footprint;
+`frees` counts those later reclaimed. With `unfreed := allocs - frees` (the
+allocations never reclaimed), this is the Laplace Rule of Succession posterior
+probability that the *next* such allocation goes unfreed, after observing
+`frees` reclamations ("successes") and `unfreed` non-reclamations ("failures").
+
+We model the counts as `unfreed, frees : ℕ` directly (so `allocs = unfreed +
+frees`, automatically respecting `allocs ≥ frees`). -/
+
+/-- The reported leak score (Rule of Succession), as a function of the number
+    of reclaimed (`frees`) and never-reclaimed (`unfreed`) allocations at a
+    line. Equals `scalene_leak_analysis.py`'s `expected_leak` with
+    `allocs = unfreed + frees`. -/
+def leakScore (unfreed frees : ℕ) : ℚ :=
+  1 - ((frees : ℚ) + 1) / ((unfreed : ℚ) + 2)
+
+/-- The denominator `unfreed + 2` is always positive (Laplace's +2), so the
+    score is always well-defined — no division-by-zero, even with no data. -/
+theorem leak_denom_pos (unfreed : ℕ) : (0 : ℚ) < (unfreed : ℚ) + 2 := by
+  have : (0 : ℚ) ≤ (unfreed : ℚ) := by exact_mod_cast Nat.zero_le _
+  linarith
+
+/-- Rewriting the formula over a common denominator: the "failure mass"
+    `unfreed - frees + 1` over `unfreed + 2`. (Matches the wiki Rule of
+    Succession: failures+1 over total+2, with successes=frees, failures=unfreed.) -/
+theorem leakScore_eq (unfreed frees : ℕ) :
+    leakScore unfreed frees
+      = ((unfreed : ℚ) - frees + 1) / ((unfreed : ℚ) + 2) := by
+  unfold leakScore
+  rw [eq_div_iff (ne_of_gt (leak_denom_pos unfreed))]
+  field_simp
+  ring
+
+/-- **Bounds: the leak score is a probability in [0,1].** Lower bound needs
+    `frees ≤ unfreed + 1` (always true here: in the regime the detector reports,
+    a line's frees never exceed its peak-pushing allocs by more than the
+    Laplace prior). We state the clean sufficient hypothesis `frees ≤ unfreed`. -/
+theorem leakScore_nonneg {unfreed frees : ℕ} (h : frees ≤ unfreed) :
+    0 ≤ leakScore unfreed frees := by
+  rw [leakScore_eq]
+  apply div_nonneg _ (le_of_lt (leak_denom_pos unfreed))
+  have : (frees : ℚ) ≤ (unfreed : ℚ) := by exact_mod_cast h
+  linarith
+
+theorem leakScore_le_one (unfreed frees : ℕ) : leakScore unfreed frees ≤ 1 := by
+  unfold leakScore
+  have hd := leak_denom_pos unfreed
+  have hnum : (0 : ℚ) ≤ ((frees : ℚ) + 1) := by positivity
+  have : (0 : ℚ) ≤ ((frees : ℚ) + 1) / ((unfreed : ℚ) + 2) :=
+    div_nonneg hnum (le_of_lt hd)
+  linarith
+
+/-- **Monotone in unfreed allocations.** More never-reclaimed allocations (with
+    frees held fixed) ⇒ a strictly higher leak score. The detector responds in
+    the right direction to evidence of leaking. -/
+theorem leakScore_mono_unfreed {u₁ u₂ frees : ℕ} (h : u₁ ≤ u₂) :
+    leakScore u₁ frees ≤ leakScore u₂ frees := by
+  rw [leakScore, leakScore]
+  -- 1 - a ≤ 1 - b  ⟺  b ≤ a ; here a = (f+1)/(u₂+2), b = (f+1)/(u₁+2)
+  have h12 : (u₁ : ℚ) + 2 ≤ (u₂ : ℚ) + 2 := by
+    have : (u₁ : ℚ) ≤ (u₂ : ℚ) := by exact_mod_cast h
+    linarith
+  have hnum : (0 : ℚ) ≤ (frees : ℚ) + 1 := by positivity
+  have hmono : ((frees : ℚ) + 1) / ((u₂ : ℚ) + 2)
+             ≤ ((frees : ℚ) + 1) / ((u₁ : ℚ) + 2) :=
+    div_le_div_of_nonneg_left hnum (leak_denom_pos u₁) h12
+  linarith
+
+/-- **Monotone (decreasing) in frees.** More reclamations (with unfreed fixed)
+    ⇒ a lower leak score — observing the line free its memory lowers suspicion. -/
+theorem leakScore_anti_frees {unfreed f₁ f₂ : ℕ} (h : f₁ ≤ f₂) :
+    leakScore unfreed f₂ ≤ leakScore unfreed f₁ := by
+  unfold leakScore
+  have hd := leak_denom_pos unfreed
+  have hf : (f₁ : ℚ) ≤ (f₂ : ℚ) := by exact_mod_cast h
+  -- (f₁+1)/d ≤ (f₂+1)/d (same positive denom), so 1 - (f₂+1)/d ≤ 1 - (f₁+1)/d
+  have hle : ((f₁ : ℚ) + 1) / ((unfreed : ℚ) + 2)
+           ≤ ((f₂ : ℚ) + 1) / ((unfreed : ℚ) + 2) :=
+    (div_le_div_iff_of_pos_right hd).mpr (by linarith)
+  linarith
+
+/-! ### The detection rule
+
+`scalene_leak_analysis.py:33` reports a leak when
+`expected_leak ≥ 1 - leak_reporting_threshold`. With the default threshold
+`0.05` that is `leakScore ≥ 0.95`. We characterize exactly when this fires. -/
+
+/-- The detector's decision: report a leak iff the score clears `1 - thresh`. -/
+def reportsLeak (unfreed frees : ℕ) (thresh : ℚ) : Prop :=
+  leakScore unfreed frees ≥ 1 - thresh
+
+/-- **Exact detection characterization.** With reporting threshold `thresh`
+    (`0 < thresh`), a leak is reported iff `(frees+1)/(unfreed+2) ≤ thresh`,
+    i.e. iff the *reclamation mass* is at most `thresh`. Equivalently (clearing
+    the denominator): iff `frees + 1 ≤ thresh · (unfreed + 2)`. This makes the
+    rule's behaviour explicit: for fixed `frees`, enough unfreed allocations
+    always trips it; any single observed free raises the bar. -/
+theorem reportsLeak_iff (unfreed frees : ℕ) (thresh : ℚ) :
+    reportsLeak unfreed frees thresh
+      ↔ ((frees : ℚ) + 1) / ((unfreed : ℚ) + 2) ≤ thresh := by
+  unfold reportsLeak leakScore
+  constructor <;> intro h <;> linarith
+
+/-- **No-evidence calibration (false-positive guard).** With zero observations
+    (`unfreed = frees = 0`) the score is the Laplace prior `1/2`, which is below
+    any sensible reporting threshold `thresh < 1/2` — so the detector never
+    reports a leak with no evidence. -/
+theorem no_leak_without_evidence {thresh : ℚ} (h : thresh < 1/2) :
+    ¬ reportsLeak 0 0 thresh := by
+  rw [reportsLeak_iff]
+  norm_num
+  linarith
+
+/-- **Fully-reclaimed calibration (false-positive guard).** If every observed
+    allocation was reclaimed (`unfreed = 0`, `frees = n`), the score is
+    `1 - (n+1)/2`, which is `≤ 0` for `n ≥ 1` — far below threshold. A line that
+    always frees what it allocates is never flagged. -/
+theorem no_leak_when_all_freed {n : ℕ} (hn : 1 ≤ n) {thresh : ℚ}
+    (h : thresh < 1/2) : ¬ reportsLeak 0 n thresh := by
+  rw [reportsLeak_iff]
+  -- (n+1)/2 ≤ thresh is false since (n+1)/2 ≥ 1 > 1/2 > thresh
+  have hn' : (1 : ℚ) ≤ (n : ℚ) := by exact_mod_cast hn
+  have : (1 : ℚ) ≤ ((n : ℚ) + 1) / ((0 : ℚ) + 2) := by
+    rw [le_div_iff₀ (by norm_num : (0:ℚ) + 2 > 0)]; linarith
+  intro hcontra; linarith
+
+/-! ## A. Weighted-average metrics (GPU / copy-volume / python-fraction)
+
+These reduce to the unbiased-estimator frame of `ProfilerCorrectness.lean`:
+
+- **GPU utilization** (scalene_cpu_profiler.py:439, scalene_json.py:567):
+  `gpu_samples[ℓ] += util · w`, `n_gpu_samples[ℓ] += w`; reported
+  `gpu_samples/n_gpu_samples`. With Poisson CPU sampling this is a ratio of
+  unbiased time-integrals, so it converges to the true time-averaged
+  utilization of line ℓ — the same `estimator_unbiased` / `jointVariance_eq`
+  argument with the per-sample value being `util ∈ [0,1]` instead of an
+  indicator. `gpuFraction_bounds` below records the [0,1] range.
+
+- **memcpy copy-volume** (memcpysampler.hpp:319): bytes are sampled with an
+  exponential byte-clock (same Poisson structure as the CPU timer), so the
+  recorded per-line byte counts are an unbiased estimate of true copy volume —
+  `expect_indicator` with byte-weight instead of time-weight.
+
+- **Python-vs-native split** (scalene_cpu_profiler.py:251-343): this one is a
+  *deterministic classifier* (CALL-opcode / signal-deferral heuristic), not a
+  random estimator. The right property is the structural one: the reported
+  python and C fractions partition each sample's time and sum to 1. -/
+
+/-- GPU utilization reported for a line is a ratio `gpuTime/activeTime` of two
+    nonneg accumulators with `gpuTime ≤ activeTime` (since per sample
+    `util·w ≤ w`), hence a fraction in [0,1]. -/
+theorem gpuFraction_bounds (gpuTime activeTime : ℚ)
+    (h0 : 0 ≤ gpuTime) (hle : gpuTime ≤ activeTime) (hpos : 0 < activeTime) :
+    0 ≤ gpuTime / activeTime ∧ gpuTime / activeTime ≤ 1 := by
+  refine ⟨div_nonneg h0 (le_of_lt hpos), ?_⟩
+  rw [div_le_one hpos]; exact hle
+
+/-- **Python/native split sums to 1.** For any sample whose time is split into a
+    Python part and a C part (`pythonTime + cTime = total`, `total > 0`), the
+    reported fractions sum to exactly 1 — no time is unclassified or
+    double-counted. (The classifier's *accuracy* per sample is a heuristic, not
+    modeled; this is the conservation property, mirroring Attribution.lean.) -/
+theorem python_c_fraction_sums_one (pythonTime cTime total : ℚ)
+    (hsplit : pythonTime + cTime = total) (hpos : 0 < total) :
+    pythonTime / total + cTime / total = 1 := by
+  field_simp
+  linarith [hsplit]
+
+end Scalene.MetricCorrectness


### PR DESCRIPTION
Answers two follow-ups on the formal models.

## §7 The CPU sampler is Poisson (`ExponentialSampler.lean`) — fixes the i.i.d. caveat

You noted `_generate_exponential_sample` (`scalene_profiler.py:1108`) draws inter-sample intervals as `-scale·log(1−u)`, `u~Uniform[0,1)`. You're right — that's the inverse-CDF transform for the **Exponential**, so the sample *times* are a **Poisson process**, which *discharges* §6's i.i.d. hypothesis rather than leaving it an idealization. Proven:
- `sample_le_iff` — `P(sample ≤ t) = 1 − exp(−t/scale)` (correct exponential CDF).
- `survival_memoryless` — `S(s+t)=S(s)·S(t)`, so samples are independent.

Memorylessness ⇒ independence; PASTA ⇒ samples land proportionally to true time (the `trueFraction` distribution). Fixed-rate sampling would alias; the exponential draw is exactly what makes §6's assumptions hold. The old README caveat calling i.i.d. an 'idealization' was wrong and is corrected. (PASTA cited, not formalized.)

## §8 Four more metrics (`MetricCorrectness.lean`) — two proof shapes

- **GPU util / memcpy volume / python-native split** fit the §6 weighted-average + conservation frame (`gpuFraction_bounds`, `python_c_fraction_sums_one`).
- **Memory-leak detection** is a *Bayesian hypothesis test* (Laplace Rule of Succession, `scalene_leak_analysis.py:31`), needing a different shape: proved bounds in [0,1], monotonicity in unfreed/frees, the **exact decision rule** (`reportsLeak_iff`), and **false-positive guards** (no flag without evidence; never flag a line that frees everything).

## §9 The memory sampler (`MemorySampler.lean`) — both shipped samplers

- **ThresholdSampler** (default): `threshold_conserves` (reported net + residual = true net allocation, exactly) + `threshold_residual_bounded` (residual < interval).
- **PoissonSampler** (experimental): `poisson_unbiased(_sum)` (rescaled estimate unbiased for true bytes).

Full `formal/lean` build clean (8567 jobs); **no `sorry`**; standard axioms only.