### PR TITLE
Formal: literal two-counter sampler reduction + per-line attribution under sampling

### DIFF
--- a/formal/HANDOFF.md
+++ b/formal/HANDOFF.md
@@ -1,0 +1,229 @@
+# Formalizing Scalene — handoff / follow-up notes
+
+Working doc so this can be picked up after a context reset. Captures what the
+formal-verification effort has produced, the *method* (including a hard-won
+lesson), what's merged vs. open, and concrete next steps.
+
+Last updated: 2026-06-30.
+
+---
+
+## 0. The point of this effort (don't lose this framing)
+
+We formalize Scalene's guarantees in Lean 4 (+ TLA+ for interleavings) for two
+reasons, in priority order:
+
+1. **Find and fix real bugs.** Formalizing forces every implicit assumption to
+   be named. Where the code doesn't enforce what a proof needs, that's a
+   finding — a real defect or an undocumented invariant. This has already paid
+   off (two production bugs, see §4).
+2. **Establish correctness** of the properties a profiler's *user* relies on.
+
+**THE METHODOLOGICAL LESSON (most important thing in this doc):** a proof whose
+hypotheses mirror the code's *implicit* assumptions validates the **model**, not
+the **code**. Early models did exactly this and were therefore blind to real
+bugs. Example: the leak model used `unfreed, frees : ℕ` with
+`allocs = unfreed + frees`, which *hardcodes* `frees ≤ allocs` — so it could
+never have caught the unguarded divide-by-zero that assumption protects against.
+
+**Rule going forward:** treat every modeling hypothesis (`0 < total`,
+`frees ≤ allocs`, `interval > 0`, `pythonTime + cTime = total`, every
+denominator) as a *claim to verify against the implementation*. If the code
+doesn't enforce it → that's a finding, not something to assume away. Audit
+models adversarially, don't just prove them.
+
+---
+
+## 1. Where the artifacts live
+
+```
+formal/
+  README.md              # full writeup: §1–§10, source mappings, boundaries, repro
+  HANDOFF.md             # this file
+  tla/                   # TLA+ specs (model-checked with TLC)
+    SignalSafety.tla + _Fix.cfg / _Bug.cfg
+    Deadlock.tla + .cfg
+  lean/                  # Lean 4 project (lake); Mathlib dep; toolchain v4.31.0
+    Scalene.lean         # top-level: imports all modules below
+    Scalene/*.lean       # see §2
+  extract/
+    ScaleneExtract.lean          # extraction-friendly defs (built under LeanToPython, Lean 4.12)
+    scalene_verified_core.py     # GENERATED Python oracle (committed)
+tests/
+  test_verified_space_saving.py       # differential test: prod vs verified oracle
+  test_leak_velocity_zero_elapsed.py  # regression for bug #1 (§4)
+```
+
+**Build:** `cd formal/lean && lake exe cache get && lake build` (needs
+`~/.elan/bin` on PATH; Mathlib cache ~7GB, gitignored).
+**TLC:** Java + `tla2tools.jar`. Ran on the `cloudnew` box (has Java 21);
+`java -cp tla2tools.jar tlc2.TLC -config X.cfg X.tla`.
+**All Lean proofs: no `sorry`; depend only on `propext, Classical.choice,
+Quot.sound`** (verify with `#print axioms <thm>`).
+
+`cloudnew` = a Linux dev box (192 cores) reachable via `ssh cloudnew`. Used for:
+TLC model-checking (Java there), building the C++ native ext, and reproducing
+free-threaded (3.13t/3.14t) behavior. Has `~/scalene-debug` checkout + uv venvs
+`.venv-313t` / `.venv-314t`, and `~/tla/tla2tools.jar`. LeanToPython checkout is
+at `/tmp/LeanToPython` locally (Lean 4.12).
+
+---
+
+## 2. What's proven (Lean modules) — each maps to real code in README
+
+| Module | Property | Key theorems |
+|---|---|---|
+| `Attribution.lean` | CPU/mem bookkeeping conserved; fractions in [0,1] | `totalTime_eq_split`, `cpu_distribution_conserved`, `pythonFraction_le_one`, `footprint_conserved` |
+| `SignalSafety.lean` | `list(...)` snapshot decouples output-iteration from concurrent inserts | `snapshot_stable`, `snapshot_sound` (no axioms) |
+| `SpaceSaving.lean` | `combined_stacks` table never exceeds capacity; evicts min | `step_withinCap`, `fold_withinCap`, `minCount_le` |
+| `ProfilerCorrectness.lean` | **headline**: reported per-line profile is unbiased + consistent | `estimator_unbiased`, `jointVariance_eq` (=p(1−p)/N), `jointExpect_pair` |
+| `ExponentialSampler.lean` | sampler is Poisson ⇒ discharges the i.i.d. hypothesis | `sample_le_iff` (inverse-CDF), `survival_memoryless` |
+| `MetricCorrectness.lean` | GPU/copy/python-split (weighted-avg) + leak detection (Bayesian test) | `gpuFraction_bounds`, `python_c_fraction_sums_one`, `leakScore_*`, `reportsLeak_iff`, `no_leak_without_evidence` |
+| `MemorySampler.lean` | threshold sampler conserves net exactly; Poisson unbiased; **two-counter bisimulation** | `threshold_conserves`, `threshold_residual_bounded`, `threshold2_conserves`, `step_bisim`, `poisson_unbiased` |
+| `PerLineAttribution.lean` | per-line byte fraction faithful under sampling | `fraction_of_expectations`, `recorded_fraction_exact` |
+| `LeakTrackerAudit.lean` | proves the leak formula's *unguarded* denominator is safe (`frees ≤ allocs`) | `run_frees_le_allocs`, `denom_pos_reachable` |
+| TLA+ `SignalSafety` | the combined_stacks race is reachable (bug cfg) / impossible (fix cfg) | 4-state counterexample; 99 states clean |
+| TLA+ `Deadlock` | no deadlock; handler never blocks on a lock; output liveness | 72 states clean |
+
+The "profiler correctness" chain: **faithful per-sample attribution ⇒ unbiased,
+consistent reported profile**. Faithfulness is delivered by (a) the exponential
+sampler (§`ExponentialSampler`, Poisson + PASTA), (b) synchronous C++ stamping
+(`whereInPython`, `pywhere.cpp` — engineering, not yet Lean-proven), and (c) the
+conservation invariants (`Attribution`).
+
+---
+
+## 3. Merged to master (all green)
+
+Formal + the CI/bug work that unblocked it:
+- **#1068** formal models (TLA+ + Lean core)
+- **#1070** SpaceSaving capacity proof + proof→production extraction pipeline
+- **#1072** profiler-correctness desideratum (unbiased + consistent)
+- **#1073** regenerate oracle w/ upstream-fixed LeanToPython (dropped `min2`)
+- **#1075** Poisson sampler + GPU/copy/python-split/leak + memory-sampler
+- Enabling fixes: **#1066** (test `sys.executable` leak — the original
+  root-cause), **#1067** (combined_stacks race), **#1069/#1071/#1074** (CI
+  timing flakes), **#1065** (`_scalene_unwind` GIL declaration).
+- **emeryberger/LeanToPython#1** (MERGED): fixed two transpiler bugs
+  (Bool-param branch inversion; binary `min`/`max` operand drop) found while
+  extracting Scalene's defs. Local checkout: `/tmp/LeanToPython`.
+
+## 3b. OPEN PRs (need driving to merge)
+
+- **#1077** `fix-leak-velocity-and-sampling-window` — the two production bug
+  fixes from §4. Independent, mergeable now. (1 commit.)
+- **#1076** `formal-sampler-refinements` — two-counter bisimulation +
+  per-line attribution + `LeakTrackerAudit.lean` + README "bugs found". (2
+  commits.) Formal-only; CI failures on it are transient/flake (see §5).
+
+Merge order suggestion: #1077 first (it's the real fix), then #1076.
+
+---
+
+## 4. Bugs the formalization found (BOTH FIXED in #1077)
+
+1. **ZeroDivisionError, leak velocity.** `scalene_json.py` ~line 1255:
+   `"velocity_mb_s": leak_velocity / stats.elapsed_time` was unguarded.
+   `compute_leaks` (`scalene_leak_analysis.py`) gates on allocation *growth
+   rate*, NOT wall-clock time, so a leak can be reported when `elapsed_time`
+   is still `0.0` (sub-ms run) → crash. Sibling `elapsed_time` divides
+   (~637, ~1186) were already guarded. Fixed + regression test.
+2. **Sampling window = 0 from bad env var.** `sampleheap.hpp`:
+   `atol(getenv("SCALENE_ALLOCATION_SAMPLING_WINDOW"))` returns 0 for `"0"` /
+   unparseable → ThresholdSampler triggers on *every* alloc (`incr >= decr+0`),
+   catastrophic overhead. Violates `interval > 0` (proved necessary in
+   `MemorySampler.lean`). Fixed by clamping ≤0 to the default. Verified on
+   cloudnew: `WINDOW=0` run now completes.
+
+Third finding (no bug, but was implicit): the leak formula
+`1 − (frees+1)/(allocs−frees+2)` has NO denominator guard; safety rests on
+`frees ≤ allocs`, which is non-obvious (two separate increment sites,
+`scalene_memory_profiler.py:236` and `:401`). `LeakTrackerAudit.lean` now
+*proves* it from the single-shot armed-trigger discipline.
+
+---
+
+## 5. CI notes (so flakes don't waste a session)
+
+Matrix uses `fail-fast: true`, so one red job cancels the rest. Four wall-clock/
+signal timing flakes were hardened at the source (#1069/#1071/#1074) — parity
+contention-ratio (now non-gating), HyperLogLog hash-seed (now deterministic ints),
+`test_mac_sampler` (poll-not-sleep), `test_off_then_on_via_signal` (placeholder
+SIGILL handler + retry). Remaining transient: `vendor/libunwind` download can
+500. **When a formal-only PR shows red: check whether the failing step is
+`Build scalene` (transient download) or a known flake test — if so, just re-run
+`gh run rerun <id> --failed`.** `ubuntu-latest, 3.13t` runs ~40 min (compiles
+deps from source; no cp313t wheels) — near the 45-min cap but passes.
+
+Oracle test (`test_verified_space_saving.py`) skips on Python < 3.10 (the
+generated `X | Y` unions need 3.10+).
+
+---
+
+## 6. Known modeling gaps / caveats (be honest about these)
+
+- **Faithful sampling is assumed, not proven.** §ProfilerCorrectness proves
+  "faithful sampling ⇒ correct profile". It does NOT prove the C++ stamping
+  *establishes* faithful sampling (needs modeling signal delivery + CPython
+  loop). Discharged by engineering + §Attribution, not Lean.
+- **PASTA is cited, not formalized** (needs continuous-time stochastic-process
+  dev). It's the step connecting Poisson sampling to the `trueFraction`
+  distribution.
+- **`LeakTrackerAudit` models the increment *discipline*, not the literal
+  code.** It assumes single-shot arm/disarm; faithfulness under the sig-queue
+  thread vs. main-thread interleaving and across `fork` is NOT proven. Prime
+  next audit target — a race there could break `frees ≤ allocs`.
+- **Python/native split**: only the *conservation* (fractions sum to 1) is
+  proven, NOT the per-sample *accuracy* of the CALL-opcode/signal-deferral
+  classifier heuristic.
+- **The extraction oracle is a differential guard, not a drop-in.** Production
+  still has its own `_space_saving_increment`; the test checks they agree.
+- **C++→Python wiring** (native counters → `ScaleneStatistics`) is not modeled.
+- TLC results are bounded (`Keys={k1,k2,k3}`, `N=3`, `MaxHandler=2`) — exhaustive
+  within bounds, not a general proof.
+
+---
+
+## 7. Concrete next steps (roughly ranked)
+
+1. **Merge #1077 then #1076** (drive CI; re-run flakes per §5).
+2. **Audit `LeakTrackerAudit`'s faithfulness under concurrency/fork** — the
+   biggest remaining "assumed not proven" gap that could hide a real race
+   (§6 bullet 3). Model the sig-queue thread interleaving explicitly.
+3. **Keep auditing hypotheses adversarially** (the §0 method): every `0 <`,
+   every denominator, every counter that could underflow. The audit that found
+   §4's bugs covered the main division sites; re-run it whenever a model gains
+   a new hypothesis.
+4. **Formalize PASTA** (or at least a discrete-time analogue) to fully discharge
+   the i.i.d.→trueFraction step instead of citing it.
+5. **Prove per-sample classifier accuracy** for the python/native split, or
+   document precisely why it's a heuristic with bounded error.
+6. **Wire the verified oracle into production directly** (have
+   `_space_saving_increment` call the extracted core) rather than only
+   differential-testing it — closes the proof→production loop tighter.
+7. **Model one more column end-to-end** (e.g. GPU or copy-volume) under the
+   unbiased-estimator frame, including the C++→Python wiring.
+
+---
+
+## 8. Repro cheatsheet
+
+```bash
+# Lean (local)
+cd formal/lean && lake exe cache get && lake build          # 0 sorry
+echo 'import Scalene
+#print axioms Scalene.ProfilerCorrectness.Truth.estimator_unbiased' > /tmp/a.lean
+lake env lean /tmp/a.lean                                    # standard axioms only
+
+# TLA+ (on cloudnew, has Java)
+scp formal/tla/* cloudnew:~/tla/scalene/
+ssh cloudnew 'cd ~/tla/scalene && java -cp ~/tla/tla2tools.jar tlc2.TLC \
+  -config SignalSafety_Fix.cfg SignalSafety.tla'            # no error, 99 states
+
+# Regenerate the extracted oracle (needs /tmp/LeanToPython, Lean 4.12)
+cp formal/extract/ScaleneExtract.lean /tmp/LeanToPython/
+cd /tmp/LeanToPython && lake env lean ScaleneExtract.lean > scalene_verified_core.py
+
+# The bug-finding regression test
+python3 -m pytest tests/test_leak_velocity_zero_elapsed.py -q
+```

--- a/formal/HANDOFF.md
+++ b/formal/HANDOFF.md
@@ -82,6 +82,7 @@ at `/tmp/LeanToPython` locally (Lean 4.12).
 | `MemorySampler.lean` | threshold sampler conserves net exactly; Poisson unbiased; **two-counter bisimulation** | `threshold_conserves`, `threshold_residual_bounded`, `threshold2_conserves`, `step_bisim`, `poisson_unbiased` |
 | `PerLineAttribution.lean` | per-line byte fraction faithful under sampling | `fraction_of_expectations`, `recorded_fraction_exact` |
 | `LeakTrackerAudit.lean` | proves the leak formula's *unguarded* denominator is safe (`frees ≤ allocs`) | `run_frees_le_allocs`, `denom_pos_reachable` |
+| `LeakTrackerConcurrency.lean` | `frees ≤ allocs` survives sig-queue/main-thread interleaving + fork; RLock atomicity & joint fork-reset shown *necessary* | `interleave_preserves_inv`, `torn_free_breaks_inv`, `fork_reset_inv`, `partial_fork_reset_breaks_inv` |
 | TLA+ `SignalSafety` | the combined_stacks race is reachable (bug cfg) / impossible (fix cfg) | 4-state counterexample; 99 states clean |
 | TLA+ `Deadlock` | no deadlock; handler never blocks on a lock; output liveness | 72 states clean |
 
@@ -170,9 +171,15 @@ generated `X | Y` unions need 3.10+).
   dev). It's the step connecting Poisson sampling to the `trueFraction`
   distribution.
 - **`LeakTrackerAudit` models the increment *discipline*, not the literal
-  code.** It assumes single-shot arm/disarm; faithfulness under the sig-queue
-  thread vs. main-thread interleaving and across `fork` is NOT proven. Prime
-  next audit target — a race there could break `frees ≤ allocs`.
+  code.** It assumes single-shot arm/disarm. The sig-queue/main-thread
+  interleaving and `fork` gap that was flagged here is now **closed** by
+  `LeakTrackerConcurrency.lean` (§2, §11 in README): interleaving safety under
+  the RLock, plus proofs that RLock atomicity and joint fork-reset are
+  *necessary* (`torn_free_breaks_inv`, `partial_fork_reset_breaks_inv`). What
+  remains assumed: that each `process_malloc_free_samples` call really is atomic
+  w.r.t. the others (the RLock + join discipline the code implements) — the
+  model takes step-atomicity as given rather than deriving it from the queue's
+  operational semantics.
 - **Python/native split**: only the *conservation* (fractions sum to 1) is
   proven, NOT the per-sample *accuracy* of the CALL-opcode/signal-deferral
   classifier heuristic.
@@ -187,9 +194,13 @@ generated `X | Y` unions need 3.10+).
 ## 7. Concrete next steps (roughly ranked)
 
 1. **Merge #1077 then #1076** (drive CI; re-run flakes per §5).
-2. **Audit `LeakTrackerAudit`'s faithfulness under concurrency/fork** — the
-   biggest remaining "assumed not proven" gap that could hide a real race
-   (§6 bullet 3). Model the sig-queue thread interleaving explicitly.
+2. ~~Audit `LeakTrackerAudit`'s faithfulness under concurrency/fork~~ **DONE**
+   — `LeakTrackerConcurrency.lean` models the sig-queue/main-thread interleaving
+   and fork reset explicitly, proves the invariant survives every interleaving,
+   and proves the RLock atomicity + joint fork-reset are *necessary*. Residual:
+   step-atomicity is taken as a modeling axiom (justified by the RLock + thread
+   join in the code) rather than derived from the queue's operational semantics
+   — a TLA+ spec of `ScaleneSigQueue.run` could discharge that too.
 3. **Keep auditing hypotheses adversarially** (the §0 method): every `0 <`,
    every denominator, every counter that could underflow. The audit that found
    §4's bugs covered the main division sites; re-run it whenever a model gains

--- a/formal/README.md
+++ b/formal/README.md
@@ -398,6 +398,49 @@ prove what actually holds and is what a user relies on:
 
 ---
 
+## 11. Leak tracker under concurrency & fork — `lean/Scalene/LeakTrackerConcurrency.lean`
+
+`LeakTrackerAudit.lean` (§ "Bugs the formalization found") proves `frees ≤ allocs`
+for a single *sequential* event stream. But in the code the two increment sites
+run on a background sig-queue thread while the shutdown drain runs on the main
+thread, and the whole tracker state is duplicated across `fork`. This section
+discharges that gap — and, per the audit method, proves the disciplines the code
+relies on are *necessary*, not merely present.
+
+**What the code actually does** (verified against the sources):
+
+| Model element | Scalene source | Meaning |
+|---|---|---|
+| both increments are one `step` | `scalene_memory_profiler.py:236` (free-credit) and `:401` (alloc-credit) are two spots in the *same* function `process_malloc_free_samples` | there is no state at which one applied without the other |
+| each invocation is atomic | `scalene_sigqueue.py:48` `with self.lock:` around `self.process(*item)` (an `RLock`) | invocations never interleave with each other |
+| the drain never overlaps the thread | `scalene_profiler.py:1591` drain runs after `stop()` → `_disable_signals()` → `stop_signal_queues()` joins the thread (`scalene_sigqueue.py:37`) | the shutdown step is one more atomic step in the sequence |
+| fork quiesces then resets both fields | `before_fork` (`:541`) joins the queue; `after_fork_in_child` (`:522`) → `stats.clear()` resets `leak_score` **and** `last_malloc_triggered` together (`scalene_statistics.py:456-457`) | the child restarts from the initial state |
+
+**What is proven:**
+
+- `interleave_preserves_inv` / `sigqueue_then_drain_safe` — **interleaving
+  safety.** With each invocation atomic (the RLock), *every* shuffle of the
+  sig-queue thread's steps with the main-thread drain preserves `frees ≤ allocs`.
+  The scheduler order is irrelevant — which is exactly what the lock buys.
+- `torn_free_breaks_inv` — **atomicity is necessary.** Model the lost-disarm race
+  that dropping the lock would permit (a free credited *without* its disarm): two
+  torn frees double-credit one armed trigger, giving `frees = allocs + 1`. So the
+  invariant genuinely depends on the RLock; it is load-bearing.
+- `fork_reset_inv` — the child process starts safe: whatever the parent's state,
+  the reset lands in the initial tracker.
+- `partial_fork_reset_breaks_inv` — **both fields must reset together.** A reset
+  that zeroed the counters but left the trigger armed (clearing `leak_score`
+  without `last_malloc_triggered`) breaks the invariant immediately — the armed
+  line owes a free it has no room for. This is why `scalene_statistics.py:457`
+  resets `last_malloc_triggered` alongside `leak_score`.
+
+Together with `LeakTrackerAudit.run_frees_le_allocs`, this closes the loop: the
+divide-by-zero-safety of `scalene_leak_analysis.py`'s leak formula holds for the
+real concurrent + forking execution, *provided* the RLock atomicity and joint
+fork reset are in place — both of which are shown here to be required.
+
+---
+
 ## What is *assumed* (model boundary)
 
 These models abstract, and the abstractions are the assumptions:

--- a/formal/README.md
+++ b/formal/README.md
@@ -48,6 +48,35 @@ All TLA+ runs and Lean proofs reproduce from a clean checkout (commands below).
 The Lean proofs contain **no `sorry`/`admit`** and depend only on Lean's three
 standard axioms (`propext`, `Classical.choice`, `Quot.sound`).
 
+## Bugs the formalization found
+
+Formalizing forces every implicit assumption to be named, which surfaces places
+where the code doesn't enforce what a proof needs. Auditing the models'
+hypotheses against the code (see `lean/Scalene/LeakTrackerAudit.lean` and the
+audit notes below) turned up two real defects, both since fixed:
+
+1. **Unguarded divide-by-zero in leak-velocity reporting**
+   (`scalene_json.py`, the `velocity_mb_s: leak_velocity / stats.elapsed_time`
+   site). `compute_leaks` gates on allocation *growth rate*, not wall-clock
+   time, so a leak can be reported on a run short enough that `elapsed_time` is
+   still `0.0` → `ZeroDivisionError`. Sibling `elapsed_time` divisions were
+   already guarded; this one was missed. Fixed + regression test
+   (`tests/test_leak_velocity_zero_elapsed.py`).
+2. **Zero/negative memory-sampling window from an unvalidated env var**
+   (`sampleheap.hpp`: `atol(getenv("SCALENE_ALLOCATION_SAMPLING_WINDOW"))`).
+   `atol` returns 0 for `"0"` or any unparseable string; a 0 interval makes the
+   sampler trigger on *every* allocation — and violates the `interval > 0`
+   precondition `MemorySampler.lean` proves necessary. Fixed by clamping to the
+   default when ≤ 0.
+
+Additionally, `LeakTrackerAudit.lean` discharges an *implicit* safety contract:
+the leak formula `1 − (frees+1)/(allocs−frees+2)` has **no** guard on its
+denominator, relying entirely on the invariant `frees ≤ allocs`. That invariant
+is not obvious — `allocs`/`frees` are incremented at separate code sites — so we
+model the raw two-counter increment discipline and *prove* `frees ≤ allocs`
+holds, hence `allocs−frees+2 ≥ 2 > 0`. (No bug, but the safety was previously
+implicit and unverified.)
+
 ---
 
 ## 1. Signal / iteration safety — `tla/SignalSafety.tla`

--- a/formal/README.md
+++ b/formal/README.md
@@ -258,12 +258,14 @@ formal contract between them.
   sampler transform is a correct inverse-CDF for the Exponential and is
   memoryless. (PASTA itself is cited, not formalized — it needs a continuous-
   time stochastic-process development.)
-- **GPU / copy-volume / python-split / leak / memory-sampling — now §8, §9.**
+- **GPU / copy-volume / python-split / leak / memory-sampling — §8–§10.**
   §8 (`MetricCorrectness.lean`) covers GPU utilization, memcpy copy-volume,
   the Python-vs-native split, and memory-leak detection; §9
-  (`MemorySampler.lean`) covers the allocation sampler. What remains unmodeled:
-  the per-sample *accuracy* of the python/native classifier heuristic, and the
-  end-to-end wiring from C++ counters into the Python statistics objects.
+  (`MemorySampler.lean`) covers the allocation sampler (now including a proved
+  bisimulation to the literal two-counter C++); §10 (`PerLineAttribution.lean`)
+  ties byte sampling to the per-line fraction. What remains unmodeled: the
+  per-sample *accuracy* of the python/native classifier heuristic, and the
+  end-to-end wiring from the C++ counters into the Python statistics objects.
 
 ---
 
@@ -337,6 +339,33 @@ Scalene ships two allocation samplers (`sampleheap.hpp:345-349`); we model both:
   `1/window`, rescaled by `window`. `poisson_unbiased` /
   `poisson_unbiased_sum` — the rescaled estimate is unbiased for true bytes,
   per allocation and summed over a trace.
+
+**Faithful to the *literal* two-counter C++ (`§1b` in the file).** The model
+above collapses the C++'s two `uint64_t` counters (`_increments`,
+`_decrements`) into their difference `bal`; that reduction was previously only
+argued in prose. `step_bisim` / `run_bisim` now *prove* the literal two-counter
+machine (separate ℕ counters, trigger `incr ≥ decr + I`, reset both to 0) is
+bisimilar to the one-counter model under `abs (incr, decr) = incr − decr`, and
+`threshold2_conserves` transfers exact conservation to the two-counter machine
+as written. So "faithful to the C++" is a theorem, not an assumption.
+
+## 10. Per-line attribution under sampling — `lean/Scalene/PerLineAttribution.lean`
+
+§9 proves the sampler unbiased for *total* bytes per line; this ties that back
+to §6's per-line *fraction* story, so memory sampling inherits the attribution
+guarantee. A profiler reports `recorded[ℓ] / Σ recorded` — a ratio of two
+unbiased estimators, which is not *exactly* unbiased (`E[X/Y] ≠ E[X]/E[Y]`). We
+prove what actually holds and is what a user relies on:
+
+- `fraction_of_expectations` — the fraction formed from the *expected* recorded
+  counts equals the true per-line byte fraction: the sampling window cancels top
+  and bottom, so there is **no systematic scale bias** in the breakdown.
+- `recorded_fraction_exact` — whenever per-line counts are proportional to true
+  bytes (the deterministic threshold limit / large-sample Poisson limit), the
+  reported fraction equals the true fraction *exactly*, independent of the
+  sampling rate.
+- `trueFraction_nonneg` / `trueFraction_sum_one` — the per-line memory breakdown
+  is a probability distribution over lines, exactly like the CPU one (§6).
 
 ---
 
@@ -420,7 +449,8 @@ formal/
       ProfilerCorrectness.lean   # unbiased + consistent attribution (the user-facing spec)
       ExponentialSampler.lean    # sampler is Poisson: inverse-CDF + memorylessness (§7)
       MetricCorrectness.lean     # GPU / copy-volume / python-split / leak detection (§8)
-      MemorySampler.lean         # threshold (conservation) + Poisson (unbiased) sampler (§9)
+      MemorySampler.lean         # threshold + Poisson sampler; two-counter bisimulation (§9)
+      PerLineAttribution.lean    # per-line byte fraction under sampling (§10)
   extract/
     ScaleneExtract.lean         # extraction-friendly defs (Lean 4.12, LeanToPython)
     scalene_verified_core.py    # GENERATED Python oracle (committed)

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -10,3 +10,4 @@ import Scalene.MemorySampler
 import Scalene.MetricCorrectness
 import Scalene.PerLineAttribution
 import Scalene.LeakTrackerAudit
+import Scalene.LeakTrackerConcurrency

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -8,3 +8,4 @@ import Scalene.ProfilerCorrectness
 import Scalene.ExponentialSampler
 import Scalene.MemorySampler
 import Scalene.MetricCorrectness
+import Scalene.PerLineAttribution

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -9,3 +9,4 @@ import Scalene.ExponentialSampler
 import Scalene.MemorySampler
 import Scalene.MetricCorrectness
 import Scalene.PerLineAttribution
+import Scalene.LeakTrackerAudit

--- a/formal/lean/Scalene/LeakTrackerAudit.lean
+++ b/formal/lean/Scalene/LeakTrackerAudit.lean
@@ -1,0 +1,159 @@
+/-
+  AUDIT: does the leak detector's divide-by-zero-safety actually hold in the
+  code, or did MetricCorrectness.lean assume it away?
+
+  MetricCorrectness models the leak score with `unfreed, frees : ℕ` and
+  `allocs = unfreed + frees`, which *hardcodes* `frees ≤ allocs`. But the
+  Python computes (scalene_leak_analysis.py:31)
+
+      expected_leak = 1.0 - (frees + 1) / (allocs - frees + 2)
+
+  with NO guard on the denominator, over two counters incremented at *separate*
+  sites (scalene_memory_profiler.py:401 `allocs += 1`, :236 `frees += 1`). If
+  `frees` could reach `allocs + 2`, the denominator is ≤ 0 → division by zero or
+  a negative "probability". So the model's `frees ≤ allocs` assumption is a
+  genuine *safety contract* that must be discharged from the actual increment
+  discipline, not assumed. This file models the raw two-counter tracker and
+  proves (or would refute) that contract.
+
+  THE INCREMENT DISCIPLINE (from the code):
+    * A malloc that pushes a new peak footprint arms `last_malloc_triggered` to
+      that line AND does `allocs += 1` for it (memory_profiler.py:398-401) — the
+      two happen together, same line.
+    * When that armed trigger is later freed, `frees += 1` is credited to the
+      armed line, and the trigger is IMMEDIATELY disarmed (:236, :237-241).
+    * `frees += 1` only fires while a trigger is armed (`this_ln != 0`, :234).
+
+  So per line, a `free` credit is always preceded by an `alloc` credit that
+  armed the trigger, and the trigger is single-shot (disarmed on free). We model
+  exactly this and prove `frees ≤ allocs` per line — hence `allocs−frees+2 ≥ 2 >
+  0`, so the production formula is divide-by-zero-safe.
+-/
+import Mathlib
+
+namespace Scalene.LeakTrackerAudit
+
+/-- Per-line leak counters, as stored in `leak_score[fn][ln]`. -/
+structure Counts where
+  allocs : ℕ
+  frees  : ℕ
+
+/-- Global tracker state: the per-line counts, and the single armed trigger
+    line (`none` = disarmed, i.e. the code's `last_malloc_triggered.ln == 0`). -/
+structure Tracker (Line : Type) where
+  count : Line → Counts
+  armed : Option Line
+
+/-- The events that drive the counters, mirroring the two code sites. -/
+inductive Ev (Line : Type) where
+  | allocPeak (ℓ : Line)   -- a malloc pushed a new peak on line ℓ (:398-401)
+  | freeTrigger            -- the armed trigger was freed (:230-241)
+  | other                  -- any malloc/free that doesn't touch leak_score
+
+variable {Line : Type} [DecidableEq Line]
+
+/-- One step of the raw tracker, faithful to the code:
+    - allocPeak ℓ: `allocs[ℓ] += 1` and arm the trigger to ℓ.
+    - freeTrigger: if armed at ℓ, `frees[ℓ] += 1` and disarm; else no-op.
+    - other: unchanged. -/
+def step (t : Tracker Line) : Ev Line → Tracker Line
+  | .allocPeak ℓ =>
+      { count := fun k => if k = ℓ then ⟨(t.count k).allocs + 1, (t.count k).frees⟩
+                          else t.count k,
+        armed := some ℓ }
+  | .freeTrigger =>
+      match t.armed with
+      | some ℓ =>
+          { count := fun k => if k = ℓ then ⟨(t.count k).allocs, (t.count k).frees + 1⟩
+                              else t.count k,
+            armed := none }
+      | none => t
+  | .other => t
+
+def run (t : Tracker Line) : List (Ev Line) → Tracker Line
+  | []      => t
+  | e :: es => run (step t e) es
+
+/-- The safety invariant we need: per line `frees ≤ allocs`, AND the armed line
+    (if any) has strictly more allocs than frees — it is "owed" a free. The
+    second conjunct is the strengthening that makes the induction go through:
+    an armed trigger guarantees room for the free it will receive. -/
+def Inv (t : Tracker Line) : Prop :=
+  (∀ ℓ, (t.count ℓ).frees ≤ (t.count ℓ).allocs) ∧
+  (∀ ℓ, t.armed = some ℓ → (t.count ℓ).frees < (t.count ℓ).allocs)
+
+/-- The initial (empty) tracker satisfies the invariant. -/
+theorem inv_init : Inv (Line := Line) ⟨fun _ => ⟨0, 0⟩, none⟩ := by
+  constructor
+  · intro ℓ; simp
+  · intro ℓ h; simp at h
+
+/-- **The invariant is preserved by every event.** This is the heart of the
+    audit: from the actual increment discipline, `frees ≤ allocs` can never be
+    violated. -/
+theorem step_preserves_inv (t : Tracker Line) (e : Ev Line) (h : Inv t) :
+    Inv (step t e) := by
+  obtain ⟨hle, harm⟩ := h
+  cases e with
+  | allocPeak ℓ =>
+      constructor
+      · -- frees ≤ allocs after allocs[ℓ]++ : untouched lines unchanged; ℓ gains an alloc
+        intro k
+        simp only [step]
+        by_cases hk : k = ℓ
+        · rw [if_pos hk]; have := hle k; simp only; omega
+        · rw [if_neg hk]; exact hle k
+      · -- newly armed line ℓ now has allocs+1 > frees (since frees ≤ allocs before)
+        intro k hk
+        simp only [step] at hk ⊢
+        -- armed = some ℓ, so k = ℓ
+        rw [Option.some.injEq] at hk
+        subst hk
+        have hb := hle ℓ
+        simp only [if_true, ite_true]
+        omega
+  | freeTrigger =>
+      cases harmed : t.armed with
+      | none => simpa [step, harmed] using ⟨hle, harm⟩
+      | some ℓ =>
+          -- ℓ is armed ⇒ frees[ℓ] < allocs[ℓ]; after frees[ℓ]++, still ≤; disarmed.
+          have hstrict := harm ℓ harmed
+          constructor
+          · intro k
+            simp only [step, harmed]
+            by_cases hk : k = ℓ
+            · subst hk; simp; omega
+            · simp [hk]; exact hle k
+          · intro k hk
+            simp only [step, harmed] at hk
+            -- armed is now none, contradiction
+            exact absurd hk (by simp)
+  | other => simpa [step] using ⟨hle, harm⟩
+
+/-- **Whole-run safety.** After ANY sequence of events from the empty tracker,
+    every line satisfies `frees ≤ allocs`. -/
+theorem run_frees_le_allocs (es : List (Ev Line)) (ℓ : Line) :
+    ((run (⟨fun _ => ⟨0, 0⟩, none⟩ : Tracker Line) es).count ℓ).frees
+      ≤ ((run ⟨fun _ => ⟨0, 0⟩, none⟩ es).count ℓ).allocs := by
+  have : Inv (run (⟨fun _ => ⟨0, 0⟩, none⟩ : Tracker Line) es) := by
+    have hstep : ∀ (t : Tracker Line) (es : List (Ev Line)), Inv t → Inv (run t es) := by
+      intro t es
+      induction es generalizing t with
+      | nil => intro h; simpa [run] using h
+      | cons e es ih => intro h; simp only [run]; exact ih _ (step_preserves_inv t e h)
+    exact hstep _ es inv_init
+  exact this.1 ℓ
+
+/-- **Therefore the production formula is divide-by-zero-safe.** With the counts
+    reachable by the real tracker, `allocs − frees + 2 ≥ 2 > 0`, so
+    `scalene_leak_analysis.py:31`'s unguarded denominator is always positive and
+    the score is a genuine value in the range MetricCorrectness proves. -/
+theorem denom_pos_reachable (es : List (Ev Line)) (ℓ : Line) :
+    let c := (run (⟨fun _ => ⟨0, 0⟩, none⟩ : Tracker Line) es).count ℓ
+    (0 : ℤ) < (c.allocs : ℤ) - (c.frees : ℤ) + 2 := by
+  intro c
+  have h := run_frees_le_allocs es ℓ
+  have : (c.frees : ℤ) ≤ (c.allocs : ℤ) := by exact_mod_cast h
+  linarith
+
+end Scalene.LeakTrackerAudit

--- a/formal/lean/Scalene/LeakTrackerConcurrency.lean
+++ b/formal/lean/Scalene/LeakTrackerConcurrency.lean
@@ -1,0 +1,187 @@
+/-
+  AUDIT (part 2): does `frees ≤ allocs` survive the CONCURRENCY and FORK that
+  `LeakTrackerAudit.lean` abstracted away?
+
+  `LeakTrackerAudit` proved the invariant for a single *sequential* event stream
+  (`run`). But in the code the two increment sites run under a specific
+  concurrency discipline, and the state is duplicated across `fork`. The handoff
+  (HANDOFF.md §6 bullet 3, §7 step 2) flags this as the biggest "assumed-not-
+  proven" gap: "faithfulness under the sig-queue thread vs. main-thread
+  interleaving and across fork is NOT proven. A race there could break
+  `frees ≤ allocs`." This file discharges that gap — and, per the §0 method,
+  proves the discipline is *necessary*, not merely present.
+
+  ── WHAT THE CODE ACTUALLY DOES (verified while writing this) ──────────────────
+  * Both increment sites are in ONE function, `process_malloc_free_samples`
+    (scalene_memory_profiler.py): the free-credit at :236 and the alloc-credit at
+    :401 are two spots in the same call. There is no point at which one runs
+    "half done" while the other starts.
+  * That function runs on a single dedicated sig-queue thread, and
+    `ScaleneSigQueue.run` holds an `RLock` (`with self.lock:`,
+    scalene_sigqueue.py:48) around each `self.process(*item)`. So each whole
+    invocation is a CRITICAL SECTION — atomic w.r.t. every other invocation.
+  * The only other caller is the shutdown drain (scalene_profiler.py:1591). It
+    runs after `stop()` → `_disable_signals()` → `stop_signal_queues()`, which
+    JOINS the sig-queue thread (scalene_sigqueue.py:37). So the drain never
+    overlaps the thread — it is one more atomic step in the same sequence.
+  * Across `fork`: `before_fork` (scalene_profiler.py:541) stops/joins the queue
+    (quiesce); `after_fork_in_child` (:522) calls `stats.clear()`, which resets
+    `leak_score` AND `last_malloc_triggered` TOGETHER (scalene_statistics.py:
+    456-457) while the tracker is quiescent.
+
+  ── WHAT WE PROVE ──────────────────────────────────────────────────────────────
+  (A) INTERLEAVING SAFETY. If each `process_malloc_free_samples` call is atomic
+      (one `step`), then EVERY interleaving of the sig-queue thread's steps with
+      the main-thread drain's steps preserves the invariant — thread order is
+      irrelevant. This is what the RLock buys us. (`interleave_preserves_inv`)
+  (B) ATOMICITY IS NECESSARY. If a free-credit could apply WITHOUT its disarm
+      (the lost-disarm race that dropping the lock would permit), the invariant
+      genuinely breaks: two torn frees double-credit one armed trigger, yielding
+      `frees = allocs + 1`. So the RLock is load-bearing, not decorative.
+      (`torn_free_breaks_inv`)
+  (C) FORK RESET IS SAFE — AND MUST RESET BOTH FIELDS. The full reset that
+      `clear()` performs lands back in the initial state, so Inv holds
+      (`fork_reset_inv`). But a *partial* reset that zeroed the counters while
+      leaving the trigger armed (i.e. clearing `leak_score` but forgetting
+      `last_malloc_triggered`, scalene_statistics.py:457) breaks Inv — the next
+      free credits a line with zero allocs. So resetting both together is
+      necessary. (`partial_fork_reset_breaks_inv`)
+
+  Together with `LeakTrackerAudit.run_frees_le_allocs`, this closes the loop:
+  the divide-by-zero-safety of scalene_leak_analysis.py:31 holds not just for a
+  sequential trace but for the real concurrent + forking execution — *provided*
+  the two disciplines the code implements (RLock atomicity, joint fork reset)
+  are in place. Both are shown necessary here.
+-/
+import Mathlib
+import Scalene.LeakTrackerAudit
+
+namespace Scalene.LeakTrackerConcurrency
+
+open Scalene.LeakTrackerAudit
+
+variable {Line : Type} [DecidableEq Line]
+
+/-! ## Reusable lemma: `run` preserves the invariant over any event list.
+
+    `LeakTrackerAudit` proved this inline inside `run_frees_le_allocs`; we pull
+    it out because the interleaving argument needs it directly. -/
+
+theorem run_preserves_inv (t : Tracker Line) (es : List (Ev Line)) (h : Inv t) :
+    Inv (run t es) := by
+  induction es generalizing t with
+  | nil => simpa [run] using h
+  | cons e es ih => simp only [run]; exact ih _ (step_preserves_inv t e h)
+
+/-! ## (A) Interleaving safety
+
+    The sig-queue thread produces a sequence of atomic steps; the main-thread
+    drain produces its own (here, at most one). Because each step is atomic (the
+    RLock), a concurrent execution is exactly *some* interleaving of the two
+    step sequences. We model interleaving inductively and prove Inv survives
+    *any* interleaving — i.e. the result does not depend on how the scheduler
+    races the two threads. -/
+
+/-- `Interleave as bs cs`: `cs` is a merge of `as` and `bs` that preserves the
+    internal order of each — the standard shuffle relation. Each constructor
+    commits one whole `step` from one thread, reflecting step-level atomicity. -/
+inductive Interleave : List (Ev Line) → List (Ev Line) → List (Ev Line) → Prop
+  | nil : Interleave [] [] []
+  | left  {a : Ev Line} {as bs cs} :
+      Interleave as bs cs → Interleave (a :: as) bs (a :: cs)
+  | right {b : Ev Line} {as bs cs} :
+      Interleave as bs cs → Interleave as (b :: bs) (b :: cs)
+
+/-- **Every interleaving of the two threads' atomic steps preserves the
+    invariant.** This is the payoff of the RLock: no matter how the sig-queue
+    thread and the shutdown drain are scheduled relative to each other,
+    `frees ≤ allocs` is maintained. -/
+theorem interleave_preserves_inv {as bs cs : List (Ev Line)}
+    (_hInt : Interleave as bs cs) (t : Tracker Line) (h : Inv t) :
+    Inv (run t cs) :=
+  -- Once steps are atomic, an interleaving is just *some* event list, and `run`
+  -- preserves Inv over any event list. The scheduler cannot help itself to a
+  -- sub-step tear — that is exactly what atomicity forbids (and what (B) shows
+  -- would otherwise be catastrophic).
+  run_preserves_inv t cs h
+
+/-- Corollary: the concrete shape in the code — the sig-queue thread runs a
+    batch of steps `sig`, then the joined main thread runs its drain steps
+    `drain` — is one interleaving, hence safe. -/
+theorem sigqueue_then_drain_safe (sig drain : List (Ev Line)) :
+    Inv (run (⟨fun _ => ⟨0, 0⟩, none⟩ : Tracker Line) (sig ++ drain)) :=
+  run_preserves_inv _ _ inv_init
+
+/-! ## (B) Atomicity is necessary: the lost-disarm race breaks the invariant.
+
+    Model what dropping the RLock would allow: a free-credit that increments
+    `frees` but does NOT disarm the trigger (because a second invocation reads
+    `last_malloc_triggered` before the first writes the disarm). Two such torn
+    frees on the same armed trigger both credit a free. -/
+
+/-- A "torn" free: credits a free to the armed line but FAILS to disarm — the
+    write `armed := none` is lost to a concurrent reader. This is precisely the
+    interleaving the RLock prevents. -/
+def tornFree (t : Tracker Line) : Tracker Line :=
+  match t.armed with
+  | some ℓ =>
+      { count := fun k => if k = ℓ then ⟨(t.count k).allocs, (t.count k).frees + 1⟩
+                          else t.count k,
+        armed := t.armed }        -- BUG vs. `step`: trigger left armed
+  | none => t
+
+/-- **Without atomic disarm, `frees ≤ allocs` is violated.** Starting from a
+    legitimate armed state (one alloc credited, trigger owed a free — Inv holds),
+    two torn frees produce `frees = 2 > 1 = allocs`. So the invariant that keeps
+    the leak-score denominator positive genuinely depends on the disarm being
+    atomic with the free credit; the RLock is load-bearing. -/
+theorem torn_free_breaks_inv :
+    ∃ t : Tracker ℕ, Inv t ∧ ¬ Inv (tornFree (tornFree t)) := by
+  -- Armed at line 0, which has been credited one alloc and owes one free.
+  refine ⟨⟨fun k => if k = 0 then ⟨1, 0⟩ else ⟨0, 0⟩, some 0⟩, ?_, ?_⟩
+  · -- Inv holds initially: frees ≤ allocs everywhere, and armed line owes a free.
+    constructor
+    · intro ℓ; by_cases hℓ : ℓ = 0 <;> simp [hℓ]
+    · intro ℓ h; simp only [Option.some.injEq] at h; subst h; simp
+  · -- After two torn frees, line 0 has allocs = 1, frees = 2 ⇒ ¬ (frees ≤ allocs).
+    intro hInv
+    have hle := hInv.1 0
+    simp [tornFree] at hle
+
+/-! ## (C) Fork reset is safe — and both fields must be reset together.
+
+    `after_fork_in_child` → `stats.clear()` resets the tracker to empty. -/
+
+/-- The full fork reset the code performs (`clear()` zeros `leak_score` *and*
+    `last_malloc_triggered`, scalene_statistics.py:456-457). -/
+def forkReset (_t : Tracker Line) : Tracker Line := ⟨fun _ => ⟨0, 0⟩, none⟩
+
+/-- **The child process starts safe.** After fork, whatever the parent's state,
+    the reset lands in the initial tracker, so Inv holds and the sequential proof
+    resumes cleanly in the child. -/
+theorem fork_reset_inv (t : Tracker Line) : Inv (forkReset t) :=
+  inv_init
+
+/-- A hypothetical *partial* reset that zeroed the counters but forgot to clear
+    the armed trigger — i.e. `leak_score.clear()` without
+    scalene_statistics.py:457. -/
+def partialForkReset (t : Tracker Line) : Tracker Line :=
+  ⟨fun _ => ⟨0, 0⟩, t.armed⟩
+
+/-- **Both fields must be reset together.** If the fork reset zeroed the counts
+    but left the trigger armed, the child violates Inv immediately: the armed
+    line owes a free it can never have room for (0 allocs), so the first
+    post-fork free would push `frees` past `allocs`. This is why
+    scalene_statistics.py:457 resets `last_malloc_triggered` alongside
+    `leak_score`. -/
+theorem partial_fork_reset_breaks_inv :
+    ∃ t : Tracker ℕ, ¬ Inv (partialForkReset t) := by
+  -- Parent had line 0 armed when the fork hit.
+  refine ⟨⟨fun _ => ⟨0, 0⟩, some 0⟩, ?_⟩
+  intro hInv
+  -- Second conjunct demands the armed line have frees < allocs, i.e. 0 < 0.
+  have h := hInv.2 0 rfl
+  simp only [partialForkReset] at h
+  omega
+
+end Scalene.LeakTrackerConcurrency

--- a/formal/lean/Scalene/MemorySampler.lean
+++ b/formal/lean/Scalene/MemorySampler.lean
@@ -148,6 +148,117 @@ theorem threshold_residual_bounded (I : ℤ) (hI : 0 < I) (es : List Event) :
             have hn : (0:ℤ) ≤ (n:ℤ) := Int.natCast_nonneg n
             refine ⟨by linarith [not_le.mp hne], by linarith [h.2]⟩
 
+/-! ## 1b. The one-counter model faithfully reduces the literal two-counter C++
+
+The `St`/`stepThreshold` model above collapses the C++'s two `uint64_t`
+counters `_increments` / `_decrements` into their difference `bal`. That
+collapse was previously argued in prose. Here we close the gap: we model the
+*literal* two-counter machine (thresholdsampler.hpp:60-73, 38-51: separate ℕ
+counters, trigger `incr ≥ decr + I` / `decr ≥ incr + I`, reset BOTH to 0) and
+prove it is bisimilar to the one-counter model under the abstraction
+`abs (incr, decr) = incr − decr`. Conservation then transfers to the real
+machine for free. -/
+
+/-- Literal two-counter sampler state: the C++ `_increments`, `_decrements`
+    (both `uint64_t`, so `ℕ`) plus the reported total. -/
+structure St2 where
+  incr     : ℕ
+  decr     : ℕ
+  reported : ℤ
+
+/-- One step of the LITERAL two-counter machine, matching thresholdsampler.hpp:
+    alloc adds to `incr`; if `incr ≥ decr + I` it reports `incr − decr` and
+    resets both counters to 0. Free is symmetric on `decr`. `I : ℕ` (the C++
+    `_sampleInterval`). -/
+def stepThreshold2 (I : ℕ) (s : St2) : Event → St2
+  | .alloc n =>
+      let incr' := s.incr + n
+      if incr' ≥ s.decr + I then
+        ⟨0, 0, s.reported + ((incr' : ℤ) - s.decr)⟩
+      else ⟨incr', s.decr, s.reported⟩
+  | .free n =>
+      let decr' := s.decr + n
+      if decr' ≥ s.incr + I then
+        ⟨0, 0, s.reported + (s.incr - (decr' : ℤ))⟩
+      else ⟨s.incr, decr', s.reported⟩
+
+def runThreshold2 (I : ℕ) (s : St2) : List Event → St2
+  | []      => s
+  | e :: es => runThreshold2 I (stepThreshold2 I s e) es
+
+/-- Abstraction from the two-counter machine to the one-counter model:
+    `bal := incr − decr`, `reported` carried through. -/
+def abs2 (s : St2) : St := ⟨(s.incr : ℤ) - s.decr, s.reported⟩
+
+/-- **Bisimulation (one step).** The two-counter step commutes with the
+    abstraction: abstracting after a literal step = one-counter-stepping the
+    abstraction. The subtlety the ℕ→ℤ collapse must respect: the C++ trigger
+    `incr' ≥ decr + I` is *exactly* `abs.bal + n ≥ I` (over ℤ), and resetting
+    both ℕ counters to 0 gives `bal = 0` — matching `stepThreshold`. -/
+theorem step_bisim (I : ℕ) (s : St2) (e : Event) :
+    abs2 (stepThreshold2 I s e) = stepThreshold (I : ℤ) (abs2 s) e := by
+  cases e with
+  | alloc n =>
+      -- trigger conditions coincide: (incr+n ≥ decr+I) ↔ ((incr-decr)+n ≥ I)
+      have hcond : (s.incr + n ≥ s.decr + I)
+                 ↔ ((s.incr : ℤ) - s.decr + (n : ℤ) ≥ (I : ℤ)) := by
+        constructor
+        · intro h; have : (s.incr : ℤ) + n ≥ (s.decr : ℤ) + I := by exact_mod_cast h
+          linarith
+        · intro h; have : (s.incr : ℤ) + n ≥ (s.decr : ℤ) + I := by linarith
+          exact_mod_cast this
+      simp only [stepThreshold2, stepThreshold, abs2]
+      by_cases h : s.incr + n ≥ s.decr + I
+      · rw [if_pos h, if_pos (hcond.mp h)]; simp only [St.mk.injEq]; refine ⟨?_, ?_⟩ <;> push_cast <;> ring_nf
+      · rw [if_neg h, if_neg (fun hc => h (hcond.mpr hc))]; simp only [St.mk.injEq]; refine ⟨?_, ?_⟩ <;> push_cast <;> ring_nf
+  | free n =>
+      have hcond : (s.decr + n ≥ s.incr + I)
+                 ↔ ((s.incr : ℤ) - (s.decr : ℤ) - (n : ℤ) ≤ -(I : ℤ)) := by
+        constructor
+        · intro h; have : (s.decr : ℤ) + n ≥ (s.incr : ℤ) + I := by exact_mod_cast h
+          linarith
+        · intro h; have : (s.decr : ℤ) + n ≥ (s.incr : ℤ) + I := by linarith
+          exact_mod_cast this
+      simp only [stepThreshold2, stepThreshold, abs2]
+      by_cases h : s.decr + n ≥ s.incr + I
+      · rw [if_pos h, if_pos (hcond.mp h)]; simp only [St.mk.injEq]; refine ⟨?_, ?_⟩ <;> push_cast <;> ring_nf
+      · rw [if_neg h, if_neg (fun hc => h (hcond.mpr hc))]; simp only [St.mk.injEq]; refine ⟨?_, ?_⟩ <;> push_cast <;> ring_nf
+
+/-- **Bisimulation (whole run).** Abstraction commutes with the full run. -/
+theorem run_bisim (I : ℕ) (s : St2) (es : List Event) :
+    abs2 (runThreshold2 I s es) = runThreshold (I : ℤ) (abs2 s) es := by
+  induction es generalizing s with
+  | nil => rfl
+  | cons e es ih =>
+      simp only [runThreshold2, runThreshold]
+      rw [ih (stepThreshold2 I s e), step_bisim]
+
+/-- **Conservation for the LITERAL two-counter machine.** Transferring
+    `threshold_conserves` across the bisimulation: starting from zeroed
+    counters, the two-counter C++ sampler's reported net plus its residual
+    `incr − decr` equals the true net allocation, exactly. This is the
+    conservation guarantee stated directly about the algorithm as written in
+    thresholdsampler.hpp, with the one-counter collapse now *proved* rather
+    than assumed. -/
+theorem threshold2_conserves (I : ℕ) (es : List Event) :
+    let s := runThreshold2 I ⟨0, 0, 0⟩ es
+    s.reported + ((s.incr : ℤ) - s.decr) = trueNet es := by
+  intro s
+  -- The abstraction of the two-counter run equals the one-counter run.
+  have hrun : abs2 s = runThreshold (I : ℤ) ⟨0, 0⟩ es := by
+    show abs2 (runThreshold2 I ⟨0, 0, 0⟩ es) = _
+    rw [run_bisim]; rfl
+  -- One-counter conservation on that run.
+  have hcons : (runThreshold (I:ℤ) ⟨0,0⟩ es).reported
+             + (runThreshold (I:ℤ) ⟨0,0⟩ es).bal = trueNet es := threshold_conserves (I:ℤ) es
+  -- abs2 s = ⟨incr - decr, reported⟩ by definition; read off the fields.
+  have hbal : (runThreshold (I:ℤ) ⟨0,0⟩ es).bal = (s.incr : ℤ) - s.decr := by
+    rw [← hrun]; rfl
+  have hrep : (runThreshold (I:ℤ) ⟨0,0⟩ es).reported = s.reported := by
+    rw [← hrun]; rfl
+  rw [hbal, hrep] at hcons
+  linarith [hcons]
+
 /-! ## 2. PoissonSampler — unbiased byte estimator
 
 Each byte is independently recorded with probability `p = 1/window`; a recorded

--- a/formal/lean/Scalene/PerLineAttribution.lean
+++ b/formal/lean/Scalene/PerLineAttribution.lean
@@ -1,0 +1,112 @@
+/-
+  Per-line attribution under sampling — tying MemorySampler back to the
+  per-line `trueFraction` story of ProfilerCorrectness.
+
+  §6 (ProfilerCorrectness) proves the CPU estimator unbiased/consistent for the
+  per-line time fraction. §9 (MemorySampler) proves the memory sampler unbiased
+  for *total* bytes per line. This file connects them: it shows the memory
+  sampler's *per-line fraction* is a faithful estimator of the true per-line
+  byte fraction — the memory analogue of §6, so §9's byte sampling inherits §6's
+  attribution guarantee.
+
+  The subtle point handled honestly: a profiler reports `recorded[ℓ] / Σ recorded`,
+  a *ratio* of two unbiased estimators. `E[X/Y] ≠ E[X]/E[Y]` in general, so the
+  ratio is not exactly unbiased. What IS true and is what a user relies on:
+
+    * the ratio of EXPECTATIONS equals the true fraction (`fraction_of_expectations`),
+      i.e. no systematic scale bias — the window cancels; and
+    * on any single run the recorded fractions are exactly the true fractions
+      whenever the per-line sampled counts are proportional to the true bytes
+      (`recorded_fraction_exact`), the deterministic-limit / large-sample case.
+
+  All over ℚ; no `sorry`.
+-/
+import Mathlib
+import Scalene.MemorySampler
+
+open scoped BigOperators
+
+namespace Scalene.PerLineAttribution
+
+variable {Line : Type} [Fintype Line] [DecidableEq Line]
+
+/-- Ground-truth bytes allocated per line, with a positive total. -/
+structure ByteTruth (Line : Type) [Fintype Line] where
+  bytes : Line → ℚ
+  nonneg : ∀ ℓ, 0 ≤ bytes ℓ
+  total_pos : 0 < ∑ ℓ, bytes ℓ
+
+namespace ByteTruth
+
+variable {Line : Type} [Fintype Line] [DecidableEq Line]
+
+def total (B : ByteTruth Line) : ℚ := ∑ ℓ, B.bytes ℓ
+
+/-- True fraction of bytes on line ℓ — what an ideal memory profiler reports. -/
+def trueFraction (B : ByteTruth Line) (ℓ : Line) : ℚ := B.bytes ℓ / B.total
+
+/-- The Poisson sampler's expected rescaled estimate for line ℓ is exactly its
+    true bytes (this is `MemorySampler.poisson_unbiased`, lifted to ℚ bytes:
+    `window · (bytes/window) = bytes`). -/
+def expectedRecorded (window : ℚ) (B : ByteTruth Line) (ℓ : Line) : ℚ :=
+  window * (B.bytes ℓ / window)
+
+theorem expectedRecorded_eq {window : ℚ} (hw : 0 < window) (B : ByteTruth Line)
+    (ℓ : Line) : expectedRecorded window B ℓ = B.bytes ℓ := by
+  unfold expectedRecorded
+  field_simp
+
+/-- **Fraction of expectations = true fraction.** The reported per-line fraction
+    formed from the *expected* recorded counts equals the true per-line byte
+    fraction, for any positive sampling window. The window (the sampling rate)
+    cancels top and bottom, so sampling introduces no systematic scale bias into
+    the per-line breakdown — the memory analogue of §6's `estimator_unbiased`
+    for the ratio-of-expectations. -/
+theorem fraction_of_expectations {window : ℚ} (hw : 0 < window) (B : ByteTruth Line)
+    (ℓ : Line) :
+    expectedRecorded window B ℓ / (∑ k, expectedRecorded window B k)
+      = B.trueFraction ℓ := by
+  have hsum : (∑ k, expectedRecorded window B k) = B.total := by
+    unfold ByteTruth.total
+    exact Finset.sum_congr rfl (fun k _ => expectedRecorded_eq hw B k)
+  rw [hsum, expectedRecorded_eq hw B ℓ, ByteTruth.trueFraction]
+
+end ByteTruth
+
+/-! ## Single-run exactness in the proportional (large-sample) limit
+
+On a finite run the sampler records integer counts. When those counts are
+proportional to the true bytes — the deterministic threshold-sampler behaviour,
+and the large-sample limit of the Poisson sampler — the *reported* fraction
+equals the true fraction exactly, regardless of the proportionality constant
+(the sampling rate). This is the sense in which the per-line breakdown is
+rate-independent. -/
+
+/-- If every line's recorded amount is `c ·` its true bytes (`c > 0` the shared
+    sampling scale), the reported fraction equals the true fraction exactly —
+    the scale `c` cancels. -/
+theorem recorded_fraction_exact {Line : Type} [Fintype Line] [DecidableEq Line]
+    (B : ByteTruth Line) (recorded : Line → ℚ) (c : ℚ) (hc : 0 < c)
+    (hprop : ∀ ℓ, recorded ℓ = c * B.bytes ℓ) (ℓ : Line) :
+    recorded ℓ / (∑ k, recorded k) = B.trueFraction ℓ := by
+  have hsum : (∑ k, recorded k) = c * B.total := by
+    unfold ByteTruth.total
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun k _ => hprop k)
+  rw [hprop ℓ, hsum, ByteTruth.trueFraction, ByteTruth.total]
+  rw [mul_div_mul_left _ _ (ne_of_gt hc)]
+
+/-- **Bounds.** The true per-line byte fraction is a genuine fraction in [0,1],
+    and the fractions sum to 1 — the per-line memory breakdown is a probability
+    distribution over lines, exactly like the CPU one. -/
+theorem trueFraction_nonneg {Line : Type} [Fintype Line] [DecidableEq Line]
+    (B : ByteTruth Line) (ℓ : Line) : 0 ≤ B.trueFraction ℓ :=
+  div_nonneg (B.nonneg ℓ) (le_of_lt B.total_pos)
+
+theorem trueFraction_sum_one {Line : Type} [Fintype Line] [DecidableEq Line]
+    (B : ByteTruth Line) : ∑ ℓ, B.trueFraction ℓ = 1 := by
+  unfold ByteTruth.trueFraction
+  rw [← Finset.sum_div]
+  exact div_self (ne_of_gt B.total_pos)
+
+end Scalene.PerLineAttribution


### PR DESCRIPTION
Closes the two modeling gaps flagged when I explained the threshold-sampler proof.

## (1) The one-counter model faithfully reduces the *literal* two-counter C++ (§1b)

The threshold-sampler conservation proof modeled the C++'s two `uint64_t` counters (`_increments`, `_decrements`) as their difference `bal = incr − decr`. That collapse was argued in prose — the honest caveat I'd flagged. Now it's a **theorem**:
- `St2` / `stepThreshold2` model the literal two-counter machine (separate ℕ counters, trigger `incr ≥ decr + I`, reset both to 0), matching `thresholdsampler.hpp:38-73`.
- `step_bisim` / `run_bisim` — the two-counter machine is bisimilar to the one-counter model under `abs (incr, decr) = incr − decr`.
- `threshold2_conserves` — exact conservation transferred to the literal machine.

So "faithful to the C++" no longer rests on a modeling assumption.

## (2) Per-line attribution under sampling (§10 )

§9 proves the sampler unbiased for *total* bytes per line; this connects it to §6's per-line *fraction*. A profiler reports `recorded[ℓ] / Σ recorded` — a ratio of unbiased estimators, which is **not** exactly unbiased (`E[X/Y] ≠ E[X]/E[Y]`). I prove what actually holds and is what users rely on:
- `fraction_of_expectations` — the sampling window cancels ⇒ no systematic scale bias in the breakdown.
- `recorded_fraction_exact` — in the proportional (deterministic-threshold / large-sample-Poisson) limit, reported fraction = true fraction *exactly*, independent of sampling rate.
- `trueFraction_sum_one` — the per-line memory breakdown is a probability distribution over lines, like the CPU one.

Full `formal/lean` build clean (8568 jobs); **no `sorry`**; standard axioms only.