### PR TITLE
Stop free-threaded CI jobs failing in setup before tests run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,15 @@ jobs:
 
     - name: install test dependencies
       run: |
-        python3 -m pip install pytest pytest-asyncio hypothesis
+        python3 -m pip install pytest pytest-asyncio
+        # hypothesis ships no wheel for free-threaded CPython 3.13, and
+        # building it from source fails there: its dependency chain pulls
+        # pyo3-ffi, and "PyO3 does not support the free-threaded build of
+        # CPython versions below 3.14". That aborted this step under
+        # ``bash -e``, so the 3.13t jobs never reached ``run tests`` at all.
+        # Install it best-effort; the two modules that need it call
+        # pytest.importorskip("hypothesis") and skip when it's absent.
+        python3 -m pip install hypothesis || echo "hypothesis unavailable; property-based tests will skip"
         # torch/JAX/TensorFlow may not be available on free-threaded Python builds
         python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu || true
         python3 -m pip install -e ".[test]" || python3 -m pip install -e .
@@ -97,7 +105,14 @@ jobs:
       run: |
         ulimit -c unlimited
         echo '/tmp/core.%e.%p' | sudo tee /proc/sys/kernel/core_pattern
-        sudo apt-get install -y gdb
+        # ``apt-get update`` first: the runner image ships a package index
+        # that can be older than the mirror's contents, and installing gdb
+        # then 404s on a superseded libc6-dbg. That failed the whole step
+        # (exit 100), skipping ``run tests`` on 3.14t. gdb is only used by
+        # the optional "Collect crash backtraces" step, so never let its
+        # absence stop the job.
+        sudo apt-get update || true
+        sudo apt-get install -y gdb || echo "gdb unavailable; crash backtraces will be skipped"
 
     - name: Quick memory profiling smoke test
       if: runner.os == 'Linux' && endsWith(matrix.python, 't')

--- a/tests/test_runningstats.py
+++ b/tests/test_runningstats.py
@@ -1,10 +1,18 @@
 from scalene import runningstats
 
-import hypothesis.strategies as st
 import math
+import pytest
 
-from hypothesis import given
 from typing import List
+
+# hypothesis has no wheel for free-threaded CPython 3.13 and its source
+# build fails there (PyO3 doesn't support free-threaded < 3.14), so CI
+# installs it best-effort. Skip rather than error out collection.
+pytest.importorskip("hypothesis")
+
+import hypothesis.strategies as st  # noqa: E402
+
+from hypothesis import given  # noqa: E402
 
 TOLERANCE = 0.5
 

--- a/tests/test_scalene_json.py
+++ b/tests/test_scalene_json.py
@@ -1,9 +1,15 @@
 from scalene import scalene_json
 
-from hypothesis import given
-from hypothesis.strategies import floats, lists
+import pytest
 
 from typing import Any, List
+
+# See tests/test_runningstats.py: hypothesis is installed best-effort in CI
+# because it can't be built for free-threaded CPython 3.13.
+pytest.importorskip("hypothesis")
+
+from hypothesis import given  # noqa: E402
+from hypothesis.strategies import floats, lists  # noqa: E402
 
 
 class TestScaleneJSON:


### PR DESCRIPTION
Three matrix entries — `run-tests (ubuntu-latest, 3.13t)`, `(macos-latest, 3.13t)` and `(ubuntu-latest, 3.14t)` — have been red without ever running pytest. In each, `run tests` shows as **skipped** because an earlier setup step aborted under `bash -e`.

Both causes are environment drift, not code: all four free-threaded jobs passed on master's [2026-07-05 run](https://github.com/plasma-umass/scalene/actions/runs/28750887246), and the failures reproduce identically on unrelated PRs (#1087, #1088).

## 3.13t — `hypothesis` can't be built for free-threaded 3.13

```
Building wheel for hypothesis (pyproject.toml): finished with status 'error'
    error: failed to run custom build command for `pyo3-ffi v0.29.0`
      error: PyO3 does not support the free-threaded build of CPython versions below 3.14,
             the selected Python version is 3.13
```

No wheel exists for `cp313t`, so pip builds from source and its dependency chain pulls `pyo3-ffi`. Installing it best-effort fixes the step.

**That alone isn't sufficient.** `tests/test_runningstats.py` and `tests/test_scalene_json.py` import hypothesis at module scope, and a collection error there interrupts the *entire* pytest session:

```
ERROR tests/test_runningstats.py
ERROR tests/test_scalene_json.py
!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!
```

So both modules now call `pytest.importorskip("hypothesis")`, matching the convention already used for `torch` (`test_torch_profiler.py`) and `numpy` (`test_issue1032_core_utilization_clamp.py`).

## 3.14t — apt 404 on `libc6-dbg`

```
Err:9 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.7
  404  Not Found [IP: 52.161.185.214 80]
E: Failed to fetch .../libc6-dbg_2.39-0ubuntu8.7_amd64.deb  404  Not Found
##[error]Process completed with exit code 100.
```

The runner image's package index is older than the mirror's contents. Adds `apt-get update` first, and stops a missing gdb from failing the job — gdb is only used by the optional `Collect crash backtraces` step, which is already `|| true` guarded.

## Verification

| scenario | before | after |
|---|---|---|
| the two modules, hypothesis absent | `Interrupted: 2 errors during collection`, non-zero exit | **2 skipped, exit 0** |
| the two modules, hypothesis present | 4 passed | **4 passed** (unchanged) |
| full suite locally | 446 passed, 13 skipped | **446 passed, 13 skipped** |

"hypothesis absent" was exercised in a real venv without the package, not simulated. The apt change can only be exercised on an Ubuntu runner, so this PR's own 3.14t job is the test.

## Note, not addressed here

`ulimit -c unlimited` runs in its own step, and each `run:` block is a separate shell, so it doesn't apply to the later pytest step — core dumps likely were never actually enabled, which would leave `Collect crash backtraces` with nothing to find. Fixing that means restructuring where the limit is set, which is beyond this PR's scope of un-breaking the setup steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)