### PR TITLE
Formal: Python/native classifier accuracy — both paths, vs CPython signal semantics

### DIFF
--- a/formal/HANDOFF.md
+++ b/formal/HANDOFF.md
@@ -87,6 +87,7 @@ at `/tmp/LeanToPython` locally (Lean 4.12).
 | `MallocFootprintWiring.lean` | **malloc footprint end-to-end (C++↔Python)**: reuses ThresholdSampler; models the free-side `max(0,·)` clamp honestly (conserves in safe regime; only over-reports otherwise) | `emit_records_sum`, `clamp_is_identity_of_safe`, `roundtrip_conservation_of_safe`, `clamp_only_raises` |
 | `PythonNativeClassifier.lean` | **Python/native classifier conserves the CPU budget in every branch** (total function); per-branch split characterized; branch-choice accuracy is the heuristic (conditional correctness only) | `charge_total`, `classified_conserves`, `split_atCall`/`split_together`, `charge_nonneg`, `branchA_exact_if_in_call` |
 | `PerLineMallocAttribution.lean` | **per-line malloc bookkeeping**: Σ per-line bytes = grand total; python-share ≤ bytes; high-water dominates & monotone | `perline_conserves`, `python_le_malloc`, `highwater_ge_current`, `highwater_monotone` |
+| `ClassifierAccuracy.lean` | **classifier accuracy, both paths**: worker + main-branch-A exact under CPython signal-delivery hypothesis; the two paths agree in the shared regime; deferral route characterized; error quantified when the hypothesis fails | `worker_classifier_correct`, `main_branchA_correct`, `main_worker_agree`, `deferral_route_iff`, `misclassified_when_unsound` |
 | `LeakTrackerAudit.lean` | proves the leak formula's *unguarded* denominator is safe (`frees ≤ allocs`) | `run_frees_le_allocs`, `denom_pos_reachable` |
 | `LeakTrackerConcurrency.lean` | `frees ≤ allocs` survives sig-queue/main-thread interleaving + fork; RLock atomicity & joint fork-reset shown *necessary* | `interleave_preserves_inv`, `torn_free_breaks_inv`, `fork_reset_inv`, `partial_fork_reset_breaks_inv` |
 | TLA+ `SignalSafety` | the combined_stacks race is reachable (bug cfg) / impossible (fix cfg) | 4-state counterexample; 99 states clean |
@@ -248,12 +249,17 @@ generated `X | Y` unions need 3.10+).
    assumes (`uniform_realizes_trueFraction`). Residual: continuous-time
    order-statistics proof still not formalized (discrete form is the operative
    content for a tick-sampled profiler).
-5. ~~Prove/characterize the python/native classifier~~ **PARTIALLY DONE** —
-   `PythonNativeClassifier.lean` proves the classifier *conserves* each sample's
-   CPU budget in every branch (`charge_total`), is a total function
-   (`classify_total`), and is conditionally correct (`branchA_exact_if_in_call`).
-   STILL OPEN: which branch is right per sample (the CALL-opcode/deferral
-   heuristic) — needs modeling signal delivery vs. bytecode, out of current scope.
+5. ~~Prove/characterize the python/native classifier~~ **DONE** —
+   `PythonNativeClassifier.lean` (conservation, totality) + `ClassifierAccuracy.lean`
+   (accuracy). The accuracy module makes CPython signal-delivery an *explicit
+   hypothesis* (`SigDeliverySound`: `atCall ⇔ truly in a C call`) and proves BOTH
+   code paths exact under it — the worker-thread bytecode classifier
+   (`_update_thread_stats`) and the main-thread branch A — plus that the two
+   paths agree in their shared regime and diverge only where the virtual timer
+   can measure deferral. STILL OPEN (the honest residual): `SigDeliverySound`
+   itself, a CPython-runtime + synchronous-stamping property. Discharging it
+   would need modeling the eval loop's signal-check + `f_lasti` semantics, or a
+   differential test harness that stress-checks `atCall` against ground truth.
 6. **Wire the verified oracle into production directly** (have
    `_space_saving_increment` call the extracted core) rather than only
    differential-testing it — closes the proof→production loop tighter.

--- a/formal/README.md
+++ b/formal/README.md
@@ -6,7 +6,7 @@ Python and differentially tests the real profiler against them.
 
 ## Proof roundup — where the correctness effort stands, by subsystem
 
-**Lean 4:** 16 modules, 133 theorems, no `sorry`, standard axioms only.
+**Lean 4:** 17 modules, 142 theorems, no `sorry`, standard axioms only.
 **TLA+/TLC:** 2 specs, exhaustively model-checked. Verdicts: **✅ Proven**,
 **⚠️ Partial**, **❌ Unproven**. This is the narrative view; [`STATUS.md`](STATUS.md)
 has the granular per-aspect table, and the numbered sections below (§1–§14) give
@@ -20,11 +20,13 @@ sampler is Poisson (`ExponentialSampler`, inverse-CDF + memorylessness) and ✅
 **PASTA** now links Poisson instants to time-fraction landing
 (`PoissonArrivals.uniform_realizes_trueFraction`, §12). ✅ the Python/native
 classifier *conserves* each sample's CPU budget in every branch
-(`PythonNativeClassifier.charge_total`, §15). ⚠️ that the C++ stamping
-*establishes* faithful placement is engineering, not Lean-proven; ⚠️ *which*
-classifier branch is right is the CALL-opcode heuristic (conditional
-correctness proven, `branchA_exact_if_in_call`; the detection itself not
-formalized).
+(`PythonNativeClassifier.charge_total`, §15) AND is *accurate* on both code
+paths — the main-thread hybrid and the worker-thread bytecode classifier are
+each exact under an explicit CPython signal-delivery hypothesis, and agree in
+their shared regime (`ClassifierAccuracy`, §17). ⚠️ residuals: that the C++
+stamping *establishes* faithful placement, and `SigDeliverySound` itself (that
+`atCall` reflects the true execution state) — both CPython-runtime/engineering
+properties, stated as hypotheses not proved.
 
 **2. Memory sampling.** ✅ the default ThresholdSampler conserves true net
 allocation exactly with bounded residual (`threshold_conserves`,
@@ -358,9 +360,11 @@ formal contract between them.
   the Python-vs-native split, and memory-leak detection; §9
   (`MemorySampler.lean`) covers the allocation sampler (now including a proved
   bisimulation to the literal two-counter C++); §10 (`PerLineAttribution.lean`)
-  ties byte sampling to the per-line fraction. What remains unmodeled: the
-  per-sample *accuracy* of the python/native classifier heuristic, and the
-  end-to-end wiring from the C++ counters into the Python statistics objects.
+  ties byte sampling to the per-line fraction. The python/native classifier's
+  per-sample accuracy is now covered too (§17, `ClassifierAccuracy.lean`) — exact
+  on both code paths under an explicit CPython signal-delivery hypothesis. What
+  remains a stated hypothesis rather than a theorem: `SigDeliverySound` itself
+  (that `atCall` reflects the true execution state).
 
 ---
 
@@ -404,8 +408,8 @@ Two proof shapes, because the metrics are not all averages:
 - **Python-vs-native split** (`scalene_cpu_profiler.py:251-343`):
   `python_c_fraction_sums_one` — the reported python and C fractions partition
   each sample and sum to 1. (This metric is a *deterministic classifier*, not a
-  random estimator; we prove the conservation property, not per-sample
-  classifier accuracy.)
+  random estimator; conservation is proven here, and per-sample accuracy in §17
+  — exact under the CPython signal-delivery hypothesis.)
 
 **Memory-leak detection — a Bayesian hypothesis test** (the different one,
 `scalene_leak_analysis.py:31`). The reported score is the Laplace Rule of
@@ -664,6 +668,55 @@ source line, and the invariants the JSON renderer's divides depend on.
 
 ---
 
+## 17. Classifier accuracy & the two paths — `lean/Scalene/ClassifierAccuracy.lean`
+
+§15 proved the classifier *conserves* the CPU budget; this proves it is
+*accurate* — the branch it picks is the right one — and compares Scalene's two
+classification code paths. Accuracy can't be a bare theorem: which branch is
+correct depends on where the program truly was when the timer fired, observable
+only through one operational fact about CPython. We state that fact as an
+explicit hypothesis and prove exact correctness relative to it.
+
+**The hypothesis (`SigDeliverySound`).** CPython runs a Python-level signal
+handler only at a bytecode boundary, so a timer that expires inside a C call is
+deferred until the call returns, leaving `f_lasti` at the CALL opcode. Hence
+`atCall = true ↔ the timer truly fired inside a C call`. Not proved here — a
+property of the CPython runtime plus synchronous C++ stamping — but stated as
+the precise contract the accuracy proofs rest on.
+
+**The two paths (source mapping).**
+
+| Path | Source | Strategy |
+|---|---|---|
+| worker-thread | `_update_thread_stats`, `scalene_cpu_profiler.py:458-466` | pure bytecode: native iff `is_call_function(orig_frame)` |
+| main-thread, branch A | `:256-275` (`use_call_attribution ∧ is_at_call`) | same bytecode decision, in wall-clock / Apple-SME mode |
+| main-thread, virtual mode | `:134-135` | interval-deferral formula `c_time = max(elapsed − interval, 0)` |
+
+**Theorems.**
+
+- `worker_classifier_correct` — under `SigDeliverySound`, the worker classifier
+  charges native *exactly* the samples that truly landed in a C call
+  (`workerNative = trueNative`, `workerPython = truePython`). Exact, not
+  approximate, given the hypothesis.
+- `main_branchA_correct` — the main path's branch A is exact under the same
+  hypothesis (it makes the identical decision).
+- `main_worker_agree` / `main_worker_both_exact` — **the comparison**: in the
+  shared regime (`use_call_attribution` true), the two paths make byte-for-byte
+  the same Python/native decision, so both are exact together. Scalene runs
+  *one* classifier from two call sites there.
+- `deferral_route_iff` — the paths diverge *exactly* in virtual-time,
+  non-thread-sampled mode, where only the main thread has a virtual timer to
+  measure deferral. `deferral_formula_exact` / `deferral_formula_zero_when_no_excess`
+  characterize that route's correctness (exact when native time appears as
+  timer-deferral; the code comments' known blind spot when it doesn't, which is
+  why wall-clock mode adds the bytecode test).
+- `misclassified_when_unsound` / `missed_when_unsound` — if `SigDeliverySound`
+  fails, the bytecode classifier errs, two-sided: a false positive charges
+  native what was Python, a false negative the reverse. This quantifies exactly
+  what the hypothesis buys.
+
+---
+
 ## What is *assumed* (model boundary)
 
 These models abstract, and the abstractions are the assumptions:
@@ -688,11 +741,15 @@ These models abstract, and the abstractions are the assumptions:
   (`CopyVolumeWiring.lean`): the emitter accumulator/flush state machine and the
   Python reader, with round-trip conservation. This is the first metric proven
   across the native boundary.
+- **Classifier accuracy is now modeled** (§17) *conditionally* on
+  `SigDeliverySound` — the CPython property that a deferred-until-bytecode-boundary
+  signal leaves `atCall` reflecting the true execution state. That hypothesis
+  itself (runtime + synchronous stamping) is stated, not proved.
 - **Out of scope (not yet modeled):** the C++ allocator's internal thread-local
   `_pythonCount`/`_cCount` accounting; the mapfile IPC *byte-format* parsing
   (the copy-volume model abstracts records, not their on-disk encoding); fork()
   lock-state hazards beyond the stop/join discipline; GPU/accelerator device
-  paths; the per-sample Python/native classifier heuristic accuracy.
+  paths.
 
 ---
 

--- a/formal/STATUS.md
+++ b/formal/STATUS.md
@@ -1,7 +1,7 @@
 # Scalene formal-verification status
 
 Where the correctness effort stands, by subsystem. Two engines: **Lean 4**
-(16 modules, 133 theorems, no `sorry`, standard axioms only) for mathematical
+(17 modules, 142 theorems, no `sorry`, standard axioms only) for mathematical
 properties, and **TLA+** (2 specs, model-checked with TLC) for concurrency and
 interleavings.
 
@@ -54,12 +54,16 @@ the counterexample-search and liveness coverage with nothing to replace them.
 | Python/C time split conserved & non-negative | ✅ | `Attribution.totalTime_eq_split`, `cpu_distribution_conserved` |
 | **Python/native classifier conserves the sample's CPU budget in every branch** | ✅ | `PythonNativeClassifier.charge_total`, `classified_conserves` (+ `charge_nonneg`, per-branch `split_*`) — §15 |
 | C++ stamping *establishes* faithful placement (signal→bytecode) | ⚠️ | engineering (`pywhere.cpp`); not modeled |
-| Python-vs-native classifier per-sample *branch-choice* accuracy | ⚠️ | conditional correctness proven (`branchA_exact_if_in_call`); which branch is *right* is the CALL-opcode heuristic, not formalized |
+| **Python-vs-native classifier accuracy, both paths** (main + worker), relative to CPython signal-delivery semantics | ✅ (conditional) | `ClassifierAccuracy.worker_classifier_correct`, `main_branchA_correct`, `main_worker_agree` — exact under the explicit `SigDeliverySound` hypothesis (§17) |
+| `SigDeliverySound` itself (atCall ⇔ truly in a C call) | ⚠️ | the operational hypothesis the accuracy proofs rest on — a CPython-runtime property, stated not proved |
 
-**Verdict:** the statistical guarantee is proven, and the sampler→correctness
-link that used to be *cited* (PASTA) is now proven in discrete-time form. The
-classifier's *bookkeeping* is now proven conserving; the open items are the
-signal-delivery physics and which-branch-is-right (the CALL-opcode heuristic).
+**Verdict:** the statistical guarantee is proven, the sampler→correctness link
+(PASTA) is proven in discrete-time form, and the classifier is now proven both
+*conserving* (every branch) and *accurate* (both code paths, exact under an
+explicit signal-delivery hypothesis — with the two paths shown to agree in their
+shared regime). The one residual is `SigDeliverySound` itself: that CPython
+delivers the signal at a bytecode boundary so `atCall` reflects the true state —
+a runtime property, stated as the honest hypothesis rather than proved.
 
 ## 2. Memory profiling
 
@@ -173,7 +177,8 @@ conservation laws — including the Python/native classifier's budget and the
 per-line malloc attribution bookkeeping — **two metrics end-to-end across the
 C++/Python boundary** (copy volume and malloc footprint, the latter modeling the
 free-side clamp honestly), bounded-structure capacity, and the signal/deadlock
-safety topology. **Not proven:** the signal-delivery physics, *which* classifier
-branch is correct per sample (the CALL-opcode heuristic — only conservation and
-conditional correctness are proven), the remaining device plumbing (GPU
+safety topology — including the classifier's per-sample accuracy on both code
+paths, proven exact under an explicit CPython signal-delivery hypothesis.
+**Not proven:** `SigDeliverySound` itself (the CPython-runtime property that
+`atCall` reflects the true execution state), the remaining device plumbing (GPU
 acquisition), output rendering, and floating-point.

--- a/formal/lean/Scalene.lean
+++ b/formal/lean/Scalene.lean
@@ -16,3 +16,4 @@ import Scalene.CopyVolumeWiring
 import Scalene.MallocFootprintWiring
 import Scalene.PythonNativeClassifier
 import Scalene.PerLineMallocAttribution
+import Scalene.ClassifierAccuracy

--- a/formal/lean/Scalene/ClassifierAccuracy.lean
+++ b/formal/lean/Scalene/ClassifierAccuracy.lean
@@ -1,0 +1,245 @@
+/-
+  Python/native classifier ACCURACY — the branch-correctness question.
+
+  `PythonNativeClassifier.lean` proved the classifier *conserves* the CPU budget
+  in every branch, but left the accuracy question — is the branch it picks the
+  *right* one? — as an engineering heuristic (HANDOFF §7 step 5). This file
+  models that question honestly. Accuracy cannot be a bare theorem: which branch
+  is correct depends on where the program truly was when the timer fired, which
+  is unobservable *except* through one operational fact about CPython. So we:
+
+    1. State that fact as an explicit hypothesis (CPython signal-delivery
+       semantics), the classifiers' shared proof obligation.
+    2. Prove each classifier is EXACTLY correct relative to it.
+    3. Compare the TWO code paths — the main-thread hybrid
+       (scalene_cpu_profiler.py:251-341) and the worker-thread pure-bytecode
+       classifier (`_update_thread_stats`, :458-466) — proving where they agree
+       and characterizing where they deliberately diverge.
+
+  ── THE OPERATIONAL FACT (the honest hypothesis) ──────────────────────────────
+  CPython runs a Python-level signal handler only at a bytecode boundary. So if
+  the sampling timer expires *inside* a C call, the handler runs when the call
+  returns, with `f_lasti` pointing at the CALL opcode; if it expires while
+  executing Python, `f_lasti` points at a non-CALL opcode. Hence the observable
+  `atCall := is_call_function(frame.f_lasti)` satisfies
+
+      atCall = true   ↔   the timer truly fired while suspended in a C call.
+
+  We call this `SigDeliverySound`. It is NOT proved here (it is a property of the
+  CPython runtime + the interposer's synchronous stamping); it is the precise
+  contract the accuracy proofs rest on — stated, not hidden.
+
+  ── WHAT WE PROVE ─────────────────────────────────────────────────────────────
+    * `worker_classifier_correct` — the worker-thread classifier (native iff
+      atCall) attributes to native EXACTLY the samples that truly landed in a C
+      call, under SigDeliverySound. Perfectly accurate given the hypothesis.
+    * `main_branchA_correct` — the main-thread branch A (at-CALL, wall-clock /
+      thread-sampled mode) is likewise exact under SigDeliverySound.
+    * `main_worker_agree` — in the SHARED regime (`use_call_attribution` true:
+      wall-clock or Apple-SME thread-sampled), the two paths make the SAME
+      Python/native decision for the same sample. One classifier, two call sites.
+    * `deferral_route_iff` / `deferral_formula_exact` — in virtual-time mode the
+      main path instead uses the interval-deferral formula
+      (`c_time = elapsed − interval`); we characterize exactly when that route is
+      taken and prove it exact under the *deferral* hypothesis (native time = the
+      measured excess). This is why the paths differ: only a thread with its own
+      virtual timer can measure deferral, so the worker path cannot use it.
+    * `misclassified_when_unsound` / `missed_when_unsound` — if SigDeliverySound
+      fails (a smeared sample: at a CALL opcode but not truly in a call, or vice
+      versa), the bytecode classifier is wrong — pinning down the two-sided error
+      the hypothesis rules out.
+
+  All over ℚ; no `sorry`.
+-/
+import Mathlib
+
+namespace Scalene.ClassifierAccuracy
+
+/-- The true execution state when the sampling timer fired. -/
+inductive ExecState where
+  | inPython   -- executing a Python bytecode
+  | inCall     -- suspended inside a native (C) call
+deriving DecidableEq
+
+/-- A CPU sample's ground truth: the true state, the total CPU time to attribute
+    (`cpu ≥ 0`), and the observable `atCall` bit the handler reads from
+    `f_lasti` (`is_call_function`). -/
+structure Sample where
+  state  : ExecState
+  cpu    : ℚ
+  atCall : Bool
+  cpuNonneg : 0 ≤ cpu
+
+/-- **The true native time of a sample**: all of `cpu` if the timer truly fired
+    inside a C call, else 0. (The bytecode classifiers are binary — a sample is
+    wholly native or wholly Python — so the ground truth is too.) -/
+def trueNative (s : Sample) : ℚ :=
+  match s.state with
+  | .inCall   => s.cpu
+  | .inPython => 0
+
+def truePython (s : Sample) : ℚ := s.cpu - trueNative s
+
+/-- **CPython signal-delivery soundness** — the operational hypothesis. The
+    observable at-CALL bit is set iff the timer truly fired inside a C call.
+    This is the property of the runtime that the whole accuracy argument rests
+    on; discharged by CPython's bytecode-boundary signal delivery + synchronous
+    C++ stamping, not proved here. -/
+def SigDeliverySound (s : Sample) : Prop :=
+  s.atCall = true ↔ s.state = .inCall
+
+/-! ## 1. The worker-thread classifier (`_update_thread_stats`, :458-466)
+
+Pure bytecode test: charge all `normalized_time` to native iff the frame is at a
+CALL opcode; else all Python. No interval, no deferral formula. -/
+
+/-- Native time the worker classifier charges. -/
+def workerNative (s : Sample) : ℚ := if s.atCall then s.cpu else 0
+
+def workerPython (s : Sample) : ℚ := if s.atCall then 0 else s.cpu
+
+/-- **The worker classifier is exactly correct — given signal-delivery
+    soundness.** It attributes to native precisely the samples that truly landed
+    in a C call. No approximation: under the hypothesis, `workerNative =
+    trueNative` and `workerPython = truePython`. -/
+theorem worker_classifier_correct (s : Sample) (h : SigDeliverySound s) :
+    workerNative s = trueNative s ∧ workerPython s = truePython s := by
+  unfold SigDeliverySound at h
+  cases hst : s.state with
+  | inCall =>
+      have hac : s.atCall = true := h.mpr hst
+      simp [workerNative, workerPython, trueNative, truePython, hac, hst]
+  | inPython =>
+      have hac : s.atCall = false := by
+        by_contra hne
+        have htrue : s.atCall = true := by cases s.atCall <;> simp_all
+        rw [h.mp htrue] at hst; exact absurd hst (by simp)
+      simp [workerNative, workerPython, trueNative, truePython, hac, hst]
+
+/-! ## 2. The main-thread branch A (:256-275), wall-clock / thread-sampled mode
+
+`use_call_attribution = (not use_virtual_time) ∨ thread_sampled`. When that
+holds AND the frame is at a CALL, branch A charges ALL `cpu` to native — the
+same decision as the worker classifier. -/
+
+/-- Whether the main path uses the at-CALL (bytecode) route, mirroring
+    `use_call_attribution` (:256-257). -/
+def useCallAttribution (useVirtualTime threadSampled : Bool) : Bool :=
+  (! useVirtualTime) || threadSampled
+
+/-- Native time the main path charges *when it takes the at-CALL route*
+    (branch A if atCall, else the deferral formula handles it — modeled in §3).
+    Here we model the branch-A decision: all-native iff atCall. -/
+def mainCallRouteNative (s : Sample) : ℚ := if s.atCall then s.cpu else 0
+
+/-- **Main-thread branch A is exact under soundness** — identical statement to
+    the worker classifier, because branch A makes the identical decision. -/
+theorem main_branchA_correct (s : Sample) (h : SigDeliverySound s) :
+    mainCallRouteNative s = trueNative s := by
+  have := (worker_classifier_correct s h).1
+  unfold workerNative at this
+  unfold mainCallRouteNative
+  exact this
+
+/-! ## 3. Comparing the two paths -/
+
+/-- **The two paths agree in the shared regime.** Whenever the main path uses
+    the call-attribution route (wall-clock or Apple-SME thread-sampled mode), its
+    at-CALL native decision is byte-for-byte the worker classifier's. So Scalene
+    runs *one* classifier from two call sites in that regime — no inconsistency
+    between how main-thread and worker-thread native time are decided. -/
+theorem main_worker_agree (s : Sample) (useVirtualTime threadSampled : Bool)
+    (_hmode : useCallAttribution useVirtualTime threadSampled = true) :
+    mainCallRouteNative s = workerNative s := by
+  unfold mainCallRouteNative workerNative
+  rfl
+
+/-- Corollary: in the shared regime, since the main branch-A decision equals the
+    worker's and (under soundness) the worker's is exact, the main path is exact
+    there too — one correctness proof covers both call sites. -/
+theorem main_worker_both_exact (s : Sample) (useVirtualTime threadSampled : Bool)
+    (_hmode : useCallAttribution useVirtualTime threadSampled = true)
+    (h : SigDeliverySound s) :
+    mainCallRouteNative s = trueNative s ∧ workerNative s = trueNative s :=
+  ⟨main_branchA_correct s h, (worker_classifier_correct s h).1⟩
+
+/-! ## 4. Why the paths diverge: the virtual-time deferral formula
+
+In virtual-time mode (`use_call_attribution = false`) the main path does NOT use
+the bytecode bit; it uses the interval-deferral formula
+(scalene_cpu_profiler.py:134-135): `python_time = interval`,
+`c_time = max(elapsed − interval, 0)`. A worker thread has no virtual timer to
+measure `elapsed − interval` against, so it *cannot* take this route — the
+divergence is by design, not inconsistency. -/
+
+/-- The deferral formula's native charge: the CPU time beyond the timer interval,
+    which (when signals were deferred during a C call) is native time that
+    accrued while the handler was pending. `interval, elapsed ≥ 0`. -/
+def deferralNative (interval elapsed : ℚ) : ℚ := max (elapsed - interval) 0
+
+/-- **The deferral route is taken exactly in virtual-time, non-thread-sampled
+    mode.** `use_call_attribution = false` forces `useVirtualTime = true` and
+    `threadSampled = false` — the only configuration in which the main path uses
+    the interval formula instead of the bytecode bit. This characterizes *when*
+    the two paths diverge: precisely when a real virtual timer is available (so
+    deferral can be measured) and no helper thread is sampling. -/
+theorem deferral_route_iff (useVirtualTime threadSampled : Bool) :
+    useCallAttribution useVirtualTime threadSampled = false
+      ↔ useVirtualTime = true ∧ threadSampled = false := by
+  unfold useCallAttribution
+  cases useVirtualTime <;> cases threadSampled <;> simp
+
+/-- **Deferral formula is exact under the deferral hypothesis.** If the true
+    native time equals the measured excess `elapsed − interval` (i.e. the timer
+    genuinely fired during a C call and stayed pending for exactly that excess),
+    and the excess is non-negative, then `deferralNative` reports it exactly.
+    This is the virtual-time counterpart to bytecode accuracy: the interval
+    formula is right precisely when native time shows up as timer-deferral. -/
+theorem deferral_formula_exact (interval elapsed trueNat : ℚ)
+    (hdefer : trueNat = elapsed - interval) (hexcess : interval ≤ elapsed) :
+    deferralNative interval elapsed = trueNat := by
+  unfold deferralNative
+  rw [hdefer, max_eq_left (by linarith)]
+
+/-- If the excess is negative (the signal fired while Python was running, so no
+    deferral occurred), the deferral formula reports 0 native time — which is
+    exactly right *when* there was truly no native call. This is the
+    complementary exact case, and also the blind spot the code comments note
+    (:127-129): native time that occurred earlier but wasn't deferred is missed
+    by this route — which is why wall-clock mode adds the bytecode test. -/
+theorem deferral_formula_zero_when_no_excess (interval elapsed : ℚ)
+    (hno : elapsed ≤ interval) :
+    deferralNative interval elapsed = 0 := by
+  unfold deferralNative
+  exact max_eq_right (by linarith)
+
+/-! ## 5. What accuracy costs when the hypothesis fails
+
+Signal-delivery soundness is a hypothesis. If it fails — a *smeared* sample that
+lands at a CALL opcode without truly being in a call (or vice versa) — the
+bytecode classifier is wrong. We pin the exact error, so the reliance on the
+hypothesis is explicit and quantified. -/
+
+/-- **Without soundness, the bytecode classifier can be wrong.** A sample at a
+    CALL opcode (`atCall = true`) but truly executing Python (`inPython`) is
+    charged fully native by the worker/main classifier, while its true native
+    time is 0 — an error of the whole `cpu`. This is the precise failure mode
+    the SigDeliverySound hypothesis rules out. -/
+theorem misclassified_when_unsound :
+    ∃ s : Sample, ¬ SigDeliverySound s ∧ workerNative s ≠ trueNative s := by
+  refine ⟨⟨.inPython, 1, true, by norm_num⟩, ?_, ?_⟩
+  · unfold SigDeliverySound; simp
+  · unfold workerNative trueNative; simp
+
+/-- Symmetric failure: truly in a call but the bytecode says otherwise
+    (`atCall = false`) — the whole `cpu` is charged to *Python* when it should be
+    native, so `workerPython` overshoots `truePython`. Together with the above,
+    this shows soundness is exactly the two-sided condition the classifier needs:
+    a false positive misattributes to native, a false negative to Python. -/
+theorem missed_when_unsound :
+    ∃ s : Sample, ¬ SigDeliverySound s ∧ workerPython s ≠ truePython s := by
+  refine ⟨⟨.inCall, 1, false, by norm_num⟩, ?_, ?_⟩
+  · unfold SigDeliverySound; simp
+  · unfold workerPython truePython trueNative; simp
+
+end Scalene.ClassifierAccuracy


### PR DESCRIPTION
Closes the classifier-accuracy gap (HANDOFF §7 step 5) and adds the per-thread comparison. `sorry`-free, standard axioms only; full `lake build` green (8576 jobs); 17 modules / 142 theorems.

Accuracy can't be a bare theorem — which branch is right depends on where the program truly was when the timer fired, observable only through CPython's signal-delivery semantics. So this module makes that an **explicit hypothesis** and proves exact correctness relative to it.

## The hypothesis — `SigDeliverySound`
CPython delivers a signal only at a bytecode boundary, so a timer firing inside a C call is deferred until the call returns, leaving `f_lasti` at the CALL opcode. Hence `atCall = true ↔ truly in a C call`. A CPython-runtime + synchronous-stamping property — stated, not proved. It is the honest residual.

## Theorems
- `worker_classifier_correct` — the worker-thread bytecode classifier (`_update_thread_stats`, `:458`) charges native *exactly* the in-call samples under the hypothesis. Exact, not approximate.
- `main_branchA_correct` — the main-thread branch A (`:256-275`) is exact too.
- `main_worker_agree` / `main_worker_both_exact` — **the comparison you asked for**: in the shared regime (`use_call_attribution` true), the two paths make byte-for-byte the same Python/native decision, so one correctness proof covers both call sites.
- `deferral_route_iff` + `deferral_formula_exact` / `deferral_formula_zero_when_no_excess` — the paths diverge *exactly* in virtual-time, non-thread-sampled mode, where only the main thread has a virtual timer to measure deferral; that route is exact when native time shows up as timer-deferral (and the code's documented blind spot otherwise).
- `misclassified_when_unsound` / `missed_when_unsound` — if the hypothesis fails, the two-sided error is pinned down (false positive → native charged for Python; false negative → the reverse), quantifying what `SigDeliverySound` buys.

## Docs
STATUS.md (classifier accuracy row ⚠️→✅-conditional; `SigDeliverySound` as the residual ⚠️), README §17 + roundup + boundary, HANDOFF module table + step 5 updated.

Formal-only; no production code touched.