### PR TITLE
Guard get_ipython() being Optional (fixes mypy on master)

### DIFF
--- a/scalene/scalene_magics.py
+++ b/scalene/scalene_magics.py
@@ -40,7 +40,20 @@ with contextlib.suppress(Exception):
             # Create a file to hold the supplied code.
             # We encode the cell number in the string for later recovery.
             # The length of the history buffer lets us find the most recent string (this one).
-            filename = f"_ipython-input-{len(IPython.get_ipython().history_manager.input_hist_raw)-1}-profile"  # type: ignore[no-untyped-call,unused-ignore]
+            #
+            # IPython >= 9.16 annotates get_ipython() as returning
+            # Optional[InteractiveShell], and history_manager is itself
+            # optional. Neither can be None in practice here — a magic only
+            # runs inside a live shell — but we can't index the history
+            # without it, so say so plainly instead of raising AttributeError.
+            shell = IPython.get_ipython()  # type: ignore[no-untyped-call,unused-ignore]
+            history = shell.history_manager if shell is not None else None
+            if history is None:
+                print(
+                    "Scalene: no IPython history is available, so this cell cannot be profiled."
+                )
+                return
+            filename = f"_ipython-input-{len(history.input_hist_raw)-1}-profile"
             with open(filename, "w+") as tmpfile:
                 tmpfile.write(code)
             args.memory = (

--- a/scalene/scalene_tracing.py
+++ b/scalene/scalene_tracing.py
@@ -154,9 +154,16 @@ class ScaleneTracing:
             import IPython
 
             if result := re.match(r"_ipython-input-([0-9]+)-.*", filename):
-                cell_contents = IPython.get_ipython().history_manager.input_hist_raw[  # type: ignore[no-untyped-call,unused-ignore]
-                    int(result[1])
-                ]
+                shell = IPython.get_ipython()  # type: ignore[no-untyped-call,unused-ignore]
+                # IPython >= 9.16 annotates get_ipython() as returning
+                # Optional[InteractiveShell], and history_manager is itself
+                # optional (absent when history is disabled). Without a live
+                # shell there is no cell to recover, so fall through to the
+                # ordinary filename rules rather than crashing.
+                history = shell.history_manager if shell is not None else None
+                if history is None:
+                    return False
+                cell_contents = history.input_hist_raw[int(result[1])]
                 with open(filename, "w+") as f:
                     f.write(cell_contents)
                 return True


### PR DESCRIPTION
The `linters` workflow is failing on **master**, independently of any PR.

IPython 9.16 annotates `get_ipython()` as returning `Optional[InteractiveShell]`, and `history_manager` is itself optional. mypy 2.3 therefore reports four `union-attr` errors in `scalene_tracing.py:157` and `scalene_magics.py:43`. The existing `# type: ignore[no-untyped-call, unused-ignore]` on those lines doesn't cover that error code — mypy says so explicitly:

```
scalene/scalene_tracing.py:157: error: Item "None" of "InteractiveShell | None" has no attribute "history_manager"  [union-attr]
scalene/scalene_tracing.py:157: note: Error code "union-attr" not covered by "type: ignore[no-untyped-call, unused-ignore]" comment
scalene/scalene_tracing.py:157: error: Item "None" of "Any | None" has no attribute "input_hist_raw"  [union-attr]
scalene/scalene_magics.py:43: error: Item "None" of "InteractiveShell | None" has no attribute "history_manager"  [union-attr]
scalene/scalene_magics.py:43: note: Error code "union-attr" not covered by "type: ignore[no-untyped-call, unused-ignore]" comment
scalene/scalene_magics.py:43: error: Item "None" of "Any | None" has no attribute "input_hist_raw"  [union-attr]
Found 4 errors in 2 files (checked 66 source files)
```

No commit caused this. Master's last `linters` run was 2026-07-05 and passed, and nothing has landed since — it broke on its own when CI's unpinned `pip install mypy ruff types-PyYAML pydantic` started resolving newer versions. Confirmed by dispatching the workflow against unmodified master: [run 30640136643](https://github.com/plasma-umass/scalene/actions/runs/30640136643) fails with the identical four errors.

## Fix

Guard both levels — the shell and its history manager:

- `_handle_jupyter_cell()` returns `False` without a live shell, falling through to the ordinary filename rules. That's the behavior it already had when the cell regex didn't match.
- `run_code()` prints a plain message and returns. Neither value can really be `None` there — a magic only runs inside a live shell — so this exists to satisfy the type checker without an `AttributeError` as the fallback.

The `# type: ignore` comments stay: on older IPython `get_ipython()` is untyped, so `no-untyped-call` still applies, and `unused-ignore` keeps the comment valid once it no longer does.

## Verification

- Reproduced in a venv pinned to CI's exact versions (**mypy 2.3.0, IPython 9.16.0**): 4 errors before, `Success: no issues found in 66 source files` after. `ruff check scalene` clean.
- Re-checked against the older pair (mypy 1.19.0, IPython 9.9.0) so the fix holds in both directions — no new errors; only the unrelated, pre-existing `scalene_signal_manager.py:314` one that mypy 2.3 doesn't flag.
- Behavior spot-checked for all three shapes: live shell (recovers the cell contents, writes the file, returns `True`), `get_ipython()` returning `None`, and `history_manager` being `None` — the last two return cleanly instead of raising.
- Full pytest suite: 442 passed, 13 skipped.

Found while checking CI on #1087, which is blocked by this same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)