### PR TITLE
Formal: Python/native classifier + per-line malloc attribution

### DIFF
--- a/formal/HANDOFF.md
+++ b/formal/HANDOFF.md
@@ -85,6 +85,8 @@ at `/tmp/LeanToPython` locally (Lean 4.12).
 | `PoissonArrivals.lean` | **PASTA (discrete)**: uniform arrival lands on ℓ with prob = ℓ's time fraction; realizes the assumed `trueFraction` sampling law → discharges the ProfilerCorrectness hypothesis | `uniform_landing_eq_timeFraction`, `uniform_realizes_trueFraction`, `sum_timeFraction` |
 | `CopyVolumeWiring.lean` | **copy volume end-to-end (C++↔Python)**: emitter/reader state machines; reported volume = observed − residual | `flushed_add_residual`, `python_total_eq_flushed`, `roundtrip_conservation`, `foreign_pid_dropped` |
 | `MallocFootprintWiring.lean` | **malloc footprint end-to-end (C++↔Python)**: reuses ThresholdSampler; models the free-side `max(0,·)` clamp honestly (conserves in safe regime; only over-reports otherwise) | `emit_records_sum`, `clamp_is_identity_of_safe`, `roundtrip_conservation_of_safe`, `clamp_only_raises` |
+| `PythonNativeClassifier.lean` | **Python/native classifier conserves the CPU budget in every branch** (total function); per-branch split characterized; branch-choice accuracy is the heuristic (conditional correctness only) | `charge_total`, `classified_conserves`, `split_atCall`/`split_together`, `charge_nonneg`, `branchA_exact_if_in_call` |
+| `PerLineMallocAttribution.lean` | **per-line malloc bookkeeping**: Σ per-line bytes = grand total; python-share ≤ bytes; high-water dominates & monotone | `perline_conserves`, `python_le_malloc`, `highwater_ge_current`, `highwater_monotone` |
 | `LeakTrackerAudit.lean` | proves the leak formula's *unguarded* denominator is safe (`frees ≤ allocs`) | `run_frees_le_allocs`, `denom_pos_reachable` |
 | `LeakTrackerConcurrency.lean` | `frees ≤ allocs` survives sig-queue/main-thread interleaving + fork; RLock atomicity & joint fork-reset shown *necessary* | `interleave_preserves_inv`, `torn_free_breaks_inv`, `fork_reset_inv`, `partial_fork_reset_breaks_inv` |
 | TLA+ `SignalSafety` | the combined_stacks race is reachable (bug cfg) / impossible (fix cfg) | 4-state counterexample; 99 states clean |
@@ -246,17 +248,21 @@ generated `X | Y` unions need 3.10+).
    assumes (`uniform_realizes_trueFraction`). Residual: continuous-time
    order-statistics proof still not formalized (discrete form is the operative
    content for a tick-sampled profiler).
-5. **Prove per-sample classifier accuracy** for the python/native split, or
-   document precisely why it's a heuristic with bounded error.
+5. ~~Prove/characterize the python/native classifier~~ **PARTIALLY DONE** —
+   `PythonNativeClassifier.lean` proves the classifier *conserves* each sample's
+   CPU budget in every branch (`charge_total`), is a total function
+   (`classify_total`), and is conditionally correct (`branchA_exact_if_in_call`).
+   STILL OPEN: which branch is right per sample (the CALL-opcode/deferral
+   heuristic) — needs modeling signal delivery vs. bytecode, out of current scope.
 6. **Wire the verified oracle into production directly** (have
    `_space_saving_increment` call the extracted core) rather than only
    differential-testing it — closes the proof→production loop tighter.
-7. ~~Model columns end-to-end incl. the C++→Python wiring~~ **DONE (×2)** —
-   `CopyVolumeWiring.lean` (memcpy) and `MallocFootprintWiring.lean` (current
-   footprint / peak memory; models the free-side `max(0,·)` clamp honestly).
-   NEXT such target: per-line malloc *attribution* wiring (the
-   `memory_malloc_samples[file][line] += count` path, distinct from the footprint
-   total modeled here) or GPU acquisition.
+7. ~~Model columns end-to-end incl. the C++→Python wiring~~ **DONE (×2)** +
+   ~~per-line malloc attribution~~ **DONE** — `CopyVolumeWiring.lean` (memcpy),
+   `MallocFootprintWiring.lean` (footprint total), and
+   `PerLineMallocAttribution.lean` (the per-line `memory_malloc_samples`/
+   `memory_python_samples`/high-water bookkeeping). NEXT such target: GPU
+   acquisition, or the per-line *free*/leak-credit bookkeeping.
 8. **A committed status map** lives at `formal/STATUS.md` — keep it current when
    modules land.
 

--- a/formal/README.md
+++ b/formal/README.md
@@ -6,7 +6,7 @@ Python and differentially tests the real profiler against them.
 
 ## Proof roundup — where the correctness effort stands, by subsystem
 
-**Lean 4:** 14 modules, 114 theorems, no `sorry`, standard axioms only.
+**Lean 4:** 16 modules, 133 theorems, no `sorry`, standard axioms only.
 **TLA+/TLC:** 2 specs, exhaustively model-checked. Verdicts: **✅ Proven**,
 **⚠️ Partial**, **❌ Unproven**. This is the narrative view; [`STATUS.md`](STATUS.md)
 has the granular per-aspect table, and the numbered sections below (§1–§14) give
@@ -18,15 +18,21 @@ on average at any sample budget N), ✅ `jointVariance_eq` (variance = p(1−p)/
 0). The i.i.d. hypothesis this rests on is discharged, not assumed: ✅ the
 sampler is Poisson (`ExponentialSampler`, inverse-CDF + memorylessness) and ✅
 **PASTA** now links Poisson instants to time-fraction landing
-(`PoissonArrivals.uniform_realizes_trueFraction`, §12). ⚠️ that the C++ stamping
-*establishes* faithful placement is engineering, not Lean-proven; ❌ the
-Python/native per-sample classifier heuristic's accuracy.
+(`PoissonArrivals.uniform_realizes_trueFraction`, §12). ✅ the Python/native
+classifier *conserves* each sample's CPU budget in every branch
+(`PythonNativeClassifier.charge_total`, §15). ⚠️ that the C++ stamping
+*establishes* faithful placement is engineering, not Lean-proven; ⚠️ *which*
+classifier branch is right is the CALL-opcode heuristic (conditional
+correctness proven, `branchA_exact_if_in_call`; the detection itself not
+formalized).
 
 **2. Memory sampling.** ✅ the default ThresholdSampler conserves true net
 allocation exactly with bounded residual (`threshold_conserves`,
 `threshold_residual_bounded`), ✅ proven bisimilar to the literal two-counter C++
 (`step_bisim`), ✅ the Poisson sampler is unbiased, ✅ per-line byte fractions
-are faithful (`PerLineAttribution`).
+are faithful (`PerLineAttribution`). ✅ the per-line reader bookkeeping conserves
+(Σ per-line bytes = grand total), keeps the python-share ≤ total bytes, and
+reports a monotone high-water peak (`PerLineMallocAttribution`, §16).
 
 **3. Memory-leak detection — fully closed, incl. concurrency.** ✅ the leak score
 is a Rule-of-Succession probability in [0,1] with monotonicity and an exact
@@ -604,6 +610,57 @@ conditional statements:
 
 Boundary: reuses the sampler model for the C++ half; models the footprint fold
 and clamp, not the mapfile byte-format parsing.
+
+---
+
+## 15. Python/native classifier — `lean/Scalene/PythonNativeClassifier.lean`
+
+The heuristic that splits each CPU sample's time between Python and native code
+(`scalene_cpu_profiler.py:251-341`). It picks one of four branches from the
+bytecode position: (A) at a CALL → all time native on this line; (B) c_time > 0
+with a preceding CALL on a different line → c_time native there, python_time
+Python here; (C) same line / not found → together; (D) else → as computed.
+
+We separate the **theorem** from the **heuristic**:
+
+- `charge_total` / `classified_conserves` — **conservation**: in *every* branch
+  the total time charged across all `(line, python|native)` buckets equals the
+  sample's `cpu = python_time + c_time`. The classification only *moves* a fixed
+  budget between buckets; it never invents or drops time.
+- `split_atCall`, `split_together`, `split_splitToCall` — the native/Python
+  split each branch decides (all-native for A; `c_time`/`python_time` for B/C/D),
+  characterizing the classifier's per-branch behaviour.
+- `charge_nonneg` — every bucket charge is ≥ 0 (from `python_time, c_time ≥ 0`,
+  which the code guarantees via `c_time = max(elapsed − python, 0)`).
+- `classify_total` — the branch selector is a total function of the observable
+  facts: exactly one branch fires for any input, so attribution is always
+  defined over the whole input space.
+
+The heuristic boundary, stated not hidden: *which* branch is correct depends on
+whether the async signal was deferred inside a C call — unobservable from the
+sample. `branchA_exact_if_in_call` proves the conditional (if the sample truly
+landed in native code, branch A is exactly right); the CALL-opcode detection
+that is supposed to establish that hypothesis is engineering, not formalized.
+
+## 16. Per-line malloc attribution — `lean/Scalene/PerLineMallocAttribution.lean`
+
+The Python reader's per-line bookkeeping (`scalene_memory_profiler.py:336-360`),
+distinct from §14's footprint *total*: the `memory_malloc_samples`,
+`memory_python_samples`, and per-line high-water dicts the profile reports per
+source line, and the invariants the JSON renderer's divides depend on.
+
+- `perline_conserves` — **per-line conservation**: Σ over lines of
+  `memory_malloc_samples[line]` = `total_memory_malloc_samples`. Every malloc's
+  bytes are credited to exactly one line and the grand total, so
+  `n_usage_fraction = malloc[line]/total` is a genuine fraction.
+- `python_le_malloc` — per line `0 ≤ memory_python_samples ≤
+  memory_malloc_samples`, because each step adds `python_fraction·count ≤ count`
+  (`python_fraction ∈ [0,1]`). This *derives* the bound `Attribution.lean`
+  assumed (`pythonBytes_le_count`) — exactly the precondition
+  `scalene_json.py`'s `n_python_fraction = python/malloc ∈ [0,1]` needs.
+- `highwater_ge_current`, `highwater_monotone` — the per-line high-water mark
+  dominates the running per-line footprint and never decreases: the reported
+  peak is a true, monotone upper bound.
 
 ---
 

--- a/formal/STATUS.md
+++ b/formal/STATUS.md
@@ -1,7 +1,7 @@
 # Scalene formal-verification status
 
 Where the correctness effort stands, by subsystem. Two engines: **Lean 4**
-(14 modules, 114 theorems, no `sorry`, standard axioms only) for mathematical
+(16 modules, 133 theorems, no `sorry`, standard axioms only) for mathematical
 properties, and **TLA+** (2 specs, model-checked with TLC) for concurrency and
 interleavings.
 
@@ -52,12 +52,14 @@ the counterexample-search and liveness coverage with nothing to replace them.
 | Sampler inter-arrivals are **Exponential** (⇒ Poisson process) | ✅ | `ExponentialSampler.sample_le_iff`, `survival_memoryless` |
 | **PASTA**: Poisson sample lands on ℓ with prob = ℓ's time fraction — *discharges the faithful-sampling hypothesis* | ✅ (discrete form) | `PoissonArrivals.uniform_realizes_trueFraction` |
 | Python/C time split conserved & non-negative | ✅ | `Attribution.totalTime_eq_split`, `cpu_distribution_conserved` |
+| **Python/native classifier conserves the sample's CPU budget in every branch** | ✅ | `PythonNativeClassifier.charge_total`, `classified_conserves` (+ `charge_nonneg`, per-branch `split_*`) — §15 |
 | C++ stamping *establishes* faithful placement (signal→bytecode) | ⚠️ | engineering (`pywhere.cpp`); not modeled |
-| Python-vs-native per-sample **classifier heuristic** accuracy | ❌ | only conservation proven, not heuristic accuracy |
+| Python-vs-native classifier per-sample *branch-choice* accuracy | ⚠️ | conditional correctness proven (`branchA_exact_if_in_call`); which branch is *right* is the CALL-opcode heuristic, not formalized |
 
 **Verdict:** the statistical guarantee is proven, and the sampler→correctness
 link that used to be *cited* (PASTA) is now proven in discrete-time form. The
-open items are the signal-delivery physics and the CALL-opcode classifier.
+classifier's *bookkeeping* is now proven conserving; the open items are the
+signal-delivery physics and which-branch-is-right (the CALL-opcode heuristic).
 
 ## 2. Memory profiling
 
@@ -69,6 +71,7 @@ open items are the signal-delivery physics and the CALL-opcode classifier.
 | Per-line byte fraction faithful under sampling | ✅ | `PerLineAttribution.fraction_of_expectations`, `recorded_fraction_exact` |
 | Footprint conservation over a batch | ✅ | `Attribution.footprint_conserved` |
 | **Malloc footprint C++→Python wiring, end-to-end** | ✅ | `MallocFootprintWiring.roundtrip_conservation_of_safe` (+ `emit_records_sum`, `clamp_only_raises`) — see §4b |
+| **Per-line malloc attribution**: Σ per-line bytes = grand total; python-share ≤ bytes; high-water dominates & is monotone | ✅ | `PerLineMallocAttribution.perline_conserves`, `python_le_malloc`, `highwater_ge_current`, `highwater_monotone` — §16 |
 
 ## 3. Memory-leak detection
 
@@ -166,9 +169,11 @@ would have "proven" conserved by ignoring the clamp.
 
 **Proven:** the statistical heart (CPU unbiased+consistent *with the PASTA link
 now closed*, memory sampling, leak detection incl. concurrency), the
-conservation laws, **two metrics end-to-end across the C++/Python boundary**
-(copy volume and malloc footprint — the latter modeling the free-side clamp
-honestly), bounded-structure capacity, and the signal/deadlock safety topology.
-**Not proven:** the signal-delivery physics, the native/Python classifier
-heuristic, the remaining C++/IPC/device plumbing (GPU acquisition, per-line
-malloc *attribution* wiring), output rendering, and floating-point.
+conservation laws — including the Python/native classifier's budget and the
+per-line malloc attribution bookkeeping — **two metrics end-to-end across the
+C++/Python boundary** (copy volume and malloc footprint, the latter modeling the
+free-side clamp honestly), bounded-structure capacity, and the signal/deadlock
+safety topology. **Not proven:** the signal-delivery physics, *which* classifier
+branch is correct per sample (the CALL-opcode heuristic — only conservation and
+conditional correctness are proven), the remaining device plumbing (GPU
+acquisition), output rendering, and floating-point.

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -14,3 +14,5 @@ import Scalene.LeakTrackerConcurrency
 import Scalene.PoissonArrivals
 import Scalene.CopyVolumeWiring
 import Scalene.MallocFootprintWiring
+import Scalene.PythonNativeClassifier
+import Scalene.PerLineMallocAttribution

--- a/formal/lean/Scalene/PerLineMallocAttribution.lean
+++ b/formal/lean/Scalene/PerLineMallocAttribution.lean
@@ -1,0 +1,198 @@
+/-
+  Per-line malloc ATTRIBUTION — conservation, python-share bound, high-water.
+
+  Distinct from `MallocFootprintWiring.lean` (which proves the *total* current
+  footprint round-trips across the C++/Python boundary). This file is about the
+  Python reader's PER-LINE bookkeeping: the four dicts
+  `memory_malloc_samples`, `memory_python_samples`, `memory_malloc_count`, and
+  the per-line high-water mark that Scalene reports per source line
+  (scalene_memory_profiler.py:336-360), and the invariants the JSON renderer
+  relies on when it divides by them.
+
+  ── THE LOOP (scalene_memory_profiler.py:336-360, malloc branch) ──────────────
+    malloc_samples_file[lineno]   += count                     # bytes on this line
+    python_samples_file[lineno]   += python_fraction * count   # python-attributed
+    total_memory_malloc_samples   += count                     # grand total
+    current_footprint_file[lineno]+= count
+    highwater_file[lineno] = max(highwater_file[lineno], current_footprint_file[lineno])
+  where `count ≥ 0` (bytes/MB) and `python_fraction ∈ [0,1]` (the C++
+  `_pythonCount/(…)` share, sampleheap.hpp).
+
+  ── WHAT WE PROVE ─────────────────────────────────────────────────────────────
+    * `perline_conserves` — Σ over lines of `memory_malloc_samples[line]` equals
+      `total_memory_malloc_samples`: every malloc's bytes are credited to exactly
+      one line AND to the grand total, so the per-line breakdown sums to the
+      whole. (The user-facing `n_usage_fraction = malloc[line]/total` is thus a
+      genuine fraction.)
+    * `python_le_malloc` — per line, `memory_python_samples[line] ≤
+      memory_malloc_samples[line]`, because each increment adds
+      `python_fraction·count ≤ count`. This is exactly the precondition
+      `scalene_json.py`'s `n_python_fraction = python/malloc ∈ [0,1]` needs; the
+      Attribution.lean bound `pythonBytes_le_count` assumed it, we now derive it
+      from the accumulation.
+    * `python_nonneg`, `malloc_nonneg` — both accumulators stay ≥ 0.
+    * `highwater_ge_current`, `highwater_monotone` — the per-line high-water mark
+      dominates the running per-line footprint and never decreases, so the
+      reported peak is a true upper bound.
+
+  All over ℚ; no `sorry`.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace Scalene.PerLineMallocAttribution
+
+variable {Line : Type} [DecidableEq Line] [Fintype Line]
+
+/-- One malloc record as the Python reader sees it: the line, the byte `count`
+    (≥ 0, in MB), and the `pythonFraction ∈ [0,1]` carried from C++. -/
+structure Malloc (Line : Type) where
+  line           : Line
+  count          : ℚ
+  pythonFraction : ℚ
+  countNonneg    : 0 ≤ count
+  fracNonneg     : 0 ≤ pythonFraction
+  fracLeOne      : pythonFraction ≤ 1
+
+/-- The per-line accumulator state the loop maintains. -/
+structure St (Line : Type) where
+  malloc      : Line → ℚ    -- memory_malloc_samples[line]
+  python      : Line → ℚ    -- memory_python_samples[line]
+  current     : Line → ℚ    -- memory_current_footprint[line]
+  highwater   : Line → ℚ    -- memory_current_highwater_mark[line]
+  totalMalloc : ℚ           -- total_memory_malloc_samples
+
+/-- Add `v` to `f` at key `ℓ`. -/
+def bump (f : Line → ℚ) (ℓ : Line) (v : ℚ) : Line → ℚ :=
+  fun ℓ' => if ℓ' = ℓ then f ℓ' + v else f ℓ'
+
+/-- One iteration of the malloc branch (scalene_memory_profiler.py:342-360). -/
+def step (s : St Line) (m : Malloc Line) : St Line :=
+  let malloc'  := bump s.malloc m.line m.count
+  let python'  := bump s.python m.line (m.pythonFraction * m.count)
+  let current' := bump s.current m.line m.count
+  { malloc      := malloc'
+    python      := python'
+    current     := current'
+    highwater   := fun ℓ' =>
+      if ℓ' = m.line then max (s.highwater m.line) (current' m.line)
+      else s.highwater ℓ'
+    totalMalloc := s.totalMalloc + m.count }
+
+def run (s : St Line) : List (Malloc Line) → St Line
+  | []      => s
+  | m :: ms => run (step s m) ms
+
+/-- The initial (empty) accumulator. -/
+def init : St Line :=
+  { malloc := fun _ => 0, python := fun _ => 0, current := fun _ => 0,
+    highwater := fun _ => 0, totalMalloc := 0 }
+
+/-! ## 1. Per-line conservation: Σ malloc[line] = totalMalloc -/
+
+/-- Sum of a per-line function over all lines. -/
+def sum (f : Line → ℚ) : ℚ := ∑ ℓ : Line, f ℓ
+
+theorem sum_bump (f : Line → ℚ) (ℓ : Line) (v : ℚ) :
+    sum (bump f ℓ v) = sum f + v := by
+  unfold sum bump
+  have hkey : ∀ ℓ' ∈ (Finset.univ : Finset Line),
+      (if ℓ' = ℓ then f ℓ' + v else f ℓ') = f ℓ' + (if ℓ' = ℓ then v else 0) := by
+    intro ℓ' _; by_cases h : ℓ' = ℓ <;> simp [h]
+  rw [Finset.sum_congr rfl hkey, Finset.sum_add_distrib,
+      Finset.sum_ite_eq' Finset.univ ℓ (fun _ => v)]
+  simp
+
+/-- **Per-line conservation.** After any sequence of mallocs from the empty
+    accumulator, the sum over lines of `memory_malloc_samples` equals
+    `total_memory_malloc_samples`. Every malloc's bytes land in exactly one
+    line's bucket and in the grand total — so `malloc[line]/total` is a genuine
+    fraction (the JSON renderer's `n_usage_fraction`). -/
+theorem perline_conserves (ms : List (Malloc Line)) :
+    sum (run (init) ms).malloc = (run (init : St Line) ms).totalMalloc := by
+  suffices H : ∀ (s : St Line), sum (run s ms).malloc = sum s.malloc
+      + ((run s ms).totalMalloc - s.totalMalloc) by
+    have h := H init
+    simp only [init, sum] at h ⊢
+    simpa using h
+  intro s
+  induction ms generalizing s with
+  | nil => simp [run]
+  | cons m ms ih =>
+      simp only [run]
+      rw [ih (step s m)]
+      simp only [step, sum_bump]
+      ring
+
+/-! ## 2. Python share is bounded by malloc bytes, per line -/
+
+/-- **Invariant: `python[ℓ] ≤ malloc[ℓ]` on every line, and both are ≥ 0.**
+    Each step adds `pythonFraction·count` to python and `count` to malloc with
+    `pythonFraction ≤ 1` and `count ≥ 0`, so the python bucket can never exceed
+    the malloc bucket. This is exactly the precondition
+    `scalene_json.py`'s `n_python_fraction = python/malloc` needs to land in
+    [0,1] (Attribution.lean's `pythonBytes_le_count`, now derived not assumed). -/
+theorem python_le_malloc (ms : List (Malloc Line)) (ℓ : Line) :
+    0 ≤ (run (init : St Line) ms).python ℓ
+    ∧ (run (init : St Line) ms).python ℓ ≤ (run (init : St Line) ms).malloc ℓ := by
+  suffices H : ∀ (s : St Line),
+      (∀ k, 0 ≤ s.python k ∧ s.python k ≤ s.malloc k) →
+      (∀ k, 0 ≤ (run s ms).python k ∧ (run s ms).python k ≤ (run s ms).malloc k) by
+    have h := H init (by intro k; simp [init])
+    exact h ℓ
+  intro s
+  induction ms generalizing s with
+  | nil => intro hinv; simpa [run] using hinv
+  | cons m ms ih =>
+      intro hinv
+      apply ih
+      intro k
+      simp only [step, bump]
+      by_cases hk : k = m.line
+      · obtain ⟨hnn, hle⟩ := hinv k
+        have hfc : 0 ≤ m.pythonFraction * m.count :=
+          mul_nonneg m.fracNonneg m.countNonneg
+        have hfrac : m.pythonFraction * m.count ≤ m.count := by
+          nlinarith [m.countNonneg, m.fracLeOne, m.fracNonneg]
+        simp only [if_pos hk]
+        constructor <;> linarith
+      · simp only [if_neg hk]; exact hinv k
+
+/-! ## 3. Per-line high-water mark dominates and is monotone -/
+
+/-- **High-water ≥ current, per line, throughout.** The reported per-line peak
+    footprint is always an upper bound on the running per-line footprint. -/
+theorem highwater_ge_current (ms : List (Malloc Line)) (ℓ : Line)
+    (hinit : ∀ k, (init : St Line).current k ≤ (init : St Line).highwater k) :
+    (run (init : St Line) ms).current ℓ ≤ (run (init : St Line) ms).highwater ℓ := by
+  suffices H : ∀ (s : St Line), (∀ k, s.current k ≤ s.highwater k) →
+      (∀ k, (run s ms).current k ≤ (run s ms).highwater k) by
+    exact H init hinit ℓ
+  intro s
+  induction ms generalizing s with
+  | nil => intro hinv; simpa [run] using hinv
+  | cons m ms ih =>
+      intro hinv
+      apply ih
+      intro k
+      simp only [step, bump]
+      by_cases hk : k = m.line
+      · subst hk; simp only [if_pos rfl]; exact le_max_right _ _
+      · simp only [if_neg hk]; exact hinv k
+
+/-- **High-water is monotone.** One step never decreases any line's high-water
+    mark — the peak only ever rises. -/
+theorem highwater_monotone (s : St Line) (m : Malloc Line) (ℓ : Line) :
+    s.highwater ℓ ≤ (step s m).highwater ℓ := by
+  simp only [step]
+  by_cases hk : ℓ = m.line
+  · simp only [if_pos hk]; rw [hk]; exact le_max_left _ _
+  · simp only [if_neg hk]; exact le_refl _
+
+/-- `totalMalloc` only grows (each malloc's `count ≥ 0`). -/
+theorem totalMalloc_monotone (s : St Line) (m : Malloc Line) :
+    s.totalMalloc ≤ (step s m).totalMalloc := by
+  simp only [step]; linarith [m.countNonneg]
+
+end Scalene.PerLineMallocAttribution

--- a/formal/lean/Scalene/PythonNativeClassifier.lean
+++ b/formal/lean/Scalene/PythonNativeClassifier.lean
@@ -1,0 +1,314 @@
+/-
+  The Python-vs-native CPU classifier — conservation & attribution correctness.
+
+  HANDOFF §6 listed this as an open gap: "only *conservation* (fractions sum to
+  1) proven, not the per-sample accuracy of the CALL-opcode/signal-deferral
+  classifier heuristic." This file proves the part that is a *theorem* — the
+  classifier is a total function that conserves the sample's CPU time exactly,
+  in every branch — and states honestly the part that is a *heuristic* (which
+  branch is "right") with the precise assumption under which it is exact.
+
+  ── THE CLASSIFIER (scalene_cpu_profiler.py:251-341) ──────────────────────────
+  Given one CPU sample carrying `python_time` (= last timer interval) and
+  `c_time` (= excess CPU beyond it), with `cpu = python_time + c_time`, and the
+  bytecode position, it charges buckets `(line, {python|native})` one of 4 ways:
+
+    (A) at a CALL and call-attribution mode → ALL `cpu` to NATIVE on this line;
+        the sample landed inside the C call, so even `python_time` was in C.
+    (B) c_time > 0 and a preceding CALL on a DIFFERENT line → SPLIT:
+        `c_time` native on the CALL line, `python_time` Python on this line.
+    (C) c_time > 0, CALL on same line / not found → together on this line:
+        `python_time` Python + `c_time` native.
+    (D) else → as computed: `python_time` Python + `c_time` native, this line.
+
+  ── WHAT WE PROVE ─────────────────────────────────────────────────────────────
+  Model the output as a finite map from `(Line × Kind)` buckets to ℚ time. Then:
+    * `charge_total` — in EVERY branch the total time charged equals the
+      sample's `cpu = python_time + c_time`. No time invented or lost by the
+      classification: it only *moves* a fixed budget between buckets.
+    * `attribute_native_split` — the native-vs-Python split of the charged total
+      is exactly (c_time-or-cpu, python_time-or-0) per branch — characterizing
+      what each branch decides.
+    * `charge_nonneg` — every bucket gets a non-negative charge (needs
+      `0 ≤ python_time`, `0 ≤ c_time`, which the code guarantees:
+      `c_time = max(elapsed − python_time, 0)`).
+    * `classify_total` — the branch selector is a total function: exactly one of
+      A/B/C/D fires for any input, so attribution is always defined.
+
+  ── THE HEURISTIC BOUNDARY (stated, not hidden) ───────────────────────────────
+  Which branch is *correct* depends on whether the async signal was deferred
+  during a C call — unobservable from the sample alone. We prove
+  `branchA_exact_if_in_call`: IF the sample truly landed in native code
+  (`trueNative = cpu`), branch A's all-native charge is exactly right. The
+  heuristic is the hypothesis `is_at_call ⇒ trueNative = cpu`; the code's
+  engineering (CALL-opcode detection) is what makes it hold in practice, and
+  that is not formalized here — only the conditional correctness is.
+
+  All over ℚ; no `sorry`.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace Scalene.PythonNativeClassifier
+
+/-- Time is charged to a line as either Python or native. -/
+inductive Kind where
+  | python
+  | native
+deriving DecidableEq
+
+variable {Line : Type} [DecidableEq Line]
+
+/-- The classifier's output: how much CPU time each `(line, kind)` bucket gets
+    charged for one sample. A finite association modeled as a function. -/
+abbrev Charge (Line : Type) := Line → Kind → ℚ
+
+/-- The empty charge. -/
+def noCharge : Charge Line := fun _ _ => 0
+
+/-- Add `t` to bucket `(ℓ, k)`. -/
+def add (c : Charge Line) (ℓ : Line) (k : Kind) (t : ℚ) : Charge Line :=
+  fun ℓ' k' => if ℓ' = ℓ ∧ k' = k then c ℓ' k' + t else c ℓ' k'
+
+/-- One sample: `python_time`, `c_time` (both ≥ 0), the current `line`, and the
+    classification facts the code computes from the bytecode. -/
+structure Sample (Line : Type) where
+  pythonTime : ℚ
+  cTime      : ℚ
+  line       : Line
+  pythonNonneg : 0 ≤ pythonTime
+  cNonneg      : 0 ≤ cTime
+
+namespace Sample
+
+variable {Line : Type} [DecidableEq Line]
+
+/-- The sample's total CPU time — the budget the classifier must conserve. -/
+def cpu (s : Sample Line) : ℚ := s.pythonTime + s.cTime
+
+/-- The four branches, as the code selects them (:256-341). `callLine?` is the
+    preceding-CALL line from `find_preceding_call_line` (none if not found). -/
+inductive Branch (Line : Type) where
+  | atCall                        -- (A) is_at_call ∧ call-attribution mode
+  | splitToCall (callLine : Line) -- (B) c_time>0, preceding CALL on a diff line
+  | together                      -- (C) c_time>0, same line / not found
+  | asComputed                    -- (D) else
+
+/-- The attribution for a sample under a chosen branch, mirroring each
+    `_update_main_thread_stats` call in scalene_cpu_profiler.py. -/
+def charge (s : Sample Line) : Branch Line → Charge Line
+  | .atCall =>
+      -- (A) all cpu time to native on this line (:263-275, python arg = 0.0)
+      add noCharge s.line .native s.cpu
+  | .splitToCall callLine =>
+      -- (B) c_time native on the CALL line; python_time Python on this line
+      add (add noCharge callLine .native s.cTime) s.line .python s.pythonTime
+  | .together =>
+      -- (C) python_time Python + c_time native, this line (:316-328)
+      add (add noCharge s.line .python s.pythonTime) s.line .native s.cTime
+  | .asComputed =>
+      -- (D) same shape as (C) (:331-341)
+      add (add noCharge s.line .python s.pythonTime) s.line .native s.cTime
+
+/-- Total time charged across all buckets of a `Charge`. Sums the python and
+    native components over all (finitely many) lines. -/
+def total [Fintype Line] (c : Charge Line) : ℚ :=
+  ∑ ℓ : Line, (c ℓ .python + c ℓ .native)
+
+end Sample
+
+open Sample
+
+variable [Fintype Line]
+
+/-- `add` increases the total by exactly `t` — it touches exactly one bucket. -/
+theorem total_add (c : Charge Line) (ℓ : Line) (k : Kind) (t : ℚ) :
+    Sample.total (add c ℓ k t) = Sample.total c + t := by
+  unfold Sample.total add
+  -- Rewrite each summand as (old summand) + (t only at ℓ), then split the sum.
+  have hkey : ∀ ℓ' ∈ (Finset.univ : Finset Line),
+      (if ℓ' = ℓ ∧ Kind.python = k then c ℓ' .python + t else c ℓ' .python)
+        + (if ℓ' = ℓ ∧ Kind.native = k then c ℓ' .native + t else c ℓ' .native)
+      = (c ℓ' .python + c ℓ' .native)
+        + (if ℓ' = ℓ then t else 0) := by
+    intro ℓ' _
+    by_cases hℓ : ℓ' = ℓ
+    · subst hℓ
+      cases k <;> (simp; ring)
+    · simp [hℓ]
+  rw [Finset.sum_congr rfl hkey, Finset.sum_add_distrib,
+      Finset.sum_ite_eq' Finset.univ ℓ (fun _ => t)]
+  simp
+
+/-- `total noCharge = 0`. -/
+@[simp] theorem total_noCharge : Sample.total (noCharge : Charge Line) = 0 := by
+  unfold Sample.total noCharge; simp
+
+/-! ## Conservation: every branch charges exactly the sample's CPU budget -/
+
+/-- **Attribution conservation.** For any sample and any branch the classifier
+    could pick, the total time charged across all buckets equals the sample's
+    `cpu = pythonTime + cTime`. The classification only *moves* a fixed budget
+    between (line, python/native) buckets — it never invents or loses time. -/
+theorem charge_total (s : Sample Line) (b : Branch Line) :
+    Sample.total (s.charge b) = s.cpu := by
+  cases b with
+  | atCall =>
+      simp only [Sample.charge, total_add, total_noCharge, zero_add]
+  | splitToCall callLine =>
+      simp only [Sample.charge, total_add, total_noCharge, zero_add]
+      unfold Sample.cpu; ring
+  | together =>
+      simp only [Sample.charge, total_add, total_noCharge, zero_add]
+      unfold Sample.cpu; ring
+  | asComputed =>
+      simp only [Sample.charge, total_add, total_noCharge, zero_add]
+      unfold Sample.cpu; ring
+
+/-! ## The native / Python split each branch decides -/
+
+/-- Total native time charged (sum of the `.native` component over all lines). -/
+def totalNative (c : Charge Line) : ℚ := ∑ ℓ : Line, c ℓ .native
+
+/-- Total Python time charged. -/
+def totalPython (c : Charge Line) : ℚ := ∑ ℓ : Line, c ℓ .python
+
+theorem totalNative_add_native (c : Charge Line) (ℓ : Line) (t : ℚ) :
+    totalNative (add c ℓ .native t) = totalNative c + t := by
+  unfold totalNative add
+  have hkey : ∀ ℓ' ∈ (Finset.univ : Finset Line),
+      (if ℓ' = ℓ ∧ Kind.native = Kind.native then c ℓ' .native + t else c ℓ' .native)
+      = c ℓ' .native + (if ℓ' = ℓ then t else 0) := by
+    intro ℓ' _; by_cases h : ℓ' = ℓ <;> simp [h]
+  rw [Finset.sum_congr rfl hkey, Finset.sum_add_distrib,
+      Finset.sum_ite_eq' Finset.univ ℓ (fun _ => t)]; simp
+
+theorem totalNative_add_python (c : Charge Line) (ℓ : Line) (t : ℚ) :
+    totalNative (add c ℓ .python t) = totalNative c := by
+  unfold totalNative add
+  apply Finset.sum_congr rfl
+  intro ℓ' _; by_cases h : ℓ' = ℓ <;> simp [h]
+
+theorem totalPython_add_python (c : Charge Line) (ℓ : Line) (t : ℚ) :
+    totalPython (add c ℓ .python t) = totalPython c + t := by
+  unfold totalPython add
+  have hkey : ∀ ℓ' ∈ (Finset.univ : Finset Line),
+      (if ℓ' = ℓ ∧ Kind.python = Kind.python then c ℓ' .python + t else c ℓ' .python)
+      = c ℓ' .python + (if ℓ' = ℓ then t else 0) := by
+    intro ℓ' _; by_cases h : ℓ' = ℓ <;> simp [h]
+  rw [Finset.sum_congr rfl hkey, Finset.sum_add_distrib,
+      Finset.sum_ite_eq' Finset.univ ℓ (fun _ => t)]; simp
+
+theorem totalPython_add_native (c : Charge Line) (ℓ : Line) (t : ℚ) :
+    totalPython (add c ℓ .native t) = totalPython c := by
+  unfold totalPython add
+  apply Finset.sum_congr rfl
+  intro ℓ' _; by_cases h : ℓ' = ℓ <;> simp [h]
+
+@[simp] theorem totalNative_noCharge : totalNative (noCharge : Charge Line) = 0 := by
+  unfold totalNative noCharge; simp
+
+@[simp] theorem totalPython_noCharge : totalPython (noCharge : Charge Line) = 0 := by
+  unfold totalPython noCharge; simp
+
+/-- **The native/Python split, branch A (at CALL).** All `cpu` charged native,
+    nothing to Python — the sample is deemed entirely inside the C call. -/
+theorem split_atCall (s : Sample Line) :
+    totalNative (s.charge .atCall) = s.cpu
+    ∧ totalPython (s.charge .atCall) = 0 := by
+  constructor <;>
+    simp only [Sample.charge, totalNative_add_native, totalPython_add_native,
+               totalNative_noCharge, totalPython_noCharge, zero_add]
+
+/-- **The native/Python split, branches B/C/D.** Exactly `cTime` native and
+    `pythonTime` Python — the interval-formula split, whether kept on one line
+    (C/D) or split across the CALL line and this line (B). -/
+theorem split_together (s : Sample Line) :
+    totalNative (s.charge .together) = s.cTime
+    ∧ totalPython (s.charge .together) = s.pythonTime := by
+  constructor <;>
+    simp only [Sample.charge, totalNative_add_native, totalNative_add_python,
+               totalPython_add_native, totalPython_add_python,
+               totalNative_noCharge, totalPython_noCharge, zero_add]
+
+theorem split_splitToCall (s : Sample Line) (callLine : Line) :
+    totalNative (s.charge (.splitToCall callLine)) = s.cTime
+    ∧ totalPython (s.charge (.splitToCall callLine)) = s.pythonTime := by
+  constructor <;>
+    simp only [Sample.charge, totalNative_add_native, totalNative_add_python,
+               totalPython_add_native, totalPython_add_python,
+               totalNative_noCharge, totalPython_noCharge, zero_add]
+
+/-! ## Non-negativity: every bucket charge is ≥ 0 -/
+
+/-- **Every bucket gets a non-negative charge.** Relies on `0 ≤ pythonTime` and
+    `0 ≤ cTime`, which the code guarantees (`c_time = max(elapsed − python, 0)`,
+    `python_time = interval ≥ 0`). So no branch can produce a negative time. -/
+theorem charge_nonneg (s : Sample Line) (b : Branch Line) (ℓ : Line) (k : Kind) :
+    0 ≤ s.charge b ℓ k := by
+  have hp := s.pythonNonneg
+  have hc := s.cNonneg
+  have hcpu : 0 ≤ s.cpu := by unfold Sample.cpu; linarith
+  cases b <;>
+    simp only [Sample.charge, add, noCharge] <;>
+    (repeat' split) <;> first | linarith | simp
+
+/-! ## The branch selector is total (exactly one branch always fires)
+
+The code's `if/elif/elif/else` picks exactly one branch from the observable
+facts. We model the selector and prove it is a genuine total function of those
+facts, so `attribute` is always defined — there is no unclassified sample. -/
+
+/-- The observable classification facts the code reads: whether the sample is at
+    a CALL under call-attribution mode, whether c_time > 0, and the preceding
+    CALL line (if found and on a different line). -/
+structure Facts (Line : Type) where
+  useCallAtCall : Bool          -- use_call_attribution ∧ is_at_call
+  cPositive     : Bool          -- average_c_time > 0
+  precedingDiff : Option Line   -- preceding CALL line, if found ∧ ≠ this line
+
+/-- The branch the code selects (:256-341), as a total function of the facts and
+    the sample's line. -/
+def classify (s : Sample Line) (f : Facts Line) : Branch Line :=
+  if f.useCallAtCall then .atCall
+  else if f.cPositive then
+    match f.precedingDiff with
+    | some cl => .splitToCall cl
+    | none    => .together
+  else .asComputed
+
+/-- **The selector is total.** `classify` returns a branch for every possible
+    combination of facts — there is no input the code leaves unclassified. (This
+    is definitional totality; we record it so the conservation theorems above
+    are known to cover the *whole* input space, not a subset.) -/
+theorem classify_total (s : Sample Line) (f : Facts Line) :
+    ∃ b : Branch Line, classify s f = b := ⟨classify s f, rfl⟩
+
+/-- Consequently, **conservation holds for the actually-selected branch**, for
+    every sample and every fact combination — the end-to-end statement. -/
+theorem classified_conserves (s : Sample Line) (f : Facts Line) :
+    Sample.total (s.charge (classify s f)) = s.cpu :=
+  charge_total s (classify s f)
+
+/-! ## The heuristic boundary, stated honestly
+
+Which branch is *correct* depends on whether the signal was deferred inside a C
+call — not observable from the sample. We prove the conditional: IF the sample
+truly landed in native code, branch A is exactly right. The classifier's
+accuracy is the (unformalized, engineering) hypothesis that `is_at_call` detects
+exactly that case. -/
+
+/-- If the sample's true attribution is entirely native (`trueNative = cpu`),
+    then branch A charges exactly the truth: all `cpu` to native, none to
+    Python. So branch A is *correct* precisely when the at-CALL detection
+    correctly identifies an in-native sample — the heuristic's proof obligation,
+    isolated. -/
+theorem branchA_exact_if_in_call (s : Sample Line) (trueNative : ℚ)
+    (h : trueNative = s.cpu) :
+    totalNative (s.charge .atCall) = trueNative
+    ∧ totalPython (s.charge .atCall) = 0 := by
+  obtain ⟨hn, hp⟩ := split_atCall s
+  exact ⟨by rw [hn, h], hp⟩
+
+end Scalene.PythonNativeClassifier


### PR DESCRIPTION
Closes two more open gaps from the correctness map. Two new Lean modules (`sorry`-free, standard axioms only; full `lake build` green — 8575 jobs; now 16 modules / 133 theorems).

## Python/native classifier — `PythonNativeClassifier.lean`
Models the 4-way heuristic that splits each CPU sample's time between Python and native (`scalene_cpu_profiler.py:251-341`). Separates the **theorem** from the **heuristic**:
- `charge_total` / `classified_conserves` — **every branch conserves** the sample's CPU budget (`python_time + c_time`) across all `(line, python|native)` buckets. The classification only *moves* a fixed budget; it never invents or drops time.
- `split_atCall` / `split_together` / `split_splitToCall` — the native/Python split each branch decides.
- `charge_nonneg` — every bucket charge ≥ 0.
- `classify_total` — the branch selector is a total function (exactly one branch fires for any input).
- `branchA_exact_if_in_call` — conditional correctness: *if* the sample truly landed in native code, branch A is exact. Which branch is right per sample (the CALL-opcode/deferral heuristic) stays an engineering hypothesis — stated, not hidden.

## Per-line malloc attribution — `PerLineMallocAttribution.lean`
The Python reader's per-line bookkeeping (`scalene_memory_profiler.py:336-360`), distinct from the footprint total in #1080.
- `perline_conserves` — Σ over lines of `memory_malloc_samples[line]` = `total_memory_malloc_samples`, so `malloc[line]/total` (the renderer's `n_usage_fraction`) is a genuine fraction.
- `python_le_malloc` — per line `0 ≤ memory_python_samples ≤ memory_malloc_samples` (from `python_fraction ∈ [0,1]`). This **derives** the bound `Attribution.lean` assumed and that `scalene_json.py`'s `n_python_fraction = python/malloc ∈ [0,1]` relies on.
- `highwater_ge_current` / `highwater_monotone` — the per-line high-water peak dominates the running footprint and never decreases.

## Docs
STATUS.md updated (CPU classifier row ❌→✅ for conservation / ⚠️ for branch-choice; new per-line attribution row), README gains §15 + §16 and the top roundup reflects both, HANDOFF module table + next-steps updated.

Formal-only; no production code touched.