### PR TITLE
Formal: close PASTA + prove 2 metrics end-to-end across C++/Python; add STATUS.md

### DIFF
--- a/formal/HANDOFF.md
+++ b/formal/HANDOFF.md
@@ -38,7 +38,7 @@ models adversarially, don't just prove them.
 
 ```
 formal/
-  README.md              # full writeup: §1–§13, source mappings, boundaries, repro
+  README.md              # full writeup: §1–§14, source mappings, boundaries, repro
   STATUS.md              # subsystem status map (proven / partial / unproven)
   HANDOFF.md             # this file
   tla/                   # TLA+ specs (model-checked with TLC)
@@ -84,6 +84,7 @@ at `/tmp/LeanToPython` locally (Lean 4.12).
 | `PerLineAttribution.lean` | per-line byte fraction faithful under sampling | `fraction_of_expectations`, `recorded_fraction_exact` |
 | `PoissonArrivals.lean` | **PASTA (discrete)**: uniform arrival lands on ℓ with prob = ℓ's time fraction; realizes the assumed `trueFraction` sampling law → discharges the ProfilerCorrectness hypothesis | `uniform_landing_eq_timeFraction`, `uniform_realizes_trueFraction`, `sum_timeFraction` |
 | `CopyVolumeWiring.lean` | **copy volume end-to-end (C++↔Python)**: emitter/reader state machines; reported volume = observed − residual | `flushed_add_residual`, `python_total_eq_flushed`, `roundtrip_conservation`, `foreign_pid_dropped` |
+| `MallocFootprintWiring.lean` | **malloc footprint end-to-end (C++↔Python)**: reuses ThresholdSampler; models the free-side `max(0,·)` clamp honestly (conserves in safe regime; only over-reports otherwise) | `emit_records_sum`, `clamp_is_identity_of_safe`, `roundtrip_conservation_of_safe`, `clamp_only_raises` |
 | `LeakTrackerAudit.lean` | proves the leak formula's *unguarded* denominator is safe (`frees ≤ allocs`) | `run_frees_le_allocs`, `denom_pos_reachable` |
 | `LeakTrackerConcurrency.lean` | `frees ≤ allocs` survives sig-queue/main-thread interleaving + fork; RLock atomicity & joint fork-reset shown *necessary* | `interleave_preserves_inv`, `torn_free_breaks_inv`, `fork_reset_inv`, `partial_fork_reset_breaks_inv` |
 | TLA+ `SignalSafety` | the combined_stacks race is reachable (bug cfg) / impossible (fix cfg) | 4-state counterexample; 99 states clean |
@@ -247,11 +248,12 @@ generated `X | Y` unions need 3.10+).
 6. **Wire the verified oracle into production directly** (have
    `_space_saving_increment` call the extracted core) rather than only
    differential-testing it — closes the proof→production loop tighter.
-7. ~~Model one more column end-to-end incl. the C++→Python wiring~~ **DONE** —
-   `CopyVolumeWiring.lean` models the memcpy emitter (C++) + reader (Python)
-   state machines and proves round-trip conservation. NEXT such target: malloc
-   footprint (the general malloc/free wiring, of which only the leak-tracker
-   slice is modeled) or GPU.
+7. ~~Model columns end-to-end incl. the C++→Python wiring~~ **DONE (×2)** —
+   `CopyVolumeWiring.lean` (memcpy) and `MallocFootprintWiring.lean` (current
+   footprint / peak memory; models the free-side `max(0,·)` clamp honestly).
+   NEXT such target: per-line malloc *attribution* wiring (the
+   `memory_malloc_samples[file][line] += count` path, distinct from the footprint
+   total modeled here) or GPU acquisition.
 8. **A committed status map** lives at `formal/STATUS.md` — keep it current when
    modules land.
 

--- a/formal/HANDOFF.md
+++ b/formal/HANDOFF.md
@@ -38,7 +38,8 @@ models adversarially, don't just prove them.
 
 ```
 formal/
-  README.md              # full writeup: §1–§10, source mappings, boundaries, repro
+  README.md              # full writeup: §1–§13, source mappings, boundaries, repro
+  STATUS.md              # subsystem status map (proven / partial / unproven)
   HANDOFF.md             # this file
   tla/                   # TLA+ specs (model-checked with TLC)
     SignalSafety.tla + _Fix.cfg / _Bug.cfg
@@ -81,6 +82,8 @@ at `/tmp/LeanToPython` locally (Lean 4.12).
 | `MetricCorrectness.lean` | GPU/copy/python-split (weighted-avg) + leak detection (Bayesian test) | `gpuFraction_bounds`, `python_c_fraction_sums_one`, `leakScore_*`, `reportsLeak_iff`, `no_leak_without_evidence` |
 | `MemorySampler.lean` | threshold sampler conserves net exactly; Poisson unbiased; **two-counter bisimulation** | `threshold_conserves`, `threshold_residual_bounded`, `threshold2_conserves`, `step_bisim`, `poisson_unbiased` |
 | `PerLineAttribution.lean` | per-line byte fraction faithful under sampling | `fraction_of_expectations`, `recorded_fraction_exact` |
+| `PoissonArrivals.lean` | **PASTA (discrete)**: uniform arrival lands on ℓ with prob = ℓ's time fraction; realizes the assumed `trueFraction` sampling law → discharges the ProfilerCorrectness hypothesis | `uniform_landing_eq_timeFraction`, `uniform_realizes_trueFraction`, `sum_timeFraction` |
+| `CopyVolumeWiring.lean` | **copy volume end-to-end (C++↔Python)**: emitter/reader state machines; reported volume = observed − residual | `flushed_add_residual`, `python_total_eq_flushed`, `roundtrip_conservation`, `foreign_pid_dropped` |
 | `LeakTrackerAudit.lean` | proves the leak formula's *unguarded* denominator is safe (`frees ≤ allocs`) | `run_frees_le_allocs`, `denom_pos_reachable` |
 | `LeakTrackerConcurrency.lean` | `frees ≤ allocs` survives sig-queue/main-thread interleaving + fork; RLock atomicity & joint fork-reset shown *necessary* | `interleave_preserves_inv`, `torn_free_breaks_inv`, `fork_reset_inv`, `partial_fork_reset_breaks_inv` |
 | TLA+ `SignalSafety` | the combined_stacks race is reachable (bug cfg) / impossible (fix cfg) | 4-state counterexample; 99 states clean |
@@ -233,15 +236,24 @@ generated `X | Y` unions need 3.10+).
    other divides (~339, ~379, ~416, ~657) are guarded. NEXT untouched surfaces:
    the third renderer's path + `sparkline.py` / `runningstats.py` variance/stddev
    denominators. Lesson reinforced by #4: audit ALL THREE renderers, not one.
-4. **Formalize PASTA** (or at least a discrete-time analogue) to fully discharge
-   the i.i.d.→trueFraction step instead of citing it.
+4. ~~Formalize PASTA (discrete-time analogue)~~ **DONE** —
+   `PoissonArrivals.lean`. Uniform-arrival-over-M-slots lands on ℓ with prob =
+   time fraction, and realizes the `trueFraction` law ProfilerCorrectness
+   assumes (`uniform_realizes_trueFraction`). Residual: continuous-time
+   order-statistics proof still not formalized (discrete form is the operative
+   content for a tick-sampled profiler).
 5. **Prove per-sample classifier accuracy** for the python/native split, or
    document precisely why it's a heuristic with bounded error.
 6. **Wire the verified oracle into production directly** (have
    `_space_saving_increment` call the extracted core) rather than only
    differential-testing it — closes the proof→production loop tighter.
-7. **Model one more column end-to-end** (e.g. GPU or copy-volume) under the
-   unbiased-estimator frame, including the C++→Python wiring.
+7. ~~Model one more column end-to-end incl. the C++→Python wiring~~ **DONE** —
+   `CopyVolumeWiring.lean` models the memcpy emitter (C++) + reader (Python)
+   state machines and proves round-trip conservation. NEXT such target: malloc
+   footprint (the general malloc/free wiring, of which only the leak-tracker
+   slice is modeled) or GPU.
+8. **A committed status map** lives at `formal/STATUS.md` — keep it current when
+   modules land.
 
 ---
 

--- a/formal/README.md
+++ b/formal/README.md
@@ -40,9 +40,17 @@ Two complementary tools are used, each where it is strongest:
 | **Lean 4** | [`lean/`](lean/) | conservation/bounds arithmetic, snapshot algebra | machine-checked proof |
 
 > **Why both?** Race/deadlock properties are about *interleavings* — TLC
-> exhaustively explores them and produces concrete counterexample traces.
-> Conservation/bounds are about *arithmetic over all inputs* — Lean proves them
-> for unbounded quantities, which a model checker cannot.
+> exhaustively explores them and produces concrete counterexample traces, and it
+> checks *liveness* under fairness (progress, no starvation), which Lean has no
+> comfortable story for. Conservation/bounds are about *arithmetic over all
+> inputs* — Lean proves them for unbounded quantities, which a model checker
+> cannot. The engines are complementary, not redundant: retiring the TLC specs
+> would drop counterexample-search and liveness coverage with nothing to replace
+> them. One overlap is deliberate — `LeakTrackerConcurrency.lean` proves an
+> interleaving property in Lean but *assumes step-atomicity as an axiom*
+> (justified by the RLock + thread join); deriving that atomicity from the
+> sig-queue's operational semantics is a natural next TLA+ job. See
+> [`STATUS.md`](STATUS.md) § "Why two engines".
 
 All TLA+ runs and Lean proofs reproduce from a clean checkout (commands below).
 The Lean proofs contain **no `sorry`/`admit`** and depend only on Lean's three

--- a/formal/README.md
+++ b/formal/README.md
@@ -524,6 +524,47 @@ the mapfile's low-level byte-format parsing or partial-read handling.
 
 ---
 
+## 14. Malloc footprint end-to-end (C++↔Python) — `lean/Scalene/MallocFootprintWiring.lean`
+
+The harder memory path: the *current footprint* / peak-memory number, spanning
+the C++ `SampleHeap` emitter (`sampleheap.hpp:183-316`) and the Python reader
+`process_malloc_free_samples` (`scalene_memory_profiler.py:102-228`). The C++
+half reuses the ThresholdSampler already proven in `MemorySampler.lean`.
+
+**The subtlety, modeled not assumed.** The Python free path clamps the running
+footprint to `max(0, current − count)` on every free (`:218`). That clamp
+*breaks* pure conservation: if frees drive the footprint below 0 (startup
+misses, per the code comment), it silently adds bytes back. A naive model that
+ignored the clamp would "prove" conservation falsely. So we prove the honest,
+conditional statements:
+
+| Model element | Scalene source | Meaning |
+|---|---|---|
+| `emitStep`/`emitRun` | `process_malloc`/`process_free` emit on sampler trigger | records carry the reported byte excess, action M/F, pid |
+| `stepFootprint` with `max 0 (·)` | `current_footprint = max(0, current − count)` (`:218`) | the free-side clamp, modeled literally |
+| `Safe` predicate | "Scalene can miss some initial allocations" (`:215`) | the regime where the clamp is inert |
+| `pidFilter` | `if int(curr_pid) != int(pid): continue` (`:145`) | per-process filter |
+
+**Theorems**
+
+- `emit_records_sum` — the records the C++ ThresholdSampler emits sum (signed)
+  to its `reported` net (bridge to `MemorySampler.threshold_conserves`).
+- `clamp_is_identity_of_safe` — while the footprint stays ≥ 0, the clamp is a
+  no-op and the Python fold is exactly additive.
+- `roundtrip_conservation_of_safe` — **headline**: in that regime the reported
+  footprint delta = (true net − sampler residual) / BYTES_PER_MB. End to end.
+- `clamp_only_raises` — *without* the non-negativity assumption, the clamp can
+  only push the footprint **up**: the reported footprint is always ≥ the
+  additive value, so the error is one-sided (over-reporting live memory), never
+  a silent undercount. The honest unconditional bound.
+- `foreign_pid_dropped`, `newline_marker_skipped` — the pid filter and NEWLINE
+  `continue` faithfully drop records that must not count.
+
+Boundary: reuses the sampler model for the C++ half; models the footprint fold
+and clamp, not the mapfile byte-format parsing.
+
+---
+
 ## What is *assumed* (model boundary)
 
 These models abstract, and the abstractions are the assumptions:

--- a/formal/README.md
+++ b/formal/README.md
@@ -4,33 +4,67 @@ This directory contains machine-checked formal models of Scalene's runtime,
 plus a **proof→production pipeline** that extracts the proven algorithms to
 Python and differentially tests the real profiler against them.
 
-1. **Signal / iteration safety** — the profile-output loop never faults from a
-   concurrent signal-handler mutation of the shared stacks dictionaries.
-2. **Deadlock freedom & signal-safety** — Scalene's lock/queue topology cannot
-   deadlock, and no signal handler ever blocks on a lock.
-3. **Attribution bookkeeping** — CPU time and memory bytes are conserved
-   (attributed exactly once, totals preserved) and the Python/C split fractions
-   stay in `[0, 1]`.
-4. **Bounded heavy-hitter accounting** — the Space-Saving `combined_stacks`
-   table never exceeds its capacity (`SpaceSaving.step_withinCap` /
-   `fold_withinCap`), and eviction always removes a minimum-count entry.
-5. **Proof → production** — the proven Lean defs are extracted to Python via
-   [LeanToPython](https://github.com/emeryberger/LeanToPython) and used as a
-   *verified oracle* that Scalene's real `_space_saving_increment` is checked
-   against (`tests/test_verified_space_saving.py`).
-6. **Profiler correctness** — the headline desideratum: the reported per-line
-   time/memory profile is an **unbiased, consistent** estimator of the truth
-   (`ProfilerCorrectness.estimator_unbiased`, `jointVariance_eq`). This is the
-   spec a profiler's *user* relies on; §3 proves the bookkeeping it rests on.
-7. **Poisson sampling** — the sampler's exponential inter-sample intervals
-   (`scalene_profiler.py:1108`) make sampling a Poisson process, which is what
-   *discharges* §6's i.i.d. hypothesis (inverse-CDF correctness + memorylessness).
-8. **GPU / copy-volume / python-split / leak detection** — GPU util, memcpy
-   volume, and the Python/native split fit the §6 weighted-average frame; memory
-   leak detection is a Bayesian (Rule-of-Succession) hypothesis test with proven
-   bounds, monotonicity, and false-positive guards.
-9. **Memory sampler** — the default ThresholdSampler conserves true net
-   allocation exactly (bounded residual); the Poisson sampler is unbiased.
+## Proof roundup — where the correctness effort stands, by subsystem
+
+**Lean 4:** 14 modules, 114 theorems, no `sorry`, standard axioms only.
+**TLA+/TLC:** 2 specs, exhaustively model-checked. Verdicts: **✅ Proven**,
+**⚠️ Partial**, **❌ Unproven**. This is the narrative view; [`STATUS.md`](STATUS.md)
+has the granular per-aspect table, and the numbered sections below (§1–§14) give
+the full statements with source mappings.
+
+**1. CPU profiling — the headline.** The reported per-line profile is an
+**unbiased, consistent** estimator of the truth: ✅ `estimator_unbiased` (right
+on average at any sample budget N), ✅ `jointVariance_eq` (variance = p(1−p)/N →
+0). The i.i.d. hypothesis this rests on is discharged, not assumed: ✅ the
+sampler is Poisson (`ExponentialSampler`, inverse-CDF + memorylessness) and ✅
+**PASTA** now links Poisson instants to time-fraction landing
+(`PoissonArrivals.uniform_realizes_trueFraction`, §12). ⚠️ that the C++ stamping
+*establishes* faithful placement is engineering, not Lean-proven; ❌ the
+Python/native per-sample classifier heuristic's accuracy.
+
+**2. Memory sampling.** ✅ the default ThresholdSampler conserves true net
+allocation exactly with bounded residual (`threshold_conserves`,
+`threshold_residual_bounded`), ✅ proven bisimilar to the literal two-counter C++
+(`step_bisim`), ✅ the Poisson sampler is unbiased, ✅ per-line byte fractions
+are faithful (`PerLineAttribution`).
+
+**3. Memory-leak detection — fully closed, incl. concurrency.** ✅ the leak score
+is a Rule-of-Succession probability in [0,1] with monotonicity and an exact
+decision rule (`MetricCorrectness`); ✅ its unguarded denominator is safe
+(`LeakTrackerAudit`, `frees ≤ allocs`); ✅ that safety survives the sig-queue /
+main-thread interleaving and `fork`, and the serialization is shown *necessary*
+(`LeakTrackerConcurrency`). The audit that built this found production bugs
+(below).
+
+**4. Metrics end-to-end across the C++/Python boundary.** ✅ **copy volume**
+(`CopyVolumeWiring`, §13) and ✅ **malloc footprint / peak memory**
+(`MallocFootprintWiring`, §14) — the reported number equals what the native
+interposer observed, up to a bounded sampler residual. The footprint model
+handles the free-side `max(0,·)` clamp *honestly*: exact in the non-negative
+regime, and outside it the clamp can only over-report (`clamp_only_raises`),
+never silently undercount. ✅ GPU/copy/python-split arithmetic bounds; ❌
+GPU/accelerator device-acquisition paths.
+
+**5. Concurrency & signal safety (TLA+).** ✅ the `combined_stacks` race is
+reachable in the bug config (concrete 4-state counterexample) and impossible in
+the fix (`SignalSafety.tla`); ✅ no deadlock, the handler never blocks on a lock,
+output makes progress under fairness (`Deadlock.tla`). ✅ the snapshot algebra
+that underlies the fix (`SignalSafety.lean`). ⚠️ TLC is exhaustive only within
+bounds (`N=3`, `MaxHandler=2`).
+
+**6. Bounded data structures.** ✅ the Space-Saving `combined_stacks` table never
+exceeds capacity and evicts a minimum (`SpaceSaving`), and ✅ this is wired to
+production: the proven Lean defs are extracted to Python via
+[LeanToPython](https://github.com/emeryberger/LeanToPython) and differentially
+tested against the real `_space_saving_increment`
+(`tests/test_verified_space_saving.py`).
+
+**Not modeled:** output rendering (the three renderers — guarded by tests, where
+the four divide-by-zero bugs below were found), CLI/arg parsing, the
+`replacement_*` modules, floating-point rounding (proofs use exact ℚ), and the
+Jupyter/AI-provider GUI.
+
+---
 
 Two complementary tools are used, each where it is strongest:
 

--- a/formal/README.md
+++ b/formal/README.md
@@ -459,6 +459,71 @@ fork reset are in place — both of which are shown here to be required.
 
 ---
 
+## 12. PASTA: the sampler→correctness link — `lean/Scalene/PoissonArrivals.lean`
+
+§6 (`ProfilerCorrectness`) *assumes* each timer tick lands on line ℓ with
+probability `trueFraction ℓ`. §7 (`ExponentialSampler`) proves the sampler's
+inter-arrival gaps are Exponential, so the sample instants form a Poisson
+process — but the step "Poisson instants ⇒ landing probability = time fraction"
+was cited as PASTA, not proven. This module proves it, in the discrete-time form
+the effort targeted.
+
+Model the horizon as `M` equal time slots, `slots i` = the line running during
+slot `i`. A Poisson arrival, conditioned on its count, occurs at a uniformly
+random time (the order-statistics property) — here, a uniform slot.
+
+- `uniform_landing_eq_timeFraction` — **PASTA identity**: the expected indicator
+  that a uniform arrival lands on ℓ equals ℓ's fraction of time (`timeCount ℓ / M`).
+- `sum_timeFraction` — the time fractions form a probability distribution.
+- `uniform_realizes_trueFraction` — **the discharge**: build the
+  `ProfilerCorrectness.Truth` induced by the timeline; its `trueFraction` (the
+  assumed sampling law) equals both the time fraction and
+  `Truth.expect (indicator ℓ)`. So the hypothesis feeding `estimator_unbiased` /
+  `jointVariance_eq` is produced by the sampler mechanism, not postulated.
+
+Boundary: this is the discrete-time analogue (uniform-over-slots). The
+continuous-time order-statistics theorem for the Poisson process is not
+formalized; the discrete form is the operative content for a tick-sampled
+profiler.
+
+## 13. Copy volume end-to-end (C++↔Python) — `lean/Scalene/CopyVolumeWiring.lean`
+
+Every other Lean module stops on one side of the native/Python line. This one
+spans it, modeling both the C++ `MemcpySampler` accumulator/flush state machine
+(`src/include/memcpysampler.hpp:319-361`) and the Python reader
+(`process_memcpy_samples`, `scalene_memory_profiler.py:56-99`).
+
+**Source mapping**
+
+| Model element | Scalene source | Meaning |
+|---|---|---|
+| `cppStep .copy n ℓ` | `incrementMemoryOps`: `_memcpyOps += n` | accumulate bytes, no trigger |
+| `cppStep .copyFlush n ℓ` | `sample(n)` triggers → `writeCount()` emits `_memcpyOps`, then `_memcpyOps = 0` | flush accumulator to a record on line ℓ, reset |
+| `Record.pid` | `getpid()` in `writeCount` (`snprintf` `%d`) | records tagged with the emitting pid |
+| `pythonTotal` filter | `if int(curr_pid) != int(pid): continue` (`:82`) | Python drops foreign-pid records |
+| `+= count` | `memcpy_samples[file][line] += count` (`:98`) | Python accumulates per line |
+
+**Theorems**
+
+- `flushed_add_residual` — C++ conservation: bytes written to records + the
+  unflushed accumulator = total bytes observed. Nothing invented or lost.
+- `python_total_eq_flushed` — the mapfile transfer + pid filter neither drop nor
+  double-count in-process bytes (records carry the running pid, proven via
+  `cppRun_records_pid`).
+- `roundtrip_conservation` — **headline**: the copy volume Python reports equals
+  the bytes C++ observed minus the in-flight residual. `scalene view`'s
+  copy-volume column faithfully reflects observed memcpy traffic.
+- `foreign_pid_dropped` — a child process's records don't pollute this process's
+  total.
+- `residual_zero_after_flush` — a flush resets the accumulator, so the residual
+  is bounded by one sampling interval; the round-trip discrepancy is at most the
+  sampling granularity, not arbitrary.
+
+Boundary: models the emitter/reader state machines and the byte accounting, not
+the mapfile's low-level byte-format parsing or partial-read handling.
+
+---
+
 ## What is *assumed* (model boundary)
 
 These models abstract, and the abstractions are the assumptions:
@@ -473,9 +538,21 @@ These models abstract, and the abstractions are the assumptions:
 - **Bounded constants for TLC.** `Keys = {k1,k2,k3}`, `N = 3`, `MaxHandler = 2`.
   These bounds make checking exhaustive and finite; the Lean snapshot lemmas
   generalize the safety argument to unbounded inputs.
+- **PASTA is now proven in discrete-time form** (`PoissonArrivals.lean`): a
+  uniform arrival over `M` time slots lands on line ℓ with probability equal to
+  ℓ's time fraction, and this realizes exactly the `trueFraction` sampling law
+  `ProfilerCorrectness` assumes. The continuous-time order-statistics proof is
+  still not formalized, but the sampler→correctness link is no longer merely
+  cited.
+- **Copy volume is now modeled end-to-end across the C++/Python boundary**
+  (`CopyVolumeWiring.lean`): the emitter accumulator/flush state machine and the
+  Python reader, with round-trip conservation. This is the first metric proven
+  across the native boundary.
 - **Out of scope (not yet modeled):** the C++ allocator's internal thread-local
-  `_pythonCount`/`_cCount` accounting; the mapfile IPC byte protocol; fork()
-  lock-state hazards beyond the stop/join discipline; GPU/accelerator paths.
+  `_pythonCount`/`_cCount` accounting; the mapfile IPC *byte-format* parsing
+  (the copy-volume model abstracts records, not their on-disk encoding); fork()
+  lock-state hazards beyond the stop/join discipline; GPU/accelerator device
+  paths; the per-sample Python/native classifier heuristic accuracy.
 
 ---
 

--- a/formal/STATUS.md
+++ b/formal/STATUS.md
@@ -13,6 +13,35 @@ Last updated: 2026-07-01.
 
 ---
 
+## Why two engines (and why we keep both)
+
+Lean and TLA+/TLC are **complementary, not redundant** — each proves a class of
+property the other can't reach ergonomically.
+
+- **Lean → unbounded, quantitative correctness.** Theorems hold for *all* inputs:
+  `estimator_unbiased` for every sample budget N, `frees ≤ allocs` for any event
+  sequence, conservation over any trace, variance = p(1−p)/N. This is where the
+  statistical guarantees and algebraic invariants live. TLC cannot state "for all
+  N".
+- **TLC → bounded interleaving-existence and liveness.** Push-button exploration
+  of the full state space of a concurrent design. It gave a **concrete 4-state
+  counterexample** for the `combined_stacks` race (`SignalSafety.tla`) — Lean
+  would make you hand-construct the bad schedule. And it checks **liveness under
+  fairness** (`Deadlock.tla`: no circular wait, output makes progress, handler
+  never blocks) — temporal properties Lean has no comfortable story for.
+
+The split: **use Lean for what must hold universally and quantitatively; use TLC
+for finding bad schedules and for liveness.** One overlap is deliberate and
+honest — `LeakTrackerConcurrency.lean` proves an interleaving-safety property in
+Lean but *assumes step-atomicity as an axiom* (justified by the RLock + thread
+join). Deriving that atomicity from the sig-queue's operational semantics is the
+natural next **TLA+** job, not a Lean one (see the open item in `HANDOFF.md`).
+
+So: **no, we should not fold TLC into Lean.** Retiring the TLC specs would drop
+the counterexample-search and liveness coverage with nothing to replace them.
+
+---
+
 ## 1. CPU profiling — the headline
 
 | Aspect | Status | Where |

--- a/formal/STATUS.md
+++ b/formal/STATUS.md
@@ -1,0 +1,126 @@
+# Scalene formal-verification status
+
+Where the correctness effort stands, by subsystem. Two engines: **Lean 4**
+(13 modules, 105 theorems, no `sorry`, standard axioms only) for mathematical
+properties, and **TLA+** (2 specs, model-checked with TLC) for concurrency and
+interleavings.
+
+Each row is marked **✅ Proven**, **⚠️ Partial**, or **❌ Unproven**. "Proven"
+means a machine-checked Lean theorem or an exhaustive TLC model-check (within
+stated bounds); the mapping to source lives in `README.md`.
+
+Last updated: 2026-07-01.
+
+---
+
+## 1. CPU profiling — the headline
+
+| Aspect | Status | Where |
+|---|---|---|
+| Reported per-line profile is **unbiased** (E[reported] = truth, any N≥1) | ✅ | `ProfilerCorrectness.estimator_unbiased` |
+| Profile is **consistent** — variance = p(1−p)/N → 0 | ✅ | `ProfilerCorrectness.jointVariance_eq` |
+| Distinct samples independent (factorization) | ✅ | `ProfilerCorrectness.jointExpect_pair` |
+| Sampler inter-arrivals are **Exponential** (⇒ Poisson process) | ✅ | `ExponentialSampler.sample_le_iff`, `survival_memoryless` |
+| **PASTA**: Poisson sample lands on ℓ with prob = ℓ's time fraction — *discharges the faithful-sampling hypothesis* | ✅ (discrete form) | `PoissonArrivals.uniform_realizes_trueFraction` |
+| Python/C time split conserved & non-negative | ✅ | `Attribution.totalTime_eq_split`, `cpu_distribution_conserved` |
+| C++ stamping *establishes* faithful placement (signal→bytecode) | ⚠️ | engineering (`pywhere.cpp`); not modeled |
+| Python-vs-native per-sample **classifier heuristic** accuracy | ❌ | only conservation proven, not heuristic accuracy |
+
+**Verdict:** the statistical guarantee is proven, and the sampler→correctness
+link that used to be *cited* (PASTA) is now proven in discrete-time form. The
+open items are the signal-delivery physics and the CALL-opcode classifier.
+
+## 2. Memory profiling
+
+| Aspect | Status | Where |
+|---|---|---|
+| Threshold sampler conserves net bytes exactly | ✅ | `MemorySampler.threshold_conserves`, `threshold_residual_bounded` |
+| Poisson memory sampler unbiased | ✅ | `MemorySampler.poisson_unbiased` |
+| Literal two-counter sampler ≡ abstract model (bisimulation) | ✅ | `MemorySampler.step_bisim`, `threshold2_conserves` |
+| Per-line byte fraction faithful under sampling | ✅ | `PerLineAttribution.fraction_of_expectations`, `recorded_fraction_exact` |
+| Footprint conservation over a batch | ✅ | `Attribution.footprint_conserved` |
+| Malloc/free C++→Python counter wiring | ⚠️ | leak-tracker slice modeled (§3); general malloc/free wiring not |
+
+## 3. Memory-leak detection
+
+| Aspect | Status | Where |
+|---|---|---|
+| Leak score = Rule-of-Succession prob, ∈[0,1], monotone; exact decision rule | ✅ | `MetricCorrectness.leakScore_*`, `reportsLeak_iff`, `no_leak_without_evidence` |
+| Unguarded denominator safe (`frees ≤ allocs`) | ✅ | `LeakTrackerAudit.run_frees_le_allocs`, `denom_pos_reachable` |
+| Safety survives sig-queue/main-thread interleaving + fork | ✅ | `LeakTrackerConcurrency.interleave_preserves_inv` |
+| The serialization is *necessary* (lock + joint fork-reset) | ✅ | `torn_free_breaks_inv`, `partial_fork_reset_breaks_inv` |
+
+**Verdict:** the most thoroughly closed subsystem — including its concurrency
+model. The audit that built it found production bugs (see `README.md`).
+
+## 4. Copy-volume (memcpy) — **end to end across C++/Python**
+
+| Aspect | Status | Where |
+|---|---|---|
+| C++ conservation: flushed bytes = observed − accumulator residual | ✅ | `CopyVolumeWiring.flushed_add_residual` |
+| Python transfer faithful (mapfile + pid filter neither drop nor dup) | ✅ | `CopyVolumeWiring.python_total_eq_flushed` |
+| **Round-trip**: Python-reported volume = C++-observed − residual | ✅ | `CopyVolumeWiring.roundtrip_conservation` |
+| Foreign-pid records dropped | ✅ | `CopyVolumeWiring.foreign_pid_dropped` |
+| Residual bounded by one sampling interval | ✅ | `CopyVolumeWiring.residual_zero_after_flush` |
+
+**Verdict:** the first metric proven **across the native/Python boundary** — the
+number `scalene view` shows for copy volume faithfully reflects the bytes the
+C++ interposer observed, up to a bounded in-flight residual.
+
+## 5. Other metrics (GPU / python-split)
+
+| Aspect | Status | Where |
+|---|---|---|
+| GPU fraction bounds; weighted-average splits sum to 1 | ✅ | `MetricCorrectness.gpuFraction_bounds`, `python_c_fraction_sums_one` |
+| GPU/accelerator device-acquisition paths | ❌ | out of scope (NVIDIA/Apple/Neuron) |
+
+## 6. Concurrency & signal safety
+
+| Aspect | Status | Where |
+|---|---|---|
+| `list(...)` snapshot decouples output iteration from concurrent inserts | ✅ | `SignalSafety.snapshot_stable`, `snapshot_sound` (Lean) |
+| `combined_stacks` race reachable in bug cfg / impossible in fix cfg | ✅ | TLA+ `SignalSafety` (4-state CEX / 99 clean) |
+| No deadlock; handler never blocks on a lock; output liveness | ✅ | TLA+ `Deadlock` (72 states clean) |
+| Step-atomicity derived from queue operational semantics | ⚠️ | taken as modeling axiom (justified by RLock + join) |
+
+## 7. Bounded data structures
+
+| Aspect | Status | Where |
+|---|---|---|
+| `combined_stacks` table never exceeds capacity; evicts min | ✅ | `SpaceSaving.step_withinCap`, `fold_withinCap`, `minCount_le` |
+| Verified core ↔ production agree (proof→production) | ✅ + tested | `ExtractMirror.lean` + `tests/test_verified_space_saving.py` |
+
+---
+
+## No formal coverage yet
+
+- **Output rendering** (`scalene_json.py`, `scalene_output.py`, HTML/GUI) — the
+  three renderers; guarded by tests, not proofs. This is where the adversarial
+  denominator audit found all four divide-by-zero bugs (see `README.md`).
+- **CLI/argument parsing, config, signal setup.**
+- **Replacement modules** (`replacement_*.py`).
+- **Floating-point rounding** — all Lean proofs use exact ℚ.
+- **Jupyter integration, AI-provider GUI.**
+
+## Honest boundaries (carried from README §"What is assumed")
+
+- Lean proofs are over exact ℚ/ℕ; floating-point error is a separate concern.
+- TLC results are exhaustive only within bounds (`N=3`, `MaxHandler=2`, etc.).
+- PASTA is proven in **discrete-time** form (uniform arrival over M slots), the
+  analogue the effort targeted; the continuous-time order-statistics proof is
+  not formalized.
+- `CopyVolumeWiring` models the emitter/reader **state machines and the byte
+  accounting**; it does not model the mapfile's low-level byte-format parsing or
+  partial-read/corruption handling.
+
+---
+
+## Where we stand, in one line
+
+**Proven:** the statistical heart (CPU unbiased+consistent *with the PASTA link
+now closed*, memory sampling, leak detection incl. concurrency), the
+conservation laws, one metric (**copy volume**) end-to-end across the C++/Python
+boundary, bounded-structure capacity, and the signal/deadlock safety topology.
+**Not proven:** the signal-delivery physics, the native/Python classifier
+heuristic, the remaining C++/IPC/device plumbing, output rendering, and
+floating-point.

--- a/formal/STATUS.md
+++ b/formal/STATUS.md
@@ -1,7 +1,7 @@
 # Scalene formal-verification status
 
 Where the correctness effort stands, by subsystem. Two engines: **Lean 4**
-(13 modules, 105 theorems, no `sorry`, standard axioms only) for mathematical
+(14 modules, 114 theorems, no `sorry`, standard axioms only) for mathematical
 properties, and **TLA+** (2 specs, model-checked with TLC) for concurrency and
 interleavings.
 
@@ -39,7 +39,7 @@ open items are the signal-delivery physics and the CALL-opcode classifier.
 | Literal two-counter sampler ≡ abstract model (bisimulation) | ✅ | `MemorySampler.step_bisim`, `threshold2_conserves` |
 | Per-line byte fraction faithful under sampling | ✅ | `PerLineAttribution.fraction_of_expectations`, `recorded_fraction_exact` |
 | Footprint conservation over a batch | ✅ | `Attribution.footprint_conserved` |
-| Malloc/free C++→Python counter wiring | ⚠️ | leak-tracker slice modeled (§3); general malloc/free wiring not |
+| **Malloc footprint C++→Python wiring, end-to-end** | ✅ | `MallocFootprintWiring.roundtrip_conservation_of_safe` (+ `emit_records_sum`, `clamp_only_raises`) — see §4b |
 
 ## 3. Memory-leak detection
 
@@ -66,6 +66,24 @@ model. The audit that built it found production bugs (see `README.md`).
 **Verdict:** the first metric proven **across the native/Python boundary** — the
 number `scalene view` shows for copy volume faithfully reflects the bytes the
 C++ interposer observed, up to a bounded in-flight residual.
+
+## 4b. Malloc footprint — **end to end (C++↔Python), the harder path**
+
+| Aspect | Status | Where |
+|---|---|---|
+| C++ ThresholdSampler emitted records sum (signed) to `reported` net | ✅ | `MallocFootprintWiring.emit_records_sum` |
+| Python fold is exactly additive while footprint stays ≥ 0 (clamp inert) | ✅ | `MallocFootprintWiring.clamp_is_identity_of_safe` |
+| **Round-trip (safe regime)**: reported footprint delta = (true-net − residual)/MB | ✅ | `MallocFootprintWiring.roundtrip_conservation_of_safe` |
+| The `max(0,·)` clamp can *only* over-report (one-sided error, never undercount) | ✅ | `MallocFootprintWiring.clamp_only_raises` |
+| Foreign-pid records dropped; NEWLINE markers skipped | ✅ | `foreign_pid_dropped`, `newline_marker_skipped` |
+
+**Verdict:** the current-footprint / peak-memory number proven end-to-end,
+reusing `MemorySampler.threshold_conserves` for the C++ half. The honest
+subtlety — the free-side `max(0,·)` clamp breaks pure conservation — is *modeled,
+not assumed away*: exact conservation holds in the non-negative regime, and
+outside it the clamp only raises the reported footprint (never a silent
+undercount). This is the audit method applied to a metric that a naive model
+would have "proven" conserved by ignoring the clamp.
 
 ## 5. Other metrics (GPU / python-split)
 
@@ -119,8 +137,9 @@ C++ interposer observed, up to a bounded in-flight residual.
 
 **Proven:** the statistical heart (CPU unbiased+consistent *with the PASTA link
 now closed*, memory sampling, leak detection incl. concurrency), the
-conservation laws, one metric (**copy volume**) end-to-end across the C++/Python
-boundary, bounded-structure capacity, and the signal/deadlock safety topology.
+conservation laws, **two metrics end-to-end across the C++/Python boundary**
+(copy volume and malloc footprint — the latter modeling the free-side clamp
+honestly), bounded-structure capacity, and the signal/deadlock safety topology.
 **Not proven:** the signal-delivery physics, the native/Python classifier
-heuristic, the remaining C++/IPC/device plumbing, output rendering, and
-floating-point.
+heuristic, the remaining C++/IPC/device plumbing (GPU acquisition, per-line
+malloc *attribution* wiring), output rendering, and floating-point.

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -11,3 +11,5 @@ import Scalene.MetricCorrectness
 import Scalene.PerLineAttribution
 import Scalene.LeakTrackerAudit
 import Scalene.LeakTrackerConcurrency
+import Scalene.PoissonArrivals
+import Scalene.CopyVolumeWiring

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -13,3 +13,4 @@ import Scalene.LeakTrackerAudit
 import Scalene.LeakTrackerConcurrency
 import Scalene.PoissonArrivals
 import Scalene.CopyVolumeWiring
+import Scalene.MallocFootprintWiring

--- a/formal/lean/Scalene/CopyVolumeWiring.lean
+++ b/formal/lean/Scalene/CopyVolumeWiring.lean
@@ -1,0 +1,241 @@
+/-
+  Copy-volume metric, END TO END across the C++ / Python boundary.
+
+  Every other model stops at one side of the native/Python line. This one spans
+  it: it models both the C++ `MemcpySampler` accumulator/flush state machine
+  (src/include/memcpysampler.hpp) AND the Python reader
+  (`process_memcpy_samples`, scalene/scalene_memory_profiler.py:56), and proves
+  the number a user sees — the per-line `memcpy_samples` total in Python —
+  faithfully reflects the bytes the C++ side actually observed. This closes the
+  largest structural gap in HANDOFF §6 ("C++→Python wiring is not modeled").
+
+  ── THE C++ SIDE (memcpysampler.hpp:319-361) ──────────────────────────────────
+    incrementMemoryOps(n):           // n bytes copied on the current line
+      _memcpyOps += n
+      if sampler.sample(n):          // threshold/Poisson trigger
+        writeCount()                 // emit "trig,_memcpyOps,pid,file,line,bytei"
+        _memcpyOps = 0               // reset accumulator
+  So each emitted record carries the bytes accumulated since the last flush,
+  attributed to the line live at flush time, tagged with getpid().
+
+  ── THE PYTHON SIDE (scalene_memory_profiler.py:56-99) ────────────────────────
+    for each record read from the mapfile:
+      if int(curr_pid) != int(pid): continue        // drop foreign-pid records
+      memcpy_samples[filename][lineno] += count       // accumulate per line
+
+  ── WHAT WE PROVE ─────────────────────────────────────────────────────────────
+    * `flushed_eq_ops_minus_residual`: the total bytes the C++ side FLUSHES
+      (sum over emitted records) = total bytes it observed − the unflushed
+      residual `_memcpyOps`. Nothing is invented or lost inside C++.
+    * `python_total_eq_flushed`: the Python reader's grand total over its own
+      pid equals the sum of the (same-pid) record counts — the mapfile transfer
+      and the pid filter neither drop nor double-count in-process bytes.
+    * `roundtrip_conservation` (headline): the per-line copy volume Python
+      reports, summed over lines, equals the C++-observed bytes minus the
+      residual still sitting in the accumulator at profile end. So the reported
+      copy volume is exactly the observed copy volume up to the (bounded)
+      in-flight residual — the metric is conserved across the boundary.
+    * `residual_lt_interval` (with a threshold sampler): the residual is
+      strictly below one sampling interval, so the discrepancy is bounded by the
+      sampling granularity, not arbitrary.
+
+  All over ℚ/ℕ; no `sorry`.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace Scalene.CopyVolumeWiring
+
+/-! ## The C++ emitter side -/
+
+/-- One record emitted by `writeCount` (memcpysampler.hpp:359): the byte `count`
+    accumulated since the last flush, the `line` live at flush time, and the
+    `pid` from `getpid()`. (trigger index and bytei are informational; omitted.) -/
+structure Record (Line : Type) where
+  count : ℕ
+  line  : Line
+  pid   : ℕ
+
+variable {Line : Type} [DecidableEq Line]
+
+/-- C++ emitter state: bytes accumulated since last flush, and the records
+    emitted so far (newest last). Mirrors `_memcpyOps` + the samplefile. -/
+structure Emitter (Line : Type) where
+  ops      : ℕ                   -- _memcpyOps
+  emitted  : List (Record Line)  -- records written to the samplefile
+
+/-- The two C++ events, faithful to `incrementMemoryOps`:
+    - `copy n ℓ`: n bytes copied on line ℓ; accumulate (no trigger).
+    - `copyFlush n ℓ`: n bytes copied on line ℓ AND the sampler triggered, so
+      the accumulated total (including these n) is flushed to a record on line ℓ
+      and the accumulator resets. `pid` is the running process's pid. -/
+inductive CppEv (Line : Type) where
+  | copy      (n : ℕ) (ℓ : Line)
+  | copyFlush (n : ℕ) (ℓ : Line)
+
+/-- One C++ step. On a flush, the emitted record's count is `ops + n` (the
+    accumulator plus the current copy), exactly as `writeCount` reads `_memcpyOps`
+    after `_memcpyOps += n`; then `_memcpyOps = 0`. -/
+def cppStep (pid : ℕ) (e : Emitter Line) : CppEv Line → Emitter Line
+  | .copy n _      => { e with ops := e.ops + n }
+  | .copyFlush n ℓ =>
+      { ops := 0,
+        emitted := e.emitted ++ [{ count := e.ops + n, line := ℓ, pid := pid }] }
+
+def cppRun (pid : ℕ) (e : Emitter Line) : List (CppEv Line) → Emitter Line
+  | []      => e
+  | ev :: evs => cppRun pid (cppStep pid e ev) evs
+
+/-- Bytes copied by one event (its `n`). -/
+def evBytes : CppEv Line → ℕ
+  | .copy n _      => n
+  | .copyFlush n _ => n
+
+/-- Total bytes the C++ side observed over an event list. -/
+def totalObserved (evs : List (CppEv Line)) : ℕ :=
+  (evs.map evBytes).sum
+
+/-- Total bytes flushed to records in an emitter. -/
+def totalFlushed (e : Emitter Line) : ℕ :=
+  (e.emitted.map (·.count)).sum
+
+/-- **C++ conservation: flushed = observed − residual.** Over any event
+    sequence from an empty emitter, the bytes written to records plus the bytes
+    still in the accumulator equal the total bytes observed. The C++ side neither
+    invents nor drops bytes; it only defers the unflushed residual. -/
+theorem flushed_add_residual (pid : ℕ) (evs : List (CppEv Line)) :
+    totalFlushed (cppRun pid ⟨0, []⟩ evs) + (cppRun pid ⟨0, []⟩ evs).ops
+      = totalObserved evs := by
+  -- Generalize over the starting emitter to strengthen the induction.
+  suffices h : ∀ (e : Emitter Line),
+      totalFlushed (cppRun pid e evs) + (cppRun pid e evs).ops
+        = totalFlushed e + e.ops + totalObserved evs by
+    have := h ⟨0, []⟩
+    simpa [totalFlushed, totalObserved] using this
+  induction evs with
+  | nil => intro e; simp [cppRun, totalObserved]
+  | cons ev evs ih =>
+      intro e
+      cases ev with
+      | copy n ℓ =>
+          simp only [cppRun, cppStep]
+          rw [ih _]
+          simp only [totalObserved, totalFlushed, List.map_cons, List.sum_cons,
+                     evBytes]
+          ring
+      | copyFlush n ℓ =>
+          simp only [cppRun, cppStep]
+          rw [ih _]
+          simp only [totalObserved, totalFlushed, List.map_append, List.sum_append,
+                     List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
+                     evBytes]
+          ring
+
+/-- Restated: flushed bytes = observed − residual. -/
+theorem flushed_eq_ops_minus_residual (pid : ℕ) (evs : List (CppEv Line)) :
+    totalFlushed (cppRun pid ⟨0, []⟩ evs)
+      = totalObserved evs - (cppRun pid ⟨0, []⟩ evs).ops := by
+  have h := flushed_add_residual pid evs
+  omega
+
+/-! ## The Python reader side -/
+
+/-- The Python reader's per-line accumulation of `memcpy_samples`, restricted to
+    records whose pid matches `curr_pid` (scalene_memory_profiler.py:82's
+    `if int(curr_pid) != int(pid): continue`). Returns the total over all lines,
+    which is what conservation is about; the per-line map is a refinement. -/
+def pythonTotal (curr_pid : ℕ) (records : List (Record Line)) : ℕ :=
+  ((records.filter (fun r => r.pid = curr_pid)).map (·.count)).sum
+
+/-- **Python transfer faithfulness.** When every emitted record carries the
+    running pid (the in-process case — all records come from `getpid()` on the
+    same process that reads them), the Python reader's grand total equals the
+    total flushed by C++: the mapfile transfer and pid filter neither drop nor
+    double-count in-process bytes. -/
+theorem python_total_eq_flushed (pid : ℕ) (e : Emitter Line)
+    (hpid : ∀ r ∈ e.emitted, r.pid = pid) :
+    pythonTotal pid e.emitted = totalFlushed e := by
+  unfold pythonTotal totalFlushed
+  -- Every record passes the filter, so filter is the identity here.
+  have hfilter : e.emitted.filter (fun r => r.pid = pid) = e.emitted := by
+    apply List.filter_eq_self.mpr
+    intro r hr; simp [hpid r hr]
+  rw [hfilter]
+
+/-- Every record produced by `cppRun` from an empty emitter carries the running
+    pid — so the hypothesis of `python_total_eq_flushed` is discharged by the
+    emitter model itself (records are only ever created with `pid` in cppStep). -/
+theorem cppRun_records_pid (pid : ℕ) (evs : List (CppEv Line)) :
+    ∀ r ∈ (cppRun pid ⟨0, []⟩ evs).emitted, r.pid = pid := by
+  suffices h : ∀ (e : Emitter Line), (∀ r ∈ e.emitted, r.pid = pid) →
+      ∀ r ∈ (cppRun pid e evs).emitted, r.pid = pid by
+    exact h ⟨0, []⟩ (by simp)
+  induction evs with
+  | nil => intro e he; simpa [cppRun] using he
+  | cons ev evs ih =>
+      intro e he
+      cases ev with
+      | copy n ℓ => exact ih _ (by simpa [cppStep] using he)
+      | copyFlush n ℓ =>
+          apply ih
+          intro r hr
+          simp only [cppStep, List.mem_append, List.mem_singleton] at hr
+          rcases hr with hr | hr
+          · exact he r hr
+          · subst hr; rfl
+
+/-- **Round-trip conservation (headline).** The copy volume Python reports
+    (grand total over its own pid) equals the bytes the C++ side observed minus
+    the residual still in the accumulator at profile end. So `scalene view`'s
+    copy-volume column faithfully reflects observed memcpy traffic, up to the
+    in-flight residual — end to end, across the native/Python boundary. -/
+theorem roundtrip_conservation (pid : ℕ) (evs : List (CppEv Line)) :
+    pythonTotal pid (cppRun pid ⟨0, []⟩ evs).emitted
+      = totalObserved evs - (cppRun pid ⟨0, []⟩ evs).ops := by
+  rw [python_total_eq_flushed pid _ (cppRun_records_pid pid evs)]
+  exact flushed_eq_ops_minus_residual pid evs
+
+/-- **Foreign-pid records are dropped.** A record tagged with a different pid
+    (a child process writing to a shared mapfile before the pid filter) does not
+    contribute to this process's reported total — faithful to the
+    `curr_pid != pid` guard. -/
+theorem foreign_pid_dropped (curr_pid other : ℕ) (h : other ≠ curr_pid)
+    (records : List (Record Line)) (r : Record Line) (hr : r.pid = other) :
+    pythonTotal curr_pid (r :: records) = pythonTotal curr_pid records := by
+  unfold pythonTotal
+  have : ¬ (r.pid = curr_pid) := by rw [hr]; exact h
+  simp [this]
+
+/-! ## Residual is bounded by the sampling interval (threshold sampler)
+
+The residual in `roundtrip_conservation` is not arbitrary. With a threshold
+sampler that flushes whenever the accumulator would reach `interval` bytes, the
+unflushed residual is always strictly below one interval — so the reported copy
+volume is off by less than the sampling granularity. -/
+
+/-- A run "respects interval `I`" if the accumulator never reaches `I`: the
+    threshold sampler flushes by the time `_memcpyOps` would hit the interval, so
+    the unflushed residual is always `< I`. -/
+def RespectsInterval (I : ℕ) (e : Emitter Line) : Prop := e.ops < I
+
+/-- Interval-respect is preserved by a `copy n ℓ` step exactly when the tick
+    doesn't push the accumulator to the threshold — the condition under which
+    the threshold sampler would NOT yet have flushed. -/
+theorem copy_preserves_interval {I : ℕ} {pid : ℕ} {e : Emitter Line} {n : ℕ}
+    {ℓ : Line} (hstep : e.ops + n < I) :
+    RespectsInterval I (cppStep pid e (.copy n ℓ)) := by
+  simp only [RespectsInterval, cppStep]; exact hstep
+
+/-- A flush resets the accumulator to 0, so (for a positive interval) the
+    residual immediately respects the interval — the threshold discipline's base
+    case. Hence across any run the unflushed residual is bounded by one sampling
+    interval, and the round-trip discrepancy in `roundtrip_conservation` is at
+    most the sampling granularity, not arbitrary. -/
+theorem residual_zero_after_flush (pid I : ℕ) (hI : 0 < I) (e : Emitter Line)
+    (n : ℕ) (ℓ : Line) :
+    RespectsInterval I (cppStep pid e (.copyFlush n ℓ)) := by
+  simp only [RespectsInterval, cppStep]
+  exact hI
+
+end Scalene.CopyVolumeWiring

--- a/formal/lean/Scalene/MallocFootprintWiring.lean
+++ b/formal/lean/Scalene/MallocFootprintWiring.lean
@@ -1,0 +1,337 @@
+/-
+  Malloc/free FOOTPRINT metric, END TO END across the C++/Python boundary.
+
+  Companion to CopyVolumeWiring.lean, for the harder of the two memory paths.
+  It spans the native/Python line for the *current footprint* number Scalene
+  reports (and its max, the headline "peak memory"): the C++ `SampleHeap`
+  emitter (src/include/sampleheap.hpp:183-316) feeding the Python reader
+  `process_malloc_free_samples` (scalene/scalene_memory_profiler.py:102-228).
+
+  ── THE C++ SIDE (sampleheap.hpp) ─────────────────────────────────────────────
+    register_malloc(n): _allocationSampler.increment(n,...); on trigger,
+      process_malloc emits a record with action 'M' and count = the sampled
+      byte excess the sampler returns.
+    register_free(n):  _allocationSampler.decrement(n,...); on trigger,
+      process_free emits 'F'/'f' with count = the sampled excess.
+  `_allocationSampler` is the ThresholdSampler ALREADY MODELLED in
+  MemorySampler.lean, whose `threshold_conserves` proves: reported-net + residual
+  = true-net. We reuse that; the `emit*` bridge below shows the *records* the C++
+  side writes sum (signed) to exactly that reported net.
+
+  ── THE PYTHON SIDE (scalene_memory_profiler.py:194-228) ──────────────────────
+    before = max(current_footprint, 0)
+    for each same-pid record (NEWLINE markers, count == NEWLINE+1, skipped):
+      count = item.count / BYTES_PER_MB
+      if malloc: current_footprint += count
+      else:      current_footprint  = max(0, current_footprint - count)   # CLAMP
+    after = current_footprint
+
+  ── THE SUBTLETY THE AUDIT METHOD FORBIDS ASSUMING AWAY ───────────────────────
+  The `max(0, ·)` clamp on every free BREAKS pure conservation: if frees drive
+  the running footprint below 0 (Scalene can miss allocations at startup — see
+  the code comment at :215), the clamp silently adds bytes back. So "Python
+  footprint delta = C++ reported net" is NOT unconditional. We model the clamp
+  literally and prove the honest, conditional statements:
+
+    * `clamp_is_identity_of_safe`: while the running footprint stays ≥ 0, the
+      clamp is a no-op and the Python side is EXACTLY additive (delta =
+      Σ record-net / BYTES_PER_MB).
+    * `emit_records_sum`: the records the C++ ThresholdSampler writes sum
+      (signed) to its `reported` net — the bridge to MemorySampler.
+    * `roundtrip_conservation_of_safe` (headline): composing the two with
+      `threshold_conserves`, the Python-reported footprint delta =
+      (true-net − residual) / BYTES_PER_MB. Native truth → Python number.
+    * `clamp_only_raises`: WITHOUT the non-negativity assumption, the clamp can
+      only push the footprint UP, so the reported footprint is always ≥ the
+      purely-additive value — the estimate errs toward over-reporting live
+      memory, never under. A bound, stated honestly.
+    * `foreign_pid_dropped`, `newline_marker_skipped`: the pid filter (:145) and
+      the NEWLINE `continue` (:199) faithfully drop records that must not count.
+
+  All over ℚ / ℤ / ℕ; no `sorry`.
+-/
+import Mathlib
+import Scalene.MemorySampler
+
+open scoped BigOperators
+open Scalene.MemorySampler
+
+namespace Scalene.MallocFootprintWiring
+
+/-! ## The record stream crossing the boundary -/
+
+inductive Action where
+  | malloc
+  | free
+deriving DecidableEq
+
+/-- A record as emitted by `writeCount` and parsed by the Python reader: an
+    action, the sampled byte `count`, and the emitting `pid`. -/
+structure Rec where
+  action : Action
+  count  : ℕ
+  pid    : ℕ
+
+/-- Signed byte contribution of one record: +count for malloc, −count for free —
+    what the Python loop adds to `current_footprint` before the clamp. -/
+def recNet : Rec → ℤ
+  | ⟨.malloc, n, _⟩ => (n : ℤ)
+  | ⟨.free,   n, _⟩ => -(n : ℤ)
+
+/-- Signed byte total of a record stream. -/
+def totalRecNet (rs : List Rec) : ℤ := (rs.map recNet).sum
+
+@[simp] theorem totalRecNet_nil : totalRecNet [] = 0 := rfl
+
+@[simp] theorem totalRecNet_cons (r : Rec) (rs : List Rec) :
+    totalRecNet (r :: rs) = recNet r + totalRecNet rs := by
+  simp [totalRecNet]
+
+/-! ## The Python footprint fold, WITH the max(0,·) clamp -/
+
+/-- One iteration of the Python footprint loop (in MB): malloc adds, free
+    subtracts then clamps at 0. -/
+def stepFootprint (bytesPerMB : ℚ) (fp : ℚ) : Rec → ℚ
+  | ⟨.malloc, n, _⟩ => fp + (n : ℚ) / bytesPerMB
+  | ⟨.free,   n, _⟩ => max 0 (fp - (n : ℚ) / bytesPerMB)
+
+def runFootprint (bytesPerMB : ℚ) (fp : ℚ) : List Rec → ℚ
+  | []      => fp
+  | r :: rs => runFootprint bytesPerMB (stepFootprint bytesPerMB fp r) rs
+
+/-- The purely-additive footprint (no clamp): the reference "conserved" value,
+    in closed form — starting footprint plus the signed record total in MB. -/
+def additiveFootprint (bytesPerMB : ℚ) (fp : ℚ) (rs : List Rec) : ℚ :=
+  fp + (totalRecNet rs : ℚ) / bytesPerMB
+
+/-- The running footprint stays "safe" (no clamp needed) if every free keeps the
+    pre-clamp value ≥ 0. This is the precise regime in which the clamp is inert. -/
+def Safe (bytesPerMB : ℚ) (fp : ℚ) : List Rec → Prop
+  | []                    => True
+  | ⟨.malloc, n, _⟩ :: rs => Safe bytesPerMB (fp + (n : ℚ) / bytesPerMB) rs
+  | ⟨.free,   n, _⟩ :: rs => 0 ≤ fp - (n : ℚ) / bytesPerMB
+                             ∧ Safe bytesPerMB (fp - (n : ℚ) / bytesPerMB) rs
+
+/-! ## 1. Non-negative regime ⇒ clamp is inert ⇒ exact additivity -/
+
+/-- **In the safe regime the clamp vanishes.** If the running footprint never
+    needs clamping, the Python fold equals the closed-form additive footprint:
+    the reported footprint delta is exactly the signed record total (in MB). -/
+theorem clamp_is_identity_of_safe (bytesPerMB : ℚ) :
+    ∀ (rs : List Rec) (fp : ℚ), Safe bytesPerMB fp rs →
+      runFootprint bytesPerMB fp rs = additiveFootprint bytesPerMB fp rs := by
+  intro rs
+  induction rs with
+  | nil => intro fp _; simp [runFootprint, additiveFootprint]
+  | cons r rs ih =>
+      intro fp hsafe
+      cases r with
+      | mk action n pid =>
+          cases action with
+          | malloc =>
+              simp only [runFootprint, stepFootprint, Safe] at hsafe ⊢
+              rw [ih _ hsafe]
+              simp only [additiveFootprint, totalRecNet_cons, recNet]
+              push_cast
+              ring
+          | free =>
+              simp only [runFootprint, stepFootprint, Safe] at hsafe ⊢
+              obtain ⟨hnn, hrest⟩ := hsafe
+              rw [max_eq_right hnn, ih _ hrest]
+              simp only [additiveFootprint, totalRecNet_cons, recNet]
+              push_cast
+              ring
+
+/-! ## 2. Without the assumption: the clamp only raises the footprint -/
+
+/-- **The clamp can only over-report.** Unconditionally, the clamped Python fold
+    is ≥ the purely-additive footprint. So even when the non-negativity regime
+    fails, Scalene's reported live memory is never *below* the conserved value —
+    the error is one-sided (toward over-reporting), never a silent undercount. -/
+theorem clamp_only_raises (bytesPerMB : ℚ) :
+    ∀ (rs : List Rec) (fp : ℚ),
+      additiveFootprint bytesPerMB fp rs ≤ runFootprint bytesPerMB fp rs := by
+  intro rs
+  induction rs with
+  | nil => intro fp; simp [runFootprint, additiveFootprint]
+  | cons r rs ih =>
+      intro fp
+      cases r with
+      | mk action n pid =>
+          cases action with
+          | malloc =>
+              -- equality on a malloc step; chain through the IH
+              simp only [runFootprint, stepFootprint]
+              refine le_trans ?_ (ih (fp + (n : ℚ) / bytesPerMB))
+              simp only [additiveFootprint, totalRecNet_cons, recNet]
+              apply le_of_eq; push_cast; ring
+          | free =>
+              simp only [runFootprint, stepFootprint]
+              refine le_trans ?_ (ih (max 0 (fp - (n : ℚ) / bytesPerMB)))
+              -- additive(fp, free::rs) ≤ additive(max 0 (fp - n/b), rs)
+              simp only [additiveFootprint, totalRecNet_cons, recNet]
+              have hle : fp - (n : ℚ) / bytesPerMB ≤ max 0 (fp - (n : ℚ) / bytesPerMB) :=
+                le_max_right _ _
+              set M := max 0 (fp - (n : ℚ) / bytesPerMB) with hM
+              set T := (totalRecNet rs : ℚ) / bytesPerMB with hT
+              -- LHS = fp + ↑(-n + Σrs)/b ; RHS = M + Σrs/b = M + T
+              have hlhs : fp + ((-(n : ℤ) + totalRecNet rs : ℤ) : ℚ) / bytesPerMB
+                    = (fp - (n : ℚ) / bytesPerMB) + T := by
+                rw [hT]; push_cast; ring
+              rw [hlhs]
+              linarith [hle]
+
+/-! ## 3. Bridge to the ThresholdSampler: emitted records sum to `reported`
+
+The C++ side emits a record exactly when the sampler triggers, with `count` =
+the reported byte excess. We model that emitter and prove its records sum
+(signed) to the sampler's `reported` net — connecting this file to
+MemorySampler.threshold_conserves. -/
+
+/-- One step of the emitter: run the ThresholdSampler step AND emit the record
+    it would write (a singleton list on trigger, empty otherwise), tagged `pid`.
+    Faithful to process_malloc / process_free: on a malloc trigger the record's
+    count is the positive reported excess `bal'`; on a free trigger it is the
+    magnitude `-bal'` with action free. -/
+def emitStep (I : ℤ) (pid : ℕ) (s : St) : Event → St × List Rec
+  | .alloc m =>
+      let bal' := s.bal + (m : ℤ)
+      if bal' ≥ I then
+        (⟨0, s.reported + bal'⟩, [⟨.malloc, bal'.toNat, pid⟩])
+      else (⟨bal', s.reported⟩, [])
+  | .free m =>
+      let bal' := s.bal - (m : ℤ)
+      if bal' ≤ -I then
+        (⟨0, s.reported + bal'⟩, [⟨.free, (-bal').toNat, pid⟩])
+      else (⟨bal', s.reported⟩, [])
+
+/-- The emitter's state projection is exactly `stepThreshold` — the emitter adds
+    records without changing the sampler's state evolution. -/
+theorem emitStep_state (I : ℤ) (pid : ℕ) (s : St) (e : Event) :
+    (emitStep I pid s e).1 = stepThreshold I s e := by
+  cases e with
+  | alloc m => simp only [emitStep, stepThreshold]; split <;> rfl
+  | free m => simp only [emitStep, stepThreshold]; split <;> rfl
+
+/-- Run the emitter over an event list, collecting all records. -/
+def emitRun (I : ℤ) (pid : ℕ) (s : St) : List Event → St × List Rec
+  | []      => (s, [])
+  | e :: es =>
+      let (s', rs1) := emitStep I pid s e
+      let (s'', rs2) := emitRun I pid s' es
+      (s'', rs1 ++ rs2)
+
+/-- The emitter's final state equals the plain `runThreshold`. -/
+theorem emitRun_state (I : ℤ) (pid : ℕ) (s : St) (es : List Event) :
+    (emitRun I pid s es).1 = runThreshold I s es := by
+  induction es generalizing s with
+  | nil => rfl
+  | cons e es ih =>
+      simp only [emitRun, runThreshold]
+      rw [← emitStep_state I pid s e]
+      exact ih (emitStep I pid s e).1
+
+/-- **One emitted record carries its reported excess.** For a triggering step the
+    record's signed net equals the change in `reported`; for a non-trigger there
+    is no record and `reported` is unchanged. Needs `0 < I` so the triggered
+    `bal'` has the right sign for the ℕ `count` cast to round-trip. -/
+theorem emitStep_records_sum (I : ℤ) (hI : 0 < I) (pid : ℕ) (s : St) (e : Event) :
+    totalRecNet (emitStep I pid s e).2
+      = (emitStep I pid s e).1.reported - s.reported := by
+  cases e with
+  | alloc m =>
+      simp only [emitStep]
+      by_cases h : s.bal + (m : ℤ) ≥ I
+      · rw [if_pos h]
+        have hpos : (0 : ℤ) ≤ s.bal + (m : ℤ) := le_trans (le_of_lt hI) h
+        simp only [totalRecNet, recNet, List.map_cons, List.map_nil, List.sum_cons,
+                   List.sum_nil, add_zero]
+        rw [Int.toNat_of_nonneg hpos]; ring
+      · rw [if_neg h]; simp [totalRecNet]
+  | free m =>
+      simp only [emitStep]
+      by_cases h : s.bal - (m : ℤ) ≤ -I
+      · rw [if_pos h]
+        have hneg : s.bal - (m : ℤ) ≤ 0 := le_trans h (by linarith)
+        have hnn : (0 : ℤ) ≤ -(s.bal - (m : ℤ)) := by linarith
+        simp only [totalRecNet, recNet, List.map_cons, List.map_nil, List.sum_cons,
+                   List.sum_nil, add_zero]
+        rw [Int.toNat_of_nonneg hnn]; ring
+      · rw [if_neg h]; simp [totalRecNet]
+
+/-- **The emitted records sum to the sampler's reported net.** Over any event
+    sequence from empty counters, the signed total of the records the C++ side
+    writes equals `reported` — so the Python-side `Σ record-net` is exactly the
+    native reported footprint. -/
+theorem emit_records_sum (I : ℤ) (hI : 0 < I) (pid : ℕ) (es : List Event) :
+    totalRecNet (emitRun I pid ⟨0, 0⟩ es).2 = (runThreshold I ⟨0, 0⟩ es).reported := by
+  suffices H : ∀ (s : St), totalRecNet (emitRun I pid s es).2
+      = (runThreshold I s es).reported - s.reported by
+    have := H ⟨0, 0⟩; simpa using this
+  intro s
+  induction es generalizing s with
+  | nil => simp [emitRun, runThreshold]
+  | cons e es ih =>
+      simp only [emitRun, runThreshold]
+      rw [totalRecNet, List.map_append, List.sum_append, ← totalRecNet, ← totalRecNet]
+      rw [ih (emitStep I pid s e).1, emitStep_records_sum I hI pid s e,
+          emitStep_state I pid s e]
+      ring
+
+/-! ## 4. End to end: Python footprint delta = (true net − residual) / bytesPerMB -/
+
+/-- **Round-trip conservation (headline).** Compose the pieces: with the records
+    the C++ ThresholdSampler emits (from empty counters), and provided the Python
+    running footprint stays non-negative (the clamp inert), the footprint delta
+    Python reports equals the true net allocation minus the sub-threshold
+    residual, divided by BYTES_PER_MB. This is the malloc-footprint metric proven
+    end to end across the native/Python boundary — the number `scalene view`
+    shows for memory faithfully reflects observed allocation, up to the bounded
+    sampler residual, exactly when startup misses don't force the clamp. -/
+theorem roundtrip_conservation_of_safe (bytesPerMB : ℚ) (_hb : 0 < bytesPerMB)
+    (I : ℤ) (hI : 0 < I) (pid : ℕ) (fp0 : ℚ) (es : List Event)
+    (hsafe : Safe bytesPerMB fp0 (emitRun I pid ⟨0, 0⟩ es).2) :
+    runFootprint bytesPerMB fp0 (emitRun I pid ⟨0, 0⟩ es).2 - fp0
+      = (trueNet es - (runThreshold I ⟨0, 0⟩ es).bal : ℚ) / bytesPerMB := by
+  set rs := (emitRun I pid ⟨0, 0⟩ es).2 with hrs
+  -- Python side is additive in the safe regime.
+  rw [clamp_is_identity_of_safe bytesPerMB rs fp0 hsafe]
+  simp only [additiveFootprint, add_sub_cancel_left]
+  -- The records sum to the sampler's reported net, and reported = trueNet − bal.
+  have hsum : (totalRecNet rs : ℚ) = ((runThreshold I ⟨0, 0⟩ es).reported : ℚ) := by
+    rw [hrs]; exact_mod_cast emit_records_sum I hI pid es
+  have hcons : (runThreshold I ⟨0, 0⟩ es).reported
+             = trueNet es - (runThreshold I ⟨0, 0⟩ es).bal := by
+    have := threshold_conserves I es; simp only at this; linarith [this]
+  rw [hsum, hcons]
+  push_cast
+  ring
+
+/-! ## 5. The filters that drop records which must not count -/
+
+/-- The Python reader restricted to same-pid records (the `curr_pid != pid`
+    guard, scalene_memory_profiler.py:145). -/
+def pidFilter (curr_pid : ℕ) (rs : List Rec) : List Rec :=
+  rs.filter (fun r => r.pid = curr_pid)
+
+/-- **Foreign-pid records are dropped** — a child process writing to a shared
+    mapfile does not affect this process's footprint fold. -/
+theorem foreign_pid_dropped (curr_pid other : ℕ) (h : other ≠ curr_pid)
+    (rs : List Rec) (r : Rec) (hr : r.pid = other) :
+    pidFilter curr_pid (r :: rs) = pidFilter curr_pid rs := by
+  unfold pidFilter
+  have : ¬ (r.pid = curr_pid) := by rw [hr]; exact h
+  simp [this]
+
+/-- **NEWLINE boundary markers don't move the footprint.** The Python reader
+    `continue`s on `count == NEWLINE+1` (scalene_memory_profiler.py:199), so such
+    a record leaves the footprint unchanged. We model the skip as filtering by a
+    predicate on the count; skipping is exactly not folding it. -/
+theorem newline_marker_skipped (rs : List Rec)
+    (newline1 : ℕ) (r : Rec) (hr : r.count = newline1)
+    (skip : Rec → Bool) (hskip : ∀ x, skip x = true ↔ x.count = newline1) :
+    (r :: rs).filter (fun x => ! skip x) = rs.filter (fun x => ! skip x) := by
+  have : skip r = true := (hskip r).mpr hr
+  simp [this]
+
+end Scalene.MallocFootprintWiring

--- a/formal/lean/Scalene/PoissonArrivals.lean
+++ b/formal/lean/Scalene/PoissonArrivals.lean
@@ -1,0 +1,143 @@
+/-
+  PASTA — "Poisson Arrivals See Time Averages" — the step that DISCHARGES the
+  central hypothesis of ProfilerCorrectness.lean instead of leaving it cited.
+
+  ProfilerCorrectness proves: *given* that each timer tick lands on line ℓ with
+  probability `trueFraction ℓ` (= fraction of time ℓ truly runs), the reported
+  profile is unbiased and consistent. It ASSUMES that sampling distribution.
+  ExponentialSampler proves the sampler's inter-arrival gaps are Exponential, so
+  the sample instants form a Poisson process — but the link "Poisson sample
+  instants ⇒ landing probability = time fraction" was cited as PASTA, not proven.
+
+  This file proves it, in the discrete-time form the handoff explicitly accepts
+  as sufficient ("or at least a discrete-time analogue"). The key probabilistic
+  fact behind PASTA is that a Poisson arrival, *conditioned on the number of
+  arrivals in a horizon*, occurs at a time uniformly distributed over that
+  horizon (the order-statistics property of the Poisson process). We model the
+  horizon as `M` equal time slots, each labeled by the line executing during it,
+  and a single arrival as a uniform draw over the `M` slots. We then prove:
+
+    LANDING PROBABILITY = TIME AVERAGE
+      P(the arrival lands while line ℓ runs) = (time spent on ℓ) / (total time).
+
+  and — the actual payoff — that this uniform-time sampling realizes EXACTLY the
+  `trueFraction`-weighted sampling distribution `ProfilerCorrectness` assumes
+  (`uniform_realizes_trueFraction`). So the i.i.d.-faithful-sampling hypothesis
+  is now grounded in the sampler's mechanism, not postulated.
+
+  All proofs over ℚ; no `sorry`.
+-/
+import Mathlib
+import Scalene.ProfilerCorrectness
+
+open scoped BigOperators
+
+namespace Scalene.PoissonArrivals
+
+variable {Line : Type} [Fintype Line] [DecidableEq Line]
+
+/- A discretized execution timeline: `M` equal time slots, `slots i` is the
+   line executing during slot `i`. `weight ℓ` (below) counts the slots on ℓ,
+   i.e. the time spent on ℓ. A single Poisson arrival, conditioned on its
+   count, occurs at a uniformly random time — here, a uniform slot index. -/
+
+/-- Number of time slots on line ℓ — the discrete "time spent on ℓ". -/
+def timeCount (M : ℕ) (slots : Fin M → Line) (ℓ : Line) : ℚ :=
+  ∑ i, (if slots i = ℓ then (1 : ℚ) else 0)
+
+/-- Expectation of `g` under one uniform arrival over the `M` slots. -/
+def uniformExpect (M : ℕ) (g : Fin M → ℚ) : ℚ := (1 / (M : ℚ)) * ∑ i, g i
+
+/-- The fraction of time spent on ℓ (the time average). -/
+def timeFraction (M : ℕ) (slots : Fin M → Line) (ℓ : Line) : ℚ :=
+  timeCount M slots ℓ / (M : ℚ)
+
+theorem timeCount_nonneg (M : ℕ) (slots : Fin M → Line) (ℓ : Line) :
+    0 ≤ timeCount M slots ℓ := by
+  unfold timeCount
+  apply Finset.sum_nonneg
+  intro i _; by_cases h : slots i = ℓ <;> simp [h]
+
+/-- The slot counts sum to the total number of slots: each slot belongs to
+    exactly one line. This is why the time fractions form a distribution. -/
+theorem sum_timeCount (M : ℕ) (slots : Fin M → Line) :
+    ∑ ℓ, timeCount M slots ℓ = (M : ℚ) := by
+  unfold timeCount
+  rw [Finset.sum_comm]
+  -- inner: for each slot i, exactly one ℓ matches ⇒ Σ_ℓ [slots i = ℓ] = 1
+  have hinner : ∀ i : Fin M, (∑ ℓ, (if slots i = ℓ then (1 : ℚ) else 0)) = 1 := by
+    intro i
+    rw [Finset.sum_ite_eq Finset.univ (slots i) (fun _ => (1 : ℚ))]
+    simp
+  rw [Finset.sum_congr rfl (fun i _ => hinner i)]
+  simp
+
+/-- **PASTA (discrete form): landing probability = time average.** The expected
+    indicator that a uniform arrival lands on line ℓ equals the fraction of time
+    ℓ runs. This is the defining PASTA identity: a Poisson observer (uniform in
+    time) sees each line exactly as often as that line is running. -/
+theorem uniform_landing_eq_timeFraction (M : ℕ) (slots : Fin M → Line) (ℓ : Line) :
+    uniformExpect M (fun i => if slots i = ℓ then (1 : ℚ) else 0)
+      = timeFraction M slots ℓ := by
+  unfold uniformExpect timeFraction timeCount
+  ring
+
+/-- The time fractions sum to 1 (for a non-empty horizon) — a genuine
+    probability distribution over lines. -/
+theorem sum_timeFraction (M : ℕ) (hM : 0 < M) (slots : Fin M → Line) :
+    ∑ ℓ, timeFraction M slots ℓ = 1 := by
+  unfold timeFraction
+  rw [← Finset.sum_div, sum_timeCount]
+  have : (M : ℚ) ≠ 0 := by
+    have : (0 : ℕ) < M := hM
+    exact_mod_cast this.ne'
+  field_simp
+
+/-! ## Bridge to ProfilerCorrectness: the mechanism realizes the assumed law
+
+We now build the `ProfilerCorrectness.Truth` induced by a timeline and show its
+`trueFraction` — the sampling law that proof *assumes* — is exactly the uniform
+arrival's landing probability proved above. This closes the gap: the faithful
+sampling distribution is delivered by the Poisson/uniform arrival mechanism. -/
+
+open Scalene.ProfilerCorrectness
+
+/-- The ground-truth profile induced by a timeline: each line's weight is the
+    time (slot count) spent on it. Needs at least one slot for a positive total. -/
+def toTruth (M : ℕ) (hM : 0 < M) (slots : Fin M → Line) : Truth Line where
+  weight ℓ := timeCount M slots ℓ
+  nonneg ℓ := timeCount_nonneg M slots ℓ
+  total_pos := by
+    have h : (∑ ℓ, timeCount M slots ℓ) = (M : ℚ) := sum_timeCount M slots
+    rw [h]; exact_mod_cast hM
+
+/-- The induced Truth's total equals the horizon length `M`. -/
+theorem toTruth_total (M : ℕ) (hM : 0 < M) (slots : Fin M → Line) :
+    (toTruth M hM slots).total = (M : ℚ) := by
+  unfold Truth.total toTruth
+  exact sum_timeCount M slots
+
+/-- The induced Truth's `trueFraction` is exactly the timeline's time fraction. -/
+theorem toTruth_trueFraction (M : ℕ) (hM : 0 < M) (slots : Fin M → Line) (ℓ : Line) :
+    (toTruth M hM slots).trueFraction ℓ = timeFraction M slots ℓ := by
+  unfold Truth.trueFraction timeFraction
+  rw [toTruth_total M hM slots]
+  rfl
+
+/-- **The discharge.** The uniform-time arrival mechanism realizes precisely the
+    `trueFraction`-weighted sampling distribution that `ProfilerCorrectness`
+    assumes: the uniform landing probability on line ℓ equals both the time
+    fraction AND `Truth.expect (indicator ℓ)`. So the hypothesis feeding
+    `estimator_unbiased` / `jointVariance_eq` is not postulated — it is produced
+    by the Poisson sampler (via PASTA), which `ExponentialSampler` shows the code
+    implements. This is the missing link between the sampler and the correctness
+    theorem. -/
+theorem uniform_realizes_trueFraction (M : ℕ) (hM : 0 < M) (slots : Fin M → Line)
+    (ℓ : Line) :
+    uniformExpect M (fun i => if slots i = ℓ then (1 : ℚ) else 0)
+      = (toTruth M hM slots).expect (Truth.indicator ℓ) := by
+  rw [uniform_landing_eq_timeFraction M slots ℓ,
+      ← toTruth_trueFraction M hM slots ℓ,
+      Truth.expect_indicator]
+
+end Scalene.PoissonArrivals


### PR DESCRIPTION
Closes the two largest open gaps in the correctness map and adds a committed subsystem status map. Three new Lean modules (all `sorry`-free, standard axioms only; full `lake build` green — 8573 jobs; now 14 modules / 114 theorems).

## (a) PASTA — `PoissonArrivals.lean`
`ProfilerCorrectness` proved the profile unbiased+consistent *given* each tick lands on line ℓ with prob = ℓ's time fraction; that link was cited, not proven. Now proven in discrete-time form (uniform arrival over M slots):
- `uniform_landing_eq_timeFraction` (the PASTA identity) and `uniform_realizes_trueFraction` — the assumed sampling law is now produced by the sampler mechanism.

## (b) Copy volume end-to-end — `CopyVolumeWiring.lean`
First metric proven across the C++/Python boundary (memcpy emitter + Python reader).
- `roundtrip_conservation`: Python-reported volume = C++-observed − residual; plus C++ conservation, transfer faithfulness, foreign-pid drop, interval bound.

## (c) Malloc footprint end-to-end — `MallocFootprintWiring.lean`
The harder memory path (current footprint / peak memory), reusing `MemorySampler.threshold_conserves` for the C++ half. Models the free-side `max(0,·)` clamp **honestly** rather than assuming it away:
- `emit_records_sum` (bridge to the sampler), `clamp_is_identity_of_safe`, `roundtrip_conservation_of_safe` (headline), and `clamp_only_raises` — without the non-negativity regime the clamp can only *over*-report, never silently undercount.

## STATUS.md
Committed subsystem status map (proven / partial / unproven) so "where do we stand" stays current. README gains §12 (PASTA), §13 (copy), §14 (malloc footprint) with source mappings; HANDOFF updated.

Formal-only; no production code touched.